### PR TITLE
fix(deploy): reload Caddy after every deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,6 +9,9 @@ git pull
 echo "==> Building and starting containers"
 docker compose up -d --build
 
+echo "==> Reloading Caddy config (bind-mounted Caddyfile is not picked up by 'up -d')"
+docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+
 echo "==> Running migrations"
 docker compose exec app refugio migrate
 


### PR DESCRIPTION
## Summary

The Caddyfile is bind-mounted into the caddy container, so editing it on the host does not cause `docker compose up -d` to restart the container or reload Caddy's running config. Any Caddyfile change silently fails to take effect after deploy.

Add an explicit \`caddy reload\` step after the compose-up. Caddy performs a graceful config swap with no dropped connections.

**Discovered while deploying PR #30** (`/prestecs` → `/prestamos`): the new route returned 404 because Caddy was still serving the old config, even though the deploy job reported success and the app container had the new build.

## Test plan

- [x] `caddy reload` is the documented graceful-reload command (no connection drops).
- [ ] After this merges + auto-deploys, verify `https://test.refugiodelsatiro.es/prestamos/` returns 200 and the old `/prestecs/` returns 404.

## Related Tasks

Follow-up to PR #30. No GitHub issue.