### PR TITLE
fix(deploy): force checkout to absorb server drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,6 @@ jobs:
           script: |
             cd /root/prestecs-satirs
             git fetch --all
-            git checkout development
+            git checkout -f development
             git reset --hard origin/development
             ./deploy/deploy.sh


### PR DESCRIPTION
## Summary
- Change `git checkout development` to `git checkout -f development` in the deploy workflow so server-side drift (uncommitted local edits) is discarded instead of blocking the deploy.

Discovered when the first CI deploy failed: the server's working tree had a hand-added `BGG_BEARER_TOKEN` line in `docker-compose.yml`. That same line now lives in the repo, so discarding the drift is lossless.

## Test plan
- [ ] Merge → workflow runs and successfully SSHes, resets, and runs `deploy/deploy.sh`
- [ ] https://test.refugiodelsatiro.es still serves the app