### PR TITLE
ci(deploy): auto-deploy on push to development

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches: [development]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script_stop: true
+          script: |
+            cd /root/prestecs-satirs
+            git fetch --all
+            git checkout development
+            git reset --hard origin/development
+            ./deploy/deploy.sh

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ cd ~/prestecs-satirs
 ./deploy/deploy.sh
 ```
 
+### Automatic deployment
+
+Pushes to `development` trigger [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml),
+which SSHes into the server and runs `deploy/deploy.sh`. Requires these GitHub
+Actions secrets on the repository:
+
+| Secret | Value |
+|--------|-------|
+| `DEPLOY_HOST` | Server hostname or IP (e.g. `45.95.175.19`) |
+| `DEPLOY_USER` | SSH user (e.g. `root`) |
+| `DEPLOY_SSH_KEY` | Private SSH key authorised on the server |
+| `DEPLOY_PORT` | SSH port, optional (defaults to `22`) |
+
 ### What the stack runs
 
 - **App container**: Python 3.12 + FastAPI serving API and built React frontend


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` that SSHes into the VPS and runs `deploy/deploy.sh` on pushes to `development`.
- Documents the required GitHub Actions secrets in the README.

## Required secrets
- `DEPLOY_HOST` — server IP
- `DEPLOY_USER` — SSH user
- `DEPLOY_SSH_KEY` — private key authorised on the server
- `DEPLOY_PORT` — optional (defaults to 22)

## Test plan
- [ ] Merge → workflow runs on merge commit
- [ ] SSH step connects successfully
- [ ] `deploy/deploy.sh` completes (pull, build, migrate, import-games, enrich-games)
- [ ] https://test.refugiodelsatiro.es still serves the app