### PR TITLE
fix(deploy): restart caddy instead of reload

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,8 +9,8 @@ git pull
 echo "==> Building and starting containers"
 docker compose up -d --build
 
-echo "==> Reloading Caddy config (bind-mounted Caddyfile is not picked up by 'up -d')"
-docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+echo "==> Restarting Caddy (bind-mounted Caddyfile is not picked up by 'up -d')"
+docker compose restart caddy
 
 echo "==> Running migrations"
 docker compose exec app refugio migrate


### PR DESCRIPTION
## Summary

PR #31 attempted to fix Caddy not picking up Caddyfile changes by running \`caddy reload\` after \`docker compose up -d\`. The command exited 0 and printed config-validation messages — but the running Caddy still served the old config (verified after deploy: \`/prestecs/\` returned 200, \`/prestamos/\` returned 404).

Switching to \`docker compose restart caddy\`. It's a hard restart (~1s connection drop) but unambiguously loads the bind-mounted Caddyfile.

## Test plan

- [ ] After deploy, \`https://test.refugiodelsatiro.es/prestamos/\` returns 200; \`/prestecs/\` returns 404.