### PR TITLE
chore(frontend): nav brand → Refugio del Sátiro

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Préstecs Sàtirs</title>
+    <title>Refugio del Sátiro — Préstecs</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/i18n/ca.json
+++ b/frontend/src/i18n/ca.json
@@ -1,5 +1,5 @@
 {
-  "nav.brand": "Préstecs Sàtirs",
+  "nav.brand": "Refugio del Sátiro",
   "nav.catalog": "Catàleg",
   "nav.myLoans": "Els meus préstecs",
   "nav.admin": "Administració",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "nav.brand": "Préstecs Sàtirs",
+  "nav.brand": "Refugio del Sátiro",
   "nav.catalog": "Catalog",
   "nav.myLoans": "My loans",
   "nav.admin": "Administration",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1,5 +1,5 @@
 {
-  "nav.brand": "Préstecs Sàtirs",
+  "nav.brand": "Refugio del Sátiro",
   "nav.catalog": "Catálogo",
   "nav.myLoans": "Mis préstamos",
   "nav.admin": "Administración",


### PR DESCRIPTION
## Summary
- Updates `nav.brand` in `ca.json`, `es.json`, `en.json` from "Préstecs Sàtirs" to "Refugio del Sátiro" across the three locales.
- Updates the browser tab title in `frontend/index.html` to "Refugio del Sátiro — Préstecs".

The lending app is now a sub-feature under `/prestecs`, so the top-level identity shown in the nav is the association name, not the feature name.

## Test plan
- [ ] Merge → deploy workflow fires.
- [ ] https://test.refugiodelsatiro.es/prestecs/ shows "Refugio del Sátiro" in the nav and tab title.