### PR TITLE
chore(deploy): align Render env vars and Resend sender with code

### DIFF
--- a/deploy/RESEND_SETUP.md
+++ b/deploy/RESEND_SETUP.md
@@ -38,7 +38,7 @@ SMTP_HOST=smtp.resend.com
 SMTP_PORT=587
 SMTP_USER=resend
 SMTP_PASSWORD=re_YOUR_API_KEY_HERE
-SMTP_FROM=prestecs@miqueladell.com
+SMTP_FROM=prestecs@refugiodelsatiro.es
 ```
 
 Then restart:

--- a/render.yaml
+++ b/render.yaml
@@ -10,11 +10,11 @@ services:
         value: "3.12.3"
       - key: NODE_VERSION
         value: "20"
-      - key: PRESTECS_JWT_SECRET
+      - key: REFUGIO_JWT_SECRET
         generateValue: true
-      - key: PRESTECS_BASE_URL
+      - key: REFUGIO_BASE_URL
         value: https://prestamos-satirs.onrender.com
-      - key: PRESTECS_DB_PATH
+      - key: REFUGIO_DB_PATH
         value: /opt/render/project/data/prestamos.db
     disk:
       name: prestamos-data


### PR DESCRIPTION
## Summary
- Rename `PRESTECS_*` env vars in `render.yaml` to `REFUGIO_*` to match what `backend/config.py` actually reads. Without this, a Render deploy would silently fall back to defaults (dev JWT secret, localhost base URL, `refugio.db` on disk).
- Update `deploy/RESEND_SETUP.md` SMTP_FROM example from the personal `prestecs@miqueladell.com` to the production mailbox `prestecs@refugiodelsatiro.es` so anyone following the guide configures the right sender.

## Context
- The env var mismatch was [flagged during review of PR #30](https://github.com/MiquelAdell/refugio-del-satiro/pull/30) but never fixed. Render isn't currently in use, so this is non-urgent — landing it now so the file is correct if/when we bring Render back.
- The Resend doc fix is doc-only.

## Related Tasks
No tracked issue — follow-up to review feedback on #30.

## Test plan
- [ ] `render.yaml` env var names match `REFUGIO_*` keys read in `backend/config.py`
- [ ] `deploy/RESEND_SETUP.md` SMTP_FROM points at `prestecs@refugiodelsatiro.es`
- [ ] No code paths reference `PRESTECS_JWT_SECRET` / `PRESTECS_BASE_URL` / `PRESTECS_DB_PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)