### PR TITLE
refactor(lending): rename /prestecs route to /prestamos

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,6 @@
 {$DOMAIN:localhost} {
-	# App (lending flow) — keeps its /prestecs prefix.
-	handle_path /prestecs/* {
+	# App (lending flow) — keeps its /prestamos prefix.
+	handle_path /prestamos/* {
 		reverse_proxy app:8000
 	}
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website for the **Refugio del Sátiro** RPG association.
 
-Current scope: the game-lending feature (mounted at `/prestecs`). Members can
+Current scope: the game-lending feature (mounted at `/prestamos`). Members can
 browse the catalog, borrow games, and return them. The catalog is imported
 from [BoardGameGeek](https://boardgamegeek.com/collection/user/RefugioDelSatiro?subtype=boardgame&own=1&ff=1).
 
@@ -42,16 +42,16 @@ refugio migrate
 refugio import-games data/bgg_collection.json
 
 # Import members
-refugio import-members members.csv --base-url http://localhost:5173/prestecs
+refugio import-members members.csv --base-url http://localhost:5173/prestamos
 
 # Start the backend (port 8000)
 uvicorn backend.api.app:create_app --factory --reload --port 8000
 
-# Start the frontend (port 5173, proxies /prestecs/api to backend)
+# Start the frontend (port 5173, proxies /prestamos/api to backend)
 cd frontend && npm run dev
 ```
 
-Open http://localhost:5173/prestecs to view the lending app.
+Open http://localhost:5173/prestamos to view the lending app.
 
 ## CLI
 
@@ -116,10 +116,10 @@ frontend/
 |----------|------------|---------|
 | `REFUGIO_DB_PATH` | SQLite database file path | `refugio.db` |
 | `REFUGIO_JWT_SECRET` | JWT signing secret | (dev secret) |
-| `REFUGIO_BASE_URL` | Lending app public URL (used in reset-password emails) | `http://localhost:5173/prestecs` |
+| `REFUGIO_BASE_URL` | Lending app public URL (used in reset-password emails) | `http://localhost:5173/prestamos` |
 | `REFUGIO_CONTENT_MIRROR_DIR` | Where the admin "Resync content" button writes scraped pages | `frontend/public/content-mirror` (dev) / `/srv/content` (prod) |
 | `BGG_BEARER_TOKEN` | BGG API bearer token (optional) | — |
-| `VITE_API_URL` | Frontend API base URL | `/prestecs/api` |
+| `VITE_API_URL` | Frontend API base URL | `/prestamos/api` |
 
 ## Deployment (VPS with Docker)
 
@@ -183,7 +183,7 @@ Content changes on `www.refugiodelsatiro.es` flow into this repo manually:
 2. Review the diff under `frontend/public/content-mirror/`.
 3. Commit and push if it looks good.
 
-Editors can also hit the admin-only "Resync" button at `/prestecs/admin/content`
+Editors can also hit the admin-only "Resync" button at `/prestamos/admin/content`
 to refresh the VPS cache immediately — changes are visible on
 `www.refugiodelsatiro.es` right away, but don't reach the repo until someone
 runs the local workflow above.

--- a/backend/config.py
+++ b/backend/config.py
@@ -14,7 +14,7 @@ class Settings:
     jwt_secret: str = os.environ.get(
         "REFUGIO_JWT_SECRET", "dev-secret-change-in-production-minimum-32-bytes"
     )
-    base_url: str = os.environ.get("REFUGIO_BASE_URL", "http://localhost:5173/prestecs")
+    base_url: str = os.environ.get("REFUGIO_BASE_URL", "http://localhost:5173/prestamos")
     bgg_bearer_token: str | None = os.environ.get("BGG_BEARER_TOKEN")
     smtp_host: str | None = os.environ.get("SMTP_HOST")
     smtp_port: int = int(os.environ.get("SMTP_PORT", "587"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - REFUGIO_DB_PATH=/app/data/db/refugio.db
       - REFUGIO_JWT_SECRET=${REFUGIO_JWT_SECRET}
-      - REFUGIO_BASE_URL=${REFUGIO_BASE_URL:-http://localhost/prestecs}
+      - REFUGIO_BASE_URL=${REFUGIO_BASE_URL:-http://localhost/prestamos}
       - REFUGIO_CONTENT_MIRROR_DIR=/srv/content
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-587}

--- a/docs/diagrams/01-server-architecture.excalidraw
+++ b/docs/diagrams/01-server-architecture.excalidraw
@@ -22,9 +22,9 @@
       "frameId": null,
       "index": "a0",
       "roundness": null,
-      "seed": 471750544,
+      "seed": 120264668,
       "version": 1,
-      "versionNonce": 612803918,
+      "versionNonce": 436067837,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -53,9 +53,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 854374484,
+      "seed": 996654627,
       "version": 1,
-      "versionNonce": 537317007,
+      "versionNonce": 819434884,
       "isDeleted": false,
       "boundElements": [
         {
@@ -90,9 +90,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 835750744,
+      "seed": 277867893,
       "version": 1,
-      "versionNonce": 758296282,
+      "versionNonce": 982496914,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -129,9 +129,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 790532885,
+      "seed": 926382958,
       "version": 1,
-      "versionNonce": 890707261,
+      "versionNonce": 775656231,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -184,9 +184,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 458925551,
+      "seed": 738915085,
       "version": 1,
-      "versionNonce": 336586383,
+      "versionNonce": 306124605,
       "isDeleted": false,
       "boundElements": [
         {
@@ -221,9 +221,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 903012456,
+      "seed": 811720198,
       "version": 1,
-      "versionNonce": 833734112,
+      "versionNonce": 844136410,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -260,9 +260,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 790739952,
+      "seed": 777774029,
       "version": 1,
-      "versionNonce": 946795080,
+      "versionNonce": 637411471,
       "isDeleted": false,
       "boundElements": [
         {
@@ -293,9 +293,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 516224228,
+      "seed": 944303881,
       "version": 1,
-      "versionNonce": 266169943,
+      "versionNonce": 558875919,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -332,9 +332,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 101703739,
+      "seed": 482990624,
       "version": 1,
-      "versionNonce": 106964353,
+      "versionNonce": 486000402,
       "isDeleted": false,
       "boundElements": [
         {
@@ -365,9 +365,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 629233261,
+      "seed": 585192668,
       "version": 1,
-      "versionNonce": 650826886,
+      "versionNonce": 936647913,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -404,9 +404,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 680686584,
+      "seed": 826667148,
       "version": 1,
-      "versionNonce": 523960388,
+      "versionNonce": 377861087,
       "isDeleted": false,
       "boundElements": [
         {
@@ -414,7 +414,7 @@
           "type": "text"
         },
         {
-          "id": "arr-prestecs",
+          "id": "arr-prestamos",
           "type": "arrow"
         }
       ],
@@ -425,9 +425,9 @@
     {
       "id": "caddy-r1-t",
       "type": "text",
-      "x": 224.5,
+      "x": 220.64999999999998,
       "y": 376.25,
-      "width": 231.00000000000003,
+      "width": 238.70000000000002,
       "height": 17.5,
       "angle": 0,
       "strokeColor": "#f08c00",
@@ -441,21 +441,21 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 529068047,
+      "seed": 556231487,
       "version": 1,
-      "versionNonce": 837425323,
+      "versionNonce": 628806944,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "/prestecs/*  ->  App container",
+      "text": "/prestamos/*  ->  App container",
       "fontSize": 14,
       "fontFamily": 5,
       "textAlign": "center",
       "verticalAlign": "middle",
       "containerId": "caddy-route1",
-      "originalText": "/prestecs/*  ->  App container",
+      "originalText": "/prestamos/*  ->  App container",
       "autoResize": true,
       "lineHeight": 1.25
     },
@@ -480,9 +480,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 642233071,
+      "seed": 504837415,
       "version": 1,
-      "versionNonce": 431761393,
+      "versionNonce": 474436884,
       "isDeleted": false,
       "boundElements": [
         {
@@ -513,9 +513,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 743119634,
+      "seed": 158860631,
       "version": 1,
-      "versionNonce": 941796561,
+      "versionNonce": 435184192,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -552,9 +552,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 757650238,
+      "seed": 449709738,
       "version": 1,
-      "versionNonce": 855661935,
+      "versionNonce": 245645502,
       "isDeleted": false,
       "boundElements": [
         {
@@ -585,9 +585,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 601518636,
+      "seed": 228310158,
       "version": 1,
-      "versionNonce": 148638863,
+      "versionNonce": 919060522,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -624,9 +624,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 980156298,
+      "seed": 301843063,
       "version": 1,
-      "versionNonce": 365947714,
+      "versionNonce": 457947796,
       "isDeleted": false,
       "boundElements": [
         {
@@ -634,7 +634,7 @@
           "type": "text"
         },
         {
-          "id": "arr-prestecs",
+          "id": "arr-prestamos",
           "type": "arrow"
         }
       ],
@@ -661,9 +661,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 552387209,
+      "seed": 635875354,
       "version": 1,
-      "versionNonce": 113937947,
+      "versionNonce": 657560744,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -700,9 +700,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 903460367,
+      "seed": 839415427,
       "version": 1,
-      "versionNonce": 901373659,
+      "versionNonce": 777760690,
       "isDeleted": false,
       "boundElements": [
         {
@@ -733,9 +733,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 105055834,
+      "seed": 694543905,
       "version": 1,
-      "versionNonce": 467225526,
+      "versionNonce": 159109431,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -772,9 +772,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 207447510,
+      "seed": 539078397,
       "version": 1,
-      "versionNonce": 190912873,
+      "versionNonce": 347838280,
       "isDeleted": false,
       "boundElements": [
         {
@@ -805,9 +805,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 355104197,
+      "seed": 212706537,
       "version": 1,
-      "versionNonce": 710436459,
+      "versionNonce": 172350135,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -844,9 +844,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 862414284,
+      "seed": 631603637,
       "version": 1,
-      "versionNonce": 971460254,
+      "versionNonce": 450989134,
       "isDeleted": false,
       "boundElements": [
         {
@@ -877,9 +877,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 787798187,
+      "seed": 499977247,
       "version": 1,
-      "versionNonce": 651118463,
+      "versionNonce": 482919431,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -916,9 +916,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 624352734,
+      "seed": 907195867,
       "version": 1,
-      "versionNonce": 397976509,
+      "versionNonce": 168114427,
       "isDeleted": false,
       "boundElements": [
         {
@@ -949,9 +949,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 723212009,
+      "seed": 775211945,
       "version": 1,
-      "versionNonce": 586768367,
+      "versionNonce": 756753828,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -988,9 +988,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 704814821,
+      "seed": 347476278,
       "version": 1,
-      "versionNonce": 924142726,
+      "versionNonce": 755575398,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1021,9 +1021,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 144174689,
+      "seed": 131368876,
       "version": 1,
-      "versionNonce": 357589755,
+      "versionNonce": 303970024,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1058,9 +1058,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 514984270,
+      "seed": 752045715,
       "version": 1,
-      "versionNonce": 639905894,
+      "versionNonce": 165317291,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1077,7 +1077,7 @@
       "lineHeight": 1.25
     },
     {
-      "id": "arr-prestecs",
+      "id": "arr-prestamos",
       "type": "arrow",
       "x": 530,
       "y": 385,
@@ -1097,9 +1097,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 233951849,
+      "seed": 175647974,
       "version": 1,
-      "versionNonce": 963130501,
+      "versionNonce": 634592748,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1150,9 +1150,9 @@
       "frameId": "frame-arch",
       "index": "a1",
       "roundness": null,
-      "seed": 623900801,
+      "seed": 793442947,
       "version": 1,
-      "versionNonce": 228862165,
+      "versionNonce": 847011612,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,

--- a/docs/diagrams/02-data-flow.excalidraw
+++ b/docs/diagrams/02-data-flow.excalidraw
@@ -22,9 +22,9 @@
       "frameId": null,
       "index": "a0",
       "roundness": null,
-      "seed": 781847566,
+      "seed": 641689557,
       "version": 1,
-      "versionNonce": 305228848,
+      "versionNonce": 747744767,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -51,9 +51,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 675352792,
+      "seed": 838143132,
       "version": 1,
-      "versionNonce": 311724709,
+      "versionNonce": 722499858,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -90,9 +90,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 757767584,
+      "seed": 272579408,
       "version": 1,
-      "versionNonce": 391293306,
+      "versionNonce": 894494710,
       "isDeleted": false,
       "boundElements": [
         {
@@ -127,9 +127,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 293639805,
+      "seed": 571492652,
       "version": 1,
-      "versionNonce": 833232528,
+      "versionNonce": 232593015,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -166,9 +166,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 169988112,
+      "seed": 393118474,
       "version": 1,
-      "versionNonce": 349452588,
+      "versionNonce": 398858233,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -205,7 +205,7 @@
       "type": "text",
       "x": 290,
       "y": 120,
-      "width": 100.10000000000001,
+      "width": 107.80000000000001,
       "height": 17.5,
       "angle": 0,
       "strokeColor": "#868e96",
@@ -219,21 +219,21 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 280393014,
+      "seed": 967276160,
       "version": 1,
-      "versionNonce": 128458999,
+      "versionNonce": 153997182,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "GET /prestecs",
+      "text": "GET /prestamos",
       "fontSize": 14,
       "fontFamily": 5,
       "textAlign": "center",
       "verticalAlign": "middle",
       "containerId": null,
-      "originalText": "GET /prestecs",
+      "originalText": "GET /prestamos",
       "autoResize": true,
       "lineHeight": 1.25
     },
@@ -258,9 +258,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 232732645,
+      "seed": 394030735,
       "version": 1,
-      "versionNonce": 137697189,
+      "versionNonce": 529201194,
       "isDeleted": false,
       "boundElements": [
         {
@@ -299,9 +299,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 343107849,
+      "seed": 371705563,
       "version": 1,
-      "versionNonce": 351192176,
+      "versionNonce": 130387306,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -338,9 +338,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 403613478,
+      "seed": 852134527,
       "version": 1,
-      "versionNonce": 115713191,
+      "versionNonce": 995840157,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -393,9 +393,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 902616124,
+      "seed": 735647464,
       "version": 1,
-      "versionNonce": 125441915,
+      "versionNonce": 952236938,
       "isDeleted": false,
       "boundElements": [
         {
@@ -430,9 +430,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 401096966,
+      "seed": 963320745,
       "version": 1,
-      "versionNonce": 127998149,
+      "versionNonce": 917300323,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -467,9 +467,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 146223635,
+      "seed": 639080643,
       "version": 1,
-      "versionNonce": 446242074,
+      "versionNonce": 195397848,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -506,9 +506,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 297857064,
+      "seed": 175522472,
       "version": 1,
-      "versionNonce": 893695504,
+      "versionNonce": 303301873,
       "isDeleted": false,
       "boundElements": [
         {
@@ -543,9 +543,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 827111482,
+      "seed": 903502777,
       "version": 1,
-      "versionNonce": 587458599,
+      "versionNonce": 625826666,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -582,9 +582,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 367120673,
+      "seed": 473659176,
       "version": 1,
-      "versionNonce": 725295202,
+      "versionNonce": 699022368,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -635,9 +635,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 838225290,
+      "seed": 636187145,
       "version": 1,
-      "versionNonce": 560810000,
+      "versionNonce": 963993296,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -674,9 +674,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 535127744,
+      "seed": 262022037,
       "version": 1,
-      "versionNonce": 707843102,
+      "versionNonce": 298851848,
       "isDeleted": false,
       "boundElements": [
         {
@@ -715,9 +715,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 704975705,
+      "seed": 390764572,
       "version": 1,
-      "versionNonce": 537393645,
+      "versionNonce": 411485688,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -754,9 +754,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 243578653,
+      "seed": 134480210,
       "version": 1,
-      "versionNonce": 935458443,
+      "versionNonce": 510357538,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -807,9 +807,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 352790478,
+      "seed": 211125204,
       "version": 1,
-      "versionNonce": 888658575,
+      "versionNonce": 322064889,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -846,9 +846,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 694967720,
+      "seed": 792418582,
       "version": 1,
-      "versionNonce": 417863662,
+      "versionNonce": 207117675,
       "isDeleted": false,
       "boundElements": [
         {
@@ -887,9 +887,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 721319291,
+      "seed": 122793014,
       "version": 1,
-      "versionNonce": 755289072,
+      "versionNonce": 909691945,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -926,9 +926,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 896495253,
+      "seed": 962344209,
       "version": 1,
-      "versionNonce": 856129665,
+      "versionNonce": 243109816,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -981,9 +981,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 316925954,
+      "seed": 426691657,
       "version": 1,
-      "versionNonce": 967189781,
+      "versionNonce": 619015914,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1018,9 +1018,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 394849698,
+      "seed": 153064886,
       "version": 1,
-      "versionNonce": 562170280,
+      "versionNonce": 586286452,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1055,9 +1055,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 242838792,
+      "seed": 470588799,
       "version": 1,
-      "versionNonce": 318821944,
+      "versionNonce": 259177178,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1094,9 +1094,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 499937480,
+      "seed": 468816101,
       "version": 1,
-      "versionNonce": 918777515,
+      "versionNonce": 372798883,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1127,9 +1127,9 @@
       "frameId": "frame-data",
       "index": "a1",
       "roundness": null,
-      "seed": 652338819,
+      "seed": 530244313,
       "version": 1,
-      "versionNonce": 491197335,
+      "versionNonce": 122047638,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,

--- a/docs/diagrams/08-password-setup.excalidraw
+++ b/docs/diagrams/08-password-setup.excalidraw
@@ -22,9 +22,9 @@
       "frameId": null,
       "index": "a0",
       "roundness": null,
-      "seed": 687127092,
+      "seed": 404222024,
       "version": 1,
-      "versionNonce": 239530723,
+      "versionNonce": 568333036,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -51,9 +51,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 848320338,
+      "seed": 296657265,
       "version": 1,
-      "versionNonce": 862802432,
+      "versionNonce": 136615673,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -90,9 +90,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 217199105,
+      "seed": 944492630,
       "version": 1,
-      "versionNonce": 955291162,
+      "versionNonce": 187008039,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -118,9 +118,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 982105356,
+      "seed": 228746216,
       "version": 1,
-      "versionNonce": 257828687,
+      "versionNonce": 105591243,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -157,9 +157,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 251431348,
+      "seed": 124760820,
       "version": 1,
-      "versionNonce": 758850849,
+      "versionNonce": 940941109,
       "isDeleted": false,
       "boundElements": [
         {
@@ -194,9 +194,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 773656897,
+      "seed": 883017943,
       "version": 1,
-      "versionNonce": 101431880,
+      "versionNonce": 968877098,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -233,9 +233,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 151071659,
+      "seed": 945063993,
       "version": 1,
-      "versionNonce": 650904176,
+      "versionNonce": 674958483,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -288,9 +288,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 803829931,
+      "seed": 351252341,
       "version": 1,
-      "versionNonce": 855805268,
+      "versionNonce": 807735392,
       "isDeleted": false,
       "boundElements": [
         {
@@ -329,9 +329,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 301242721,
+      "seed": 846119462,
       "version": 1,
-      "versionNonce": 256613645,
+      "versionNonce": 500038687,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -368,9 +368,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 970572487,
+      "seed": 866316140,
       "version": 1,
-      "versionNonce": 643258762,
+      "versionNonce": 480141079,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -423,9 +423,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 627529421,
+      "seed": 420149784,
       "version": 1,
-      "versionNonce": 467180187,
+      "versionNonce": 226318063,
       "isDeleted": false,
       "boundElements": [
         {
@@ -464,9 +464,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 109516127,
+      "seed": 415920811,
       "version": 1,
-      "versionNonce": 688493528,
+      "versionNonce": 189382490,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -503,9 +503,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 854002028,
+      "seed": 152709325,
       "version": 1,
-      "versionNonce": 599630090,
+      "versionNonce": 429590177,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -558,9 +558,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 145669132,
+      "seed": 165395005,
       "version": 1,
-      "versionNonce": 616993629,
+      "versionNonce": 571612867,
       "isDeleted": false,
       "boundElements": [
         {
@@ -595,9 +595,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 832734324,
+      "seed": 471320019,
       "version": 1,
-      "versionNonce": 246043972,
+      "versionNonce": 369058862,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -634,9 +634,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 939096106,
+      "seed": 696594017,
       "version": 1,
-      "versionNonce": 559352669,
+      "versionNonce": 805026994,
       "isDeleted": false,
       "boundElements": [
         {
@@ -651,9 +651,9 @@
     {
       "id": "link-example-t",
       "type": "text",
-      "x": 48.924999999999955,
+      "x": 45.349999999999966,
       "y": 259.375,
-      "width": 722.1500000000001,
+      "width": 729.3000000000001,
       "height": 16.25,
       "angle": 0,
       "strokeColor": "#6741d9",
@@ -667,21 +667,21 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 161760721,
+      "seed": 125978053,
       "version": 1,
-      "versionNonce": 202757288,
+      "versionNonce": 955802171,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestecs/set-password?token=a3f8c9...",
+      "text": "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9...",
       "fontSize": 13,
       "fontFamily": 3,
       "textAlign": "center",
       "verticalAlign": "middle",
       "containerId": "link-example",
-      "originalText": "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestecs/set-password?token=a3f8c9...",
+      "originalText": "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9...",
       "autoResize": true,
       "lineHeight": 1.25
     },
@@ -706,9 +706,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 950815009,
+      "seed": 236070944,
       "version": 1,
-      "versionNonce": 318243587,
+      "versionNonce": 721384097,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -734,9 +734,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 279314710,
+      "seed": 689037932,
       "version": 1,
-      "versionNonce": 589992180,
+      "versionNonce": 699409405,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -773,9 +773,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 207981481,
+      "seed": 611134477,
       "version": 1,
-      "versionNonce": 379988608,
+      "versionNonce": 543713118,
       "isDeleted": false,
       "boundElements": [
         {
@@ -810,9 +810,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 250160729,
+      "seed": 352566909,
       "version": 1,
-      "versionNonce": 725259723,
+      "versionNonce": 502776629,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -849,9 +849,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 725134811,
+      "seed": 590236241,
       "version": 1,
-      "versionNonce": 467147192,
+      "versionNonce": 838028567,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -904,9 +904,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 808114279,
+      "seed": 189431035,
       "version": 1,
-      "versionNonce": 353521114,
+      "versionNonce": 550264477,
       "isDeleted": false,
       "boundElements": [
         {
@@ -945,9 +945,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 406869106,
+      "seed": 128117893,
       "version": 1,
-      "versionNonce": 803124352,
+      "versionNonce": 583829134,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -984,9 +984,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 498106488,
+      "seed": 600023782,
       "version": 1,
-      "versionNonce": 391844385,
+      "versionNonce": 265870856,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1039,9 +1039,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 780623902,
+      "seed": 780225981,
       "version": 1,
-      "versionNonce": 916770197,
+      "versionNonce": 559094880,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1076,9 +1076,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 959696526,
+      "seed": 932934661,
       "version": 1,
-      "versionNonce": 199079891,
+      "versionNonce": 324275137,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1115,9 +1115,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 783031535,
+      "seed": 809648439,
       "version": 1,
-      "versionNonce": 258838483,
+      "versionNonce": 693173897,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1143,9 +1143,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 392003748,
+      "seed": 877302291,
       "version": 1,
-      "versionNonce": 668661484,
+      "versionNonce": 624395746,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1182,9 +1182,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 833453900,
+      "seed": 574802666,
       "version": 1,
-      "versionNonce": 911893486,
+      "versionNonce": 633172199,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1215,9 +1215,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 559314561,
+      "seed": 569913917,
       "version": 1,
-      "versionNonce": 695649316,
+      "versionNonce": 200864798,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1254,9 +1254,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 460093264,
+      "seed": 907587363,
       "version": 1,
-      "versionNonce": 664931280,
+      "versionNonce": 301701378,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1299,9 +1299,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 164039509,
+      "seed": 486724925,
       "version": 1,
-      "versionNonce": 181824856,
+      "versionNonce": 980908336,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1332,9 +1332,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 722635615,
+      "seed": 835938743,
       "version": 1,
-      "versionNonce": 153741226,
+      "versionNonce": 837383483,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1371,9 +1371,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 834679270,
+      "seed": 893051514,
       "version": 1,
-      "versionNonce": 755235031,
+      "versionNonce": 187770742,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1416,9 +1416,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 440114371,
+      "seed": 260727347,
       "version": 1,
-      "versionNonce": 942533525,
+      "versionNonce": 192608440,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1449,9 +1449,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 115852891,
+      "seed": 584269865,
       "version": 1,
-      "versionNonce": 239254450,
+      "versionNonce": 923568225,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1488,9 +1488,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 216361592,
+      "seed": 465907537,
       "version": 1,
-      "versionNonce": 295956165,
+      "versionNonce": 497129062,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1533,9 +1533,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 777495989,
+      "seed": 522797091,
       "version": 1,
-      "versionNonce": 271107188,
+      "versionNonce": 925994418,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1566,9 +1566,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 587810798,
+      "seed": 323325192,
       "version": 1,
-      "versionNonce": 668504017,
+      "versionNonce": 879992379,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1605,9 +1605,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 314352381,
+      "seed": 453875201,
       "version": 1,
-      "versionNonce": 886387463,
+      "versionNonce": 146566219,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1650,9 +1650,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 792187531,
+      "seed": 978134450,
       "version": 1,
-      "versionNonce": 593560886,
+      "versionNonce": 740336829,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1683,9 +1683,9 @@
       "frameId": "frame-pwd",
       "index": "a1",
       "roundness": null,
-      "seed": 705251500,
+      "seed": 752202949,
       "version": 1,
-      "versionNonce": 407711095,
+      "versionNonce": 534969920,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,

--- a/docs/diagrams/09-website-integration.excalidraw
+++ b/docs/diagrams/09-website-integration.excalidraw
@@ -22,9 +22,9 @@
       "frameId": null,
       "index": "a0",
       "roundness": null,
-      "seed": 234626561,
+      "seed": 422828661,
       "version": 1,
-      "versionNonce": 768029874,
+      "versionNonce": 946251033,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -51,9 +51,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 124857258,
+      "seed": 366268742,
       "version": 1,
-      "versionNonce": 487350754,
+      "versionNonce": 529412163,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -90,9 +90,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 959283440,
+      "seed": 347681106,
       "version": 1,
-      "versionNonce": 914851465,
+      "versionNonce": 410020361,
       "isDeleted": false,
       "boundElements": [
         {
@@ -123,9 +123,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 966519233,
+      "seed": 574856988,
       "version": 1,
-      "versionNonce": 341554973,
+      "versionNonce": 369659522,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -162,9 +162,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 300617943,
+      "seed": 886046739,
       "version": 1,
-      "versionNonce": 484024235,
+      "versionNonce": 297825638,
       "isDeleted": false,
       "boundElements": [
         {
@@ -195,9 +195,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 416880602,
+      "seed": 611042674,
       "version": 1,
-      "versionNonce": 308975808,
+      "versionNonce": 637426114,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -234,9 +234,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 678442155,
+      "seed": 378429941,
       "version": 1,
-      "versionNonce": 334056318,
+      "versionNonce": 763105050,
       "isDeleted": false,
       "boundElements": [
         {
@@ -267,9 +267,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 993857401,
+      "seed": 634470359,
       "version": 1,
-      "versionNonce": 863855812,
+      "versionNonce": 589378594,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -306,9 +306,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 428034251,
+      "seed": 770915420,
       "version": 1,
-      "versionNonce": 455850108,
+      "versionNonce": 987880749,
       "isDeleted": false,
       "boundElements": [
         {
@@ -339,9 +339,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 489454673,
+      "seed": 816580526,
       "version": 1,
-      "versionNonce": 898769382,
+      "versionNonce": 952214363,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -378,9 +378,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 645948944,
+      "seed": 487238153,
       "version": 1,
-      "versionNonce": 732613369,
+      "versionNonce": 768505661,
       "isDeleted": false,
       "boundElements": [
         {
@@ -411,9 +411,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 533061609,
+      "seed": 928998259,
       "version": 1,
-      "versionNonce": 933916922,
+      "versionNonce": 946098598,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -448,9 +448,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 839381830,
+      "seed": 898839856,
       "version": 1,
-      "versionNonce": 932227936,
+      "versionNonce": 591309905,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -487,9 +487,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 935839768,
+      "seed": 587531584,
       "version": 1,
-      "versionNonce": 939569091,
+      "versionNonce": 127053567,
       "isDeleted": false,
       "boundElements": [
         {
@@ -520,9 +520,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 317779576,
+      "seed": 638773342,
       "version": 1,
-      "versionNonce": 895122764,
+      "versionNonce": 528100793,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -543,7 +543,7 @@
       "type": "text",
       "x": 70,
       "y": 440,
-      "width": 269.5,
+      "width": 277.20000000000005,
       "height": 35.0,
       "angle": 0,
       "strokeColor": "#868e96",
@@ -557,21 +557,21 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 666572057,
+      "seed": 789353357,
       "version": 1,
-      "versionNonce": 637534144,
+      "versionNonce": 914714306,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "Python + React + SQLite\nAt /prestecs/ on a different server",
+      "text": "Python + React + SQLite\nAt /prestamos/ on a different server",
       "fontSize": 14,
       "fontFamily": 5,
       "textAlign": "left",
       "verticalAlign": "middle",
       "containerId": null,
-      "originalText": "Python + React + SQLite\nAt /prestecs/ on a different server",
+      "originalText": "Python + React + SQLite\nAt /prestamos/ on a different server",
       "autoResize": true,
       "lineHeight": 1.25
     },
@@ -594,9 +594,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 956712363,
+      "seed": 800622822,
       "version": 1,
-      "versionNonce": 624912744,
+      "versionNonce": 182822306,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -631,9 +631,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 300598651,
+      "seed": 430371589,
       "version": 1,
-      "versionNonce": 344411801,
+      "versionNonce": 190952075,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -670,9 +670,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 191973097,
+      "seed": 917545244,
       "version": 1,
-      "versionNonce": 478630264,
+      "versionNonce": 370151314,
       "isDeleted": false,
       "boundElements": [
         {
@@ -703,9 +703,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 904841546,
+      "seed": 784610701,
       "version": 1,
-      "versionNonce": 767622712,
+      "versionNonce": 540854634,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -742,9 +742,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 568135407,
+      "seed": 873798870,
       "version": 1,
-      "versionNonce": 566463818,
+      "versionNonce": 754386372,
       "isDeleted": false,
       "boundElements": [
         {
@@ -775,9 +775,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 733527384,
+      "seed": 534530542,
       "version": 1,
-      "versionNonce": 504758898,
+      "versionNonce": 390149226,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -814,9 +814,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 889134165,
+      "seed": 325783089,
       "version": 1,
-      "versionNonce": 745894291,
+      "versionNonce": 130658645,
       "isDeleted": false,
       "boundElements": [
         {
@@ -847,9 +847,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 951108188,
+      "seed": 373193614,
       "version": 1,
-      "versionNonce": 627985086,
+      "versionNonce": 489029632,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -886,9 +886,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 746636782,
+      "seed": 472693592,
       "version": 1,
-      "versionNonce": 746212235,
+      "versionNonce": 961249370,
       "isDeleted": false,
       "boundElements": [
         {
@@ -905,7 +905,7 @@
       "type": "text",
       "x": 655,
       "y": 391.25,
-      "width": 331.1,
+      "width": 338.8,
       "height": 87.5,
       "angle": 0,
       "strokeColor": "#e8590c",
@@ -919,21 +919,21 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 487398936,
+      "seed": 678030637,
       "version": 1,
-      "versionNonce": 543593929,
+      "versionNonce": 750477362,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "Dynamic section (lending system):\n\n  /prestecs/           Game catalogue\n  /prestecs/games/:id  Game detail + borrow\n  /prestecs/my-loans   My active loans",
+      "text": "Dynamic section (lending system):\n\n  /prestamos/           Game catalogue\n  /prestamos/games/:id  Game detail + borrow\n  /prestamos/my-loans   My active loans",
       "fontSize": 14,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "middle",
       "containerId": "fut-lending-area",
-      "originalText": "Dynamic section (lending system):\n\n  /prestecs/           Game catalogue\n  /prestecs/games/:id  Game detail + borrow\n  /prestecs/my-loans   My active loans",
+      "originalText": "Dynamic section (lending system):\n\n  /prestamos/           Game catalogue\n  /prestamos/games/:id  Game detail + borrow\n  /prestamos/my-loans   My active loans",
       "autoResize": true,
       "lineHeight": 1.25
     },
@@ -958,9 +958,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 196366468,
+      "seed": 625258472,
       "version": 1,
-      "versionNonce": 854739642,
+      "versionNonce": 989109882,
       "isDeleted": false,
       "boundElements": [
         {
@@ -991,9 +991,9 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 771997603,
+      "seed": 215154281,
       "version": 1,
-      "versionNonce": 143385250,
+      "versionNonce": 905445400,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1030,9 +1030,9 @@
       "roundness": {
         "type": 2
       },
-      "seed": 738684301,
+      "seed": 119400824,
       "version": 1,
-      "versionNonce": 616277706,
+      "versionNonce": 615437477,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
@@ -1075,9 +1075,9 @@
       "roundness": {
         "type": 3
       },
-      "seed": 504016520,
+      "seed": 326468209,
       "version": 1,
-      "versionNonce": 253516840,
+      "versionNonce": 513211955,
       "isDeleted": false,
       "boundElements": [
         {
@@ -1094,7 +1094,7 @@
       "type": "text",
       "x": 45,
       "y": 638.75,
-      "width": 685.3000000000001,
+      "width": 693.0,
       "height": 122.5,
       "angle": 0,
       "strokeColor": "#f08c00",
@@ -1108,21 +1108,21 @@
       "frameId": "frame-vision",
       "index": "a1",
       "roundness": null,
-      "seed": 493711173,
+      "seed": 736187195,
       "version": 1,
-      "versionNonce": 247210497,
+      "versionNonce": 525251382,
       "isDeleted": false,
       "boundElements": null,
       "updated": 1700000000000,
       "link": null,
       "locked": false,
-      "text": "How it connects:\n\nCaddy (the reverse proxy) routes traffic based on URL path:\n  /prestecs/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n  everything else  ->  Static files                    = static HTML/CSS pages\n\nBoth live on the same domain, same server. One Caddy config ties them together.",
+      "text": "How it connects:\n\nCaddy (the reverse proxy) routes traffic based on URL path:\n  /prestamos/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n  everything else  ->  Static files                    = static HTML/CSS pages\n\nBoth live on the same domain, same server. One Caddy config ties them together.",
       "fontSize": 14,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "middle",
       "containerId": "how-box",
-      "originalText": "How it connects:\n\nCaddy (the reverse proxy) routes traffic based on URL path:\n  /prestecs/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n  everything else  ->  Static files                    = static HTML/CSS pages\n\nBoth live on the same domain, same server. One Caddy config ties them together.",
+      "originalText": "How it connects:\n\nCaddy (the reverse proxy) routes traffic based on URL path:\n  /prestamos/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n  everything else  ->  Static files                    = static HTML/CSS pages\n\nBoth live on the same domain, same server. One Caddy config ties them together.",
       "autoResize": true,
       "lineHeight": 1.25
     }

--- a/docs/generate_diagrams.py
+++ b/docs/generate_diagrams.py
@@ -296,8 +296,8 @@ def diagram_architecture() -> None:
                      container_id="caddy-https", stroke="#6741d9", frame_id=fid))
 
     els.append(rect("caddy-route1", 150, 360, 380, 50, bg="#fff3bf", stroke="#f08c00", frame_id=fid,
-                     bound=[{"id": "caddy-r1-t", "type": "text"}, {"id": "arr-prestecs", "type": "arrow"}]))
-    els.append(text("caddy-r1-t", 0, 0, "/prestecs/*  ->  App container", size=14,
+                     bound=[{"id": "caddy-r1-t", "type": "text"}, {"id": "arr-prestamos", "type": "arrow"}]))
+    els.append(text("caddy-r1-t", 0, 0, "/prestamos/*  ->  App container", size=14,
                      container_id="caddy-route1", stroke="#f08c00", frame_id=fid))
 
     els.append(rect("caddy-route2", 150, 430, 380, 50, bg="#b2f2bb", stroke="#2f9e44", frame_id=fid,
@@ -313,7 +313,7 @@ def diagram_architecture() -> None:
     # App container
     els.append(rect("app-box", 640, 220, 440, 500, bg="#ffd8a8", stroke="#e8590c",
                      frame_id=fid,
-                     bound=[{"id": "app-title", "type": "text"}, {"id": "arr-prestecs", "type": "arrow"}]))
+                     bound=[{"id": "app-title", "type": "text"}, {"id": "arr-prestamos", "type": "arrow"}]))
     els.append(text("app-title", 0, 0, "App container", size=18,
                      container_id="app-box", stroke="#e8590c", valign="top", frame_id=fid))
 
@@ -348,7 +348,7 @@ def diagram_architecture() -> None:
                      stroke="#868e96", frame_id=fid, align="left"))
 
     # Arrow Caddy -> App
-    els.append(arrow("arr-prestecs", 530, 385, [[0, 0], [110, 0]],
+    els.append(arrow("arr-prestamos", 530, 385, [[0, 0], [110, 0]],
                      start_id="caddy-route1", end_id="app-box", stroke="#e8590c", frame_id=fid))
 
     # Port label
@@ -379,7 +379,7 @@ def diagram_data_flow() -> None:
 
     els.append(arrow("arr-dl", 260, y_step1 + 90, [[0, 0], [160, 0]],
                      start_id="browser1", end_id="server1", stroke="#1971c2", frame_id=fid))
-    els.append(text("arr-dl-t", 290, y_step1 + 60, "GET /prestecs", size=14, stroke="#868e96", frame_id=fid))
+    els.append(text("arr-dl-t", 290, y_step1 + 60, "GET /prestamos", size=14, stroke="#868e96", frame_id=fid))
 
     els.append(rect("server1", 420, y_step1 + 50, 200, 80, bg="#ffd8a8", stroke="#e8590c", frame_id=fid,
                      bound=[{"id": "server1-t", "type": "text"}, {"id": "arr-dl", "type": "arrow"}, {"id": "arr-dl-back", "type": "arrow"}]))
@@ -983,7 +983,7 @@ def diagram_password_setup() -> None:
     els.append(rect("link-example", 60, y + 150, 700, 35, bg="#f3f0ff", stroke="#6741d9", frame_id=fid,
                      bound=[{"id": "link-example-t", "type": "text"}]))
     els.append(text("link-example-t", 0, 0,
-                     "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestecs/set-password?token=a3f8c9...",
+                     "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9...",
                      size=13, font=3, container_id="link-example", stroke="#6741d9", frame_id=fid))
 
     # --- Phase 2: Admin shares link ---
@@ -1097,7 +1097,7 @@ def diagram_integration() -> None:
     els.append(text("cur-lending-title", 0, 0, "Lending system (separate!)", size=18,
                      container_id="cur-lending", stroke="#e8590c", valign="top", frame_id=fid))
 
-    els.append(text("cur-lending-detail", 70, 440, "Python + React + SQLite\nAt /prestecs/ on a different server",
+    els.append(text("cur-lending-detail", 70, 440, "Python + React + SQLite\nAt /prestamos/ on a different server",
                      size=14, stroke="#868e96", align="left", frame_id=fid))
 
     # Disconnection indicator
@@ -1136,9 +1136,9 @@ def diagram_integration() -> None:
                      bound=[{"id": "fut-lending-t", "type": "text"}]))
     els.append(text("fut-lending-t", 0, 0,
                      "Dynamic section (lending system):\n\n"
-                     "  /prestecs/           Game catalogue\n"
-                     "  /prestecs/games/:id  Game detail + borrow\n"
-                     "  /prestecs/my-loans   My active loans",
+                     "  /prestamos/           Game catalogue\n"
+                     "  /prestamos/games/:id  Game detail + borrow\n"
+                     "  /prestamos/my-loans   My active loans",
                      size=14, font=3, container_id="fut-lending-area", stroke="#e8590c", align="left", frame_id=fid))
 
     # Shared elements callout
@@ -1159,7 +1159,7 @@ def diagram_integration() -> None:
     els.append(text("how-t", 0, 0,
                      "How it connects:\n\n"
                      "Caddy (the reverse proxy) routes traffic based on URL path:\n"
-                     "  /prestecs/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n"
+                     "  /prestamos/*  ->  App container (FastAPI + React)     = dynamic, with database and login\n"
                      "  everything else  ->  Static files                    = static HTML/CSS pages\n\n"
                      "Both live on the same domain, same server. One Caddy config ties them together.",
                      size=14, font=3, container_id="how-box", stroke="#f08c00", align="left", frame_id=fid))

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -57,7 +57,7 @@ in two steps:
 
 ### Step 1: The browser downloads the "app shell"
 
-When you visit `/prestecs`, the browser downloads a single HTML file plus some
+When you visit `/prestamos`, the browser downloads a single HTML file plus some
 JavaScript and CSS. This is the React application — it's like a blank
 container that knows *how* to display games, loans, and members, but doesn't
 have the actual data yet.
@@ -68,7 +68,7 @@ Once the app shell is loaded, the JavaScript code says: "OK, now I need the
 list of games." It sends a request to the server:
 
 ```
-GET /prestecs/api/games
+GET /prestamos/api/games
 ```
 
 The server (Python, running FastAPI) receives this request, opens the database
@@ -125,7 +125,7 @@ from Maria, who already proved her identity 3 minutes ago."
 The login page is a form. When you click "Log in", the browser sends:
 
 ```
-POST /prestecs/api/login
+POST /prestamos/api/login
 Body: { "email": "maria@example.com", "password": "her-password" }
 ```
 
@@ -174,7 +174,7 @@ automatically attaches the cookie. The server reads the JWT from the cookie,
 verifies the signature, extracts "member #5", and knows who's asking.
 
 ```
-GET /prestecs/api/members/me
+GET /prestamos/api/members/me
 Cookie: session_token=eyJhbGciOi...
 → Server: "This is Maria (member #5), she's active, here's her profile"
 ```
@@ -225,7 +225,7 @@ Members don't "register" themselves. An admin imports them from a CSV file
 generates a unique, random, one-time link for each member:
 
 ```
-https://refugidelsatiro.cat/prestecs/set-password?token=a3f8c9d1e7...
+https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9d1e7...
 ```
 
 The admin shares this link with each member (by message, email, etc.). When
@@ -283,7 +283,7 @@ they connect:
 │  │  Ports 80/443 ←──────│──│→ Port 8000          │  │
 │  │  (internet-facing)   │  │  (internal only)    │  │
 │  │                      │  │                     │  │
-│  │  /prestecs/* ────────│──│→ FastAPI + React    │  │
+│  │  /prestamos/* ────────│──│→ FastAPI + React    │  │
 │  │  / ──→ static files  │  │                     │  │
 │  │  (the existing site) │  │  refugio.db 📁      │  │
 │  └──────────────────────┘  └─────────────────────┘  │
@@ -293,7 +293,7 @@ they connect:
 
 **Key point for the future website integration:** Caddy currently serves the
 root path `/` from a folder of static files (`deploy/wip/`). This is where
-the existing site lives. Everything under `/prestecs/` gets forwarded to
+the existing site lives. Everything under `/prestamos/` gets forwarded to
 the lending app. Both coexist on the same domain.
 
 ### Comparison with PythonAnywhere
@@ -489,7 +489,7 @@ refugio-del-satiro/
 │  │     (the existing  │     │    ├─ API routes             │        │
 │  │           site)     │     │    ├─ Domain logic            │        │
 │  │                     │     │    ├─ SQLite database         │        │
-│  │  /prestecs/* ──────────→  │    └─ React frontend (built) │        │
+│  │  /prestamos/* ──────────→  │    └─ React frontend (built) │        │
 │  │                     │     │                              │        │
 │  │  HTTPS (automatic)  │     │  refugio.db  📁              │        │
 │  └─────────────────────┘     └──────────────────────────────┘        │
@@ -501,7 +501,7 @@ refugio-del-satiro/
 │                         BROWSER (user)                               │
 │                                                                      │
 │  1. Loads React app (HTML + JS + CSS)                                │
-│  2. React fetches data from /prestecs/api/games → gets JSON          │
+│  2. React fetches data from /prestamos/api/games → gets JSON          │
 │  3. Renders game cards                                               │
 │  4. User logs in → gets a cookie (JWT)                               │
 │  5. Cookie sent automatically with every request                     │

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "prestecs-frontend",
+  "name": "refugio-frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "prestecs-frontend",
+      "name": "refugio-frontend",
       "version": "0.0.0",
       "dependencies": {
         "i18next": "^26.0.3",
@@ -942,9 +942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -982,9 +976,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,9 +993,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,9 +1010,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1042,9 +1027,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2986,9 +2968,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3010,9 +2989,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3034,9 +3010,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3058,9 +3031,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import "./i18n";
 
 export default function App() {
   return (
-    <BrowserRouter basename="/prestecs">
+    <BrowserRouter basename="/prestamos">
       <AuthProvider>
         <NavBar />
         <main>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_URL ?? "/prestecs/api";
+const API_BASE = import.meta.env.VITE_API_URL ?? "/prestamos/api";
 
 export async function apiFetch<T>(
   path: string,

--- a/frontend/src/pages/AdminContentPage.tsx
+++ b/frontend/src/pages/AdminContentPage.tsx
@@ -23,7 +23,7 @@ type ScraperEvent = {
 };
 
 const EVENT_STREAM_URL = `${
-  import.meta.env.VITE_API_URL ?? "/prestecs/api"
+  import.meta.env.VITE_API_URL ?? "/prestamos/api"
 }/admin/content/events`;
 
 export function AdminContentPage() {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,15 +4,15 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/prestecs/",
+  base: "/prestamos/",
   plugins: [react()],
   server: {
     port: 5173,
     proxy: {
-      "/prestecs/api": {
+      "/prestamos/api": {
         target: "http://localhost:8000",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/prestecs/, ""),
+        rewrite: (path) => path.replace(/^\/prestamos/, ""),
       },
     },
   },

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -5,7 +5,7 @@ context: |
 
   What it is:
   - The website for the "Refugio del Sátiro" RPG association.
-  - Current scope: the game-lending app, mounted at `/prestecs`. Members can
+  - Current scope: the game-lending app, mounted at `/prestamos`. Members can
     browse available games, request loans, and track who has what.
   - The root path `/` serves a work-in-progress placeholder; the home page
     is planned as a future addition.
@@ -61,8 +61,8 @@ context: |
   Configuration:
   - REFUGIO_DB_PATH: SQLite database file path (default: refugio.db)
   - REFUGIO_JWT_SECRET: JWT signing secret (required in production)
-  - REFUGIO_BASE_URL: Lending app public URL, used in reset-password email links (default: http://localhost:5173/prestecs)
-  - VITE_API_URL: Frontend API base URL (default: /prestecs/api)
+  - REFUGIO_BASE_URL: Lending app public URL, used in reset-password email links (default: http://localhost:5173/prestamos)
+  - VITE_API_URL: Frontend API base URL (default: /prestamos/api)
 
   Canonical commands:
   - Backend install: pip install -e ".[dev]"

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: prestecs-satirs
+    name: prestamos-satirs
     runtime: python
     plan: free
     buildCommand: ./build.sh
@@ -13,10 +13,10 @@ services:
       - key: PRESTECS_JWT_SECRET
         generateValue: true
       - key: PRESTECS_BASE_URL
-        value: https://prestecs-satirs.onrender.com
+        value: https://prestamos-satirs.onrender.com
       - key: PRESTECS_DB_PATH
-        value: /opt/render/project/data/prestecs.db
+        value: /opt/render/project/data/prestamos.db
     disk:
-      name: prestecs-data
+      name: prestamos-data
       mountPath: /opt/render/project/data
       sizeGB: 1

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -115,7 +115,7 @@ Add a host we want to rehost → add the substring to
   the diff under `frontend/public/content-mirror/`. This is how content
   changes enter the repo; nothing automated commits for us.
 - **Admin button (ephemeral VPS refresh)**: `POST /api/admin/content/resync`
-  (admin-only) in the lending React app, at `/prestecs/admin/content`.
+  (admin-only) in the lending React app, at `/prestamos/admin/content`.
   Streams progress via SSE at `GET /api/admin/content/events`. The button
   writes to the VPS `content-cache` volume that Caddy serves — it does
   **not** touch the git checkout. Useful for editors who want to see their

--- a/tasks/lending-redesign/README.md
+++ b/tasks/lending-redesign/README.md
@@ -4,7 +4,7 @@ Research and planning folder for two linked initiatives:
 
 1. Replicating the club's existing website (Google Sites +
    PythonAnywhere) inside this repo.
-2. Redesigning the `/prestecs` lending flow to match the TFM (Master's
+2. Redesigning the `/prestamos` lending flow to match the TFM (Master's
    thesis) design prototype.
 
 All work here is documentation-only. No code changes yet.

--- a/tasks/lending-redesign/current-state.md
+++ b/tasks/lending-redesign/current-state.md
@@ -1,8 +1,8 @@
-# Current State Inventory: Lending/Prèstecs UI
+# Current State Inventory: Lending/Préstamos UI
 
 ## 1. Frontend Route Map
 
-All routes mounted at `/prestecs` via React Router basename.
+All routes mounted at `/prestamos` via React Router basename.
 
 | Path | Component | Purpose | Target User |
 |------|-----------|---------|-------------|
@@ -90,7 +90,7 @@ All routes mounted at `/prestecs` via React Router basename.
 
 ## 5. Backend API Endpoints
 
-All prefixed `/api` (full paths: `/prestecs/api/*`).
+All prefixed `/api` (full paths: `/prestamos/api/*`).
 
 | Method | Path | Purpose | Auth | Request | Response |
 |--------|------|---------|------|---------|----------|
@@ -122,10 +122,10 @@ All prefixed `/api` (full paths: `/prestecs/api/*`).
 
 **Current State:** No separation yet. The lending app IS the app.
 
-- **Routing:** Lending app mounted at `/prestecs` (React Router basename)
+- **Routing:** Lending app mounted at `/prestamos` (React Router basename)
 - **Layout:** Shared [NavBar](../../frontend/src/components/NavBar.tsx) with brand "Refugio del Sátiro" (or i18n key `nav.brand`)
 - **Styling:** Same tokens, reset, and CSS modules throughout
-- **Landing Content:** Intended to merge with existing club landing page at `/` (root), but currently `/prestecs/` redirects to CatalogPage
+- **Landing Content:** Intended to merge with existing club landing page at `/` (root), but currently `/prestamos/` redirects to CatalogPage
 
 **Implications:**
 - No distinct landing UI; catalog doubles as landing (must be guest-accessible)
@@ -160,4 +160,4 @@ All prefixed `/api` (full paths: `/prestecs/api/*`).
 
 ## Summary
 
-The lending app (`/prestecs`) is a self-contained React SPA with a Python FastAPI backend, styled via CSS modules with design tokens. It features a game catalog with advanced filtering, loan management, and admin controls, all behind JWT auth. The primary redesign challenges are: **(1) Clarifying the landing/lending boundary** once the club website lands merges; **(2) Consolidating form, button, and layout patterns** into shared components to reduce duplication; **(3) Adding feedback systems** (toasts, loading spinners, error boundaries) for better UX; and **(4) Improving the card/filter UI** for mobile and desktop consistency. The backend API is well-structured; the frontend would most benefit from extracting layout/form abstractions and a consistent state/feedback pattern across pages.
+The lending app (`/prestamos`) is a self-contained React SPA with a Python FastAPI backend, styled via CSS modules with design tokens. It features a game catalog with advanced filtering, loan management, and admin controls, all behind JWT auth. The primary redesign challenges are: **(1) Clarifying the landing/lending boundary** once the club website lands merges; **(2) Consolidating form, button, and layout patterns** into shared components to reduce duplication; **(3) Adding feedback systems** (toasts, loading spinners, error boundaries) for better UX; and **(4) Improving the card/filter UI** for mobile and desktop consistency. The backend API is well-structured; the frontend would most benefit from extracting layout/form abstractions and a consistent state/feedback pattern across pages.

--- a/tasks/lending-redesign/decisions.md
+++ b/tasks/lending-redesign/decisions.md
@@ -17,7 +17,7 @@ Today the club has two disconnected web presences:
 `www.refugiodelsatiro.es` (Google Sites, edited by several club
 collaborators) and `refugiosatiro.pythonanywhere.com` (Ariadna's Flask
 app, embedded into Sites on two pages). Our repo `refugio-del-satiro`
-currently ships only the lending app mounted at `/prestecs`. The
+currently ships only the lending app mounted at `/prestamos`. The
 direction of travel is "everything under `www.refugiodelsatiro.es`":
 the club site's content pages *plus* the lending flow, served from
 one origin. The merge raises a content-workflow question that only
@@ -36,7 +36,7 @@ should not be left implicit.
   collaborators to learn a different editor — or stop editing and rely
   on a dev.
 - Google Sites' custom-domain mapping is all-or-nothing at the apex:
-  we can't tell Google to serve `/prestecs` to the VPS and everything
+  we can't tell Google to serve `/prestamos` to the VPS and everything
   else to Sites.
 
 ### Options
@@ -45,7 +45,7 @@ should not be left implicit.
 Editors keep editing Sites. A sync job (manual trigger or nightly cron)
 downloads the rendered HTML + assets, stores them in our repo (or on
 disk), and the VPS serves them as static files. The VPS also serves
-`/prestecs` from the React app. `www.refugiodelsatiro.es` points at the
+`/prestamos` from the React app. `www.refugiodelsatiro.es` points at the
 VPS.
 - Pros: editors unchanged; single origin for everything; simple URL
   routing (all of `/` is just static files from the VPS).
@@ -67,7 +67,7 @@ system, versioning, review/approval workflow. Re-train editors.
 
 **Option 3 — Reverse-proxy Google Sites live.**
 `www.refugiodelsatiro.es` points at the VPS (Caddy). Caddy routes
-`/prestecs/*` to the React app; everything else reverse-proxies to
+`/prestamos/*` to the React app; everything else reverse-proxies to
 `sites.google.com/view/refugiodelsatiro/...`, rewriting absolute URLs
 in the response body. No scraping, edits go out instantly.
 - Pros: editors unchanged; no lag; nothing to re-train.
@@ -110,7 +110,7 @@ Avoid Option 2. The scope is incommensurate with the value.
 
 ---
 
-## Decision 2 — Spanish only for `/prestecs` v1?
+## Decision 2 — Spanish only for `/prestamos` v1?
 
 ### Context
 
@@ -152,14 +152,14 @@ editorial ownership should be explicit:
 
 1. **Sites content** (home, FAQ, events, members info).
 2. **Ludoteca catalog** (BGG-backed).
-3. **Lending flow** (`/prestecs`).
+3. **Lending flow** (`/prestamos`).
 
 ### Options & recommendation
 
 **Assumed model** (confirm in the meeting):
 - Sites content → existing collaborators, via Google Sites, on their
   current cadence.
-- Ludoteca catalog → admins of the `/prestecs` app (and eventually,
+- Ludoteca catalog → admins of the `/prestamos` app (and eventually,
   Nora persona from the TFM). Board games are added to the BGG source
   list; our app syncs.
 - Lending flow & admin UI → admins only.
@@ -422,7 +422,7 @@ actually answer.
 ## Parking lot — already decided (carried forward)
 
 - **Routing**: single canonical table in
-  `plan-replicate-existing-site.md`. `/prestecs` stays for private
+  `plan-replicate-existing-site.md`. `/prestamos` stays for private
   flow; `/ludoteca` is the public read-only view of the same catalog.
 - **v1 scope for lending**: catalog + borrow/return + game detail +
   member validation + admin members restyle. Everything else

--- a/tasks/lending-redesign/plan-lending-redesign.md
+++ b/tasks/lending-redesign/plan-lending-redesign.md
@@ -1,4 +1,4 @@
-# Plan: lending-flow redesign (`/prestec/*`)
+# Plan: lending-flow redesign (`/prestamos/*`)
 
 Status: **draft, pending user approval / answers to open questions**
 Owner: Miquel (solo) · target: 2026-Q2/Q3
@@ -25,7 +25,7 @@ Owner: Miquel (solo) · target: 2026-Q2/Q3
 
 ## What the redesign is for
 
-The current lending app (`/prestecs`) was built standalone with a
+The current lending app (`/prestamos`) was built standalone with a
 utilitarian look (Tailwind-blue `#2563eb`, system fonts). We're merging
 it into the main club site, and the TFM presents a more polished,
 brand-aligned UX for the same flow. We adopt the TFM look & flow, but
@@ -175,7 +175,7 @@ F1. Audit every new string for CA/ES/(EN?) translations (see Q1 in
 
 ## Resolved decisions (answered 2026-04-21)
 
-- Routing: keep `/prestecs` for private flow, expose same component at
+- Routing: keep `/prestamos` for private flow, expose same component at
   `/ludoteca` for public read-only browsing.
 - v1 scope triage above (catalog + borrow/return + detail + member
   validation + admin members restyle) — confirmed.
@@ -205,8 +205,8 @@ F1. Audit every new string for CA/ES/(EN?) translations (see Q1 in
   flow.
 - **L7. Accessibility target.** WCAG AA? AAA? Baseline needed so we
   don't have to re-do it.
-- ~~**L8. Keeping the existing `/prestecs` path.**~~ Resolved in
-  `plan-replicate-existing-site.md`: keep `/prestecs/...` for the
+- ~~**L8. Keeping the existing `/prestamos` path.**~~ Resolved in
+  `plan-replicate-existing-site.md`: keep `/prestamos/...` for the
   private lending flow (members/admin), expose `/ludoteca` as a
   public, read-only view of the same catalog component.
 - **L9. Figma access.** If you share a viewable link to the Figma

--- a/tasks/lending-redesign/plan-replicate-existing-site.md
+++ b/tasks/lending-redesign/plan-replicate-existing-site.md
@@ -16,7 +16,7 @@ Today the club has two online presences:
      a Google Drive source.
 
 Our repo `refugio-del-satiro` currently only hosts the lending app
-(`/prestecs`). The decision is to **merge everything into this repo** so
+(`/prestamos`). The decision is to **merge everything into this repo** so
 the RackNerd VPS serves the entire club site, and then redirect
 `www.refugiodelsatiro.es` to it.
 
@@ -70,7 +70,7 @@ Two kinds of pages share one layout:
   JSX) files in `frontend/src/content/...`, rendered by a common
   `<ContentPage>` layout. Minimal logic, maximum simplicity.
 - **App pages** — Ludoteca catalog, game detail, member validation,
-  plus everything under `/prestecs` (the lending flow). These already
+  plus everything under `/prestamos` (the lending flow). These already
   consume the FastAPI backend; we extend it.
 
 ### Routing
@@ -86,17 +86,17 @@ Two kinds of pages share one layout:
 | `/eventos` · `/eventos/:slug` | content | Events |
 | `/faq` · `/faq/normas-de-conducta` | content | FAQ + code of conduct |
 | `/socios` · `/socios/entidades-amigas` | content | Members info |
-| `/ludoteca` | app (public) | Catalog (read-only for guests) — **same React page as** `/prestecs/`, served in guest mode when unauthenticated. Replaces `/socios/ludoteca`. |
+| `/ludoteca` | app (public) | Catalog (read-only for guests) — **same React page as** `/prestamos/`, served in guest mode when unauthenticated. Replaces `/socios/ludoteca`. |
 | `/ludoteca/:id` | app (public) | Game detail (read-only for guests) |
 | `/validacion` | app (public) | Member lookup. Replaces `/Validacion-Membresia`. |
-| `/prestecs/...` | app (private) | The full lending flow — borrow, return, my-loans, admin. **Keeps the existing `/prestecs` path** so existing bookmarks, Caddyfile rules, and the current React basename don't change. See `plan-lending-redesign.md`. |
+| `/prestamos/...` | app (private) | The full lending flow — borrow, return, my-loans, admin. **Keeps the existing `/prestamos` path** so existing bookmarks, Caddyfile rules, and the current React basename don't change. See `plan-lending-redesign.md`. |
 | `/login` · `/forgot-password` · `/set-password` | auth | |
 | `/admin/*` | app (admin) | Admin-gated |
 
-Relationship between `/ludoteca` and `/prestecs`: one React catalog
+Relationship between `/ludoteca` and `/prestamos`: one React catalog
 component renders both. When the viewer is unauthenticated, borrow
 buttons are hidden and the page is reachable via `/ludoteca`; when
-authenticated, the same component mounts at `/prestecs/` with borrow
+authenticated, the same component mounts at `/prestamos/` with borrow
 actions enabled. This avoids duplicating code.
 
 Keep 301 redirects for every old Sites slug:
@@ -128,7 +128,7 @@ link + rating. We extend it to:
    "Refresh catalog from BGG"; later: cron.
 
 Data migration: we don't import existing data from PythonAnywhere; we
-re-ingest from BGG. Current `prestecs.db` is the source of truth for
+re-ingest from BGG. Current `prestamos.db` is the source of truth for
 board-game inventory (already has the correct 200-ish games).
 
 ### Member validation reimplementation
@@ -202,7 +202,7 @@ Decision 1 Option 3 (live reverse proxy) or Option 4 (headless CMS).
 - Keep a fallback to the Sites page for a week in case of rollback.
 
 **Phase 5 — lending redesign**
-- Ship the redesigned `/prestecs/*` flow (separate plan:
+- Ship the redesigned `/prestamos/*` flow (separate plan:
   `plan-lending-redesign.md`). Phases A–B (tokens, primitives, catalog
   restyle) can run **in parallel** with Phases 1–2 here — they share
   the same component library. Phases C–F only make sense once the
@@ -241,7 +241,7 @@ DNS cutover:
 - **Email delivery.** The lending app already sends password-reset
   emails. Document SMTP provider, from-address, and failure behaviour
   before new flows (notify-me, request-new-game) go live.
-- **Backups.** Nightly dump of `prestecs.db` to off-box storage.
+- **Backups.** Nightly dump of `prestamos.db` to off-box storage.
   Keep ≥14 days. Test a restore once.
 - **Monitoring.** At minimum: a cron that pings the home + catalog
   + `/api/games` and alerts on failure.
@@ -254,7 +254,7 @@ DNS cutover:
 
 ## Resolved decisions (answered 2026-04-21)
 
-- **Routing**: keep `/prestecs` private, expose `/ludoteca` as public
+- **Routing**: keep `/prestamos` private, expose `/ludoteca` as public
   read-only (same component).
 - **v1 scope**: confirmed (see `plan-lending-redesign.md`).
 - **Languages**: Spanish only for now (main site is ES; drop CA/EN


### PR DESCRIPTION
## Summary

Switch the lending app's URL prefix, Render service/disk names, and local SQLite filename from Catalan (`prestecs`) to Spanish (`prestamos`) to align with:

- The rest of the website (which is in Spanish).
- The TFM prototype, which uses Spanish UI labels: **Préstamos**, **Mis préstamos**, **En préstamo** (the thesis memoir is in Catalan, but the designed UI is in Spanish — confirmed in user-test transcripts and "idioma de la web actual: castellà" in the TFM).

### What changed

- **URL path**: `/prestecs` → `/prestamos` everywhere (Caddyfile, Vite config + proxy, React Router basename, API client default, backend `REFUGIO_BASE_URL` default, docs, plan files, generated diagrams).
- **Render config** (`render.yaml`):
  - Service name `prestecs-satirs` → `prestamos-satirs`.
  - Disk name `prestecs-data` → `prestamos-data`.
  - DB file path `/opt/render/project/data/prestecs.db` → `prestamos.db`.
  - On-Render URL value updated.
- **Local SQLite file**: `prestecs.db` (and `-shm`/`-wal` sidecars) renamed to `prestamos.db` locally — gitignored, so this only matters for the dev workflow.

### What was NOT changed (intentional)

- Catalan i18n strings in `frontend/src/i18n/ca.json` (`Els meus préstecs`, `Agafar en préstec`, …) — these are translations, not URL paths.
- Catalan email body in `backend/data/email_client.py` (`Préstecs Sàtirs`, etc.).
- Catalan error message in `backend/domain/use_cases/return_game.py`.
- `SMTP_FROM=prestecs@miqueladell.com` in `deploy/RESEND_SETUP.md` — that's a real configured mailbox; renaming the doc value would imply a mailbox change.

### Pre-existing issue worth flagging (not fixed here)

`render.yaml` declares `PRESTECS_JWT_SECRET`, `PRESTECS_BASE_URL`, `PRESTECS_DB_PATH`, but `backend/config.py` reads `REFUGIO_*` env vars. These names don't match. Not fixing in this PR to keep scope tight, but worth a follow-up.

### Render disk rename

The disk is renamed from `prestecs-data` to `prestamos-data`. Render treats this as a new disk, so the existing volume content would not auto-migrate. **Confirmed safe** — no operations have started on the existing volume yet (the production deploy is on the VPS via docker-compose, not Render).

## Test plan

- [x] `tsc --noEmit` on frontend — clean.
- [x] Backend imports + `Settings()` instantiates correctly with new defaults.
- [x] Diagram regeneration runs cleanly.
- [ ] Manually verify dev flow: `dev.sh`, then open `http://localhost:5173/prestamos` and confirm catalog renders, login works, API proxy hits `/prestamos/api/*`.
- [ ] Verify Caddy routing in a local docker-compose run (optional — same prefix swap).

## Related Tasks

No GitHub issue — chat-driven decision.