### PR TITLE
fix(caddy): 301 redirect non-trailing-slash URLs to canonical form

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,14 +5,37 @@
 	}
 
 	# 301 redirects for legacy Google Sites slugs.
-	redir /inicio                           /                           permanent
-	redir /inicio/                          /                           permanent
-	redir /socios/ludoteca                  /ludoteca                   permanent
-	redir /socios/ludoteca/                 /ludoteca                   permanent
-	redir /Validacion-Membresia             /validacion                 permanent
-	redir /Validacion-Membresia/            /validacion                 permanent
-	redir /juegos-de-rol/campa%C3%B1as      /juegos-de-rol/campanas     permanent
-	redir /juegos-de-rol/campañas           /juegos-de-rol/campanas     permanent
+	redir /inicio / permanent
+	redir /inicio/ / permanent
+	redir /socios/ludoteca /ludoteca permanent
+	redir /socios/ludoteca/ /ludoteca permanent
+	redir /Validacion-Membresia /validacion permanent
+	redir /Validacion-Membresia/ /validacion permanent
+	redir /juegos-de-rol/campa%C3%B1as /juegos-de-rol/campanas permanent
+	redir /juegos-de-rol/campañas /juegos-de-rol/campanas permanent
+
+	# Canonicalize directory-style URLs to a trailing slash. Search engines
+	# treat /calendario and /calendario/ as separate URLs unless we 301 one
+	# to the other; this picks the trailing-slash form (which is also what
+	# the SPA's <base href="/prestamos/"> requires).
+	#
+	# Excluded:
+	#   - "/" itself (already canonical)
+	#   - "/prestamos/*" — the SPA owns its own routes (React Router would
+	#     break if /prestamos/games/1 redirected to /prestamos/games/1/)
+	#   - paths already ending in "/"
+	#   - paths with a "." in them (assumed to be files: /_assets/foo.css,
+	#     /favicon.ico, /manifest.json)
+	#
+	# Note: "/prestamos" (no slash) IS redirected here, since it does not
+	# match "/prestamos/*". Result: /prestamos → /prestamos/.
+	@needs_trailing_slash {
+		not path /
+		not path /prestamos/*
+		not path */
+		not path *.*
+	}
+	redir @needs_trailing_slash {path}/ 301
 
 	# Content mirror served from a VPS volume. The volume is seeded from the
 	# git-checked-in content on every deploy; admin-triggered syncs rewrite it


### PR DESCRIPTION
## Summary

Today the bare `https://test.refugiodelsatiro.es/prestamos` 404s because Caddy's `handle_path /prestamos/*` doesn't match a path with no trailing slash. This change adds a generic Caddy redirect that canonicalizes directory-style URLs to the trailing-slash form, so:

- `/prestamos` → `/prestamos/` (the SPA entry, currently broken)
- `/calendario` → `/calendario/`
- `/eventos` → `/eventos/`
- `/socios` → `/socios/`
- ...etc.

## Why this is the standard fix

301 redirects to a canonical URL form is industry standard for directory-mounted resources (Apache/nginx default behaviour, eliminates duplicate-content SEO issues, matches what the SPA's `<base href="/prestamos/">` already expects). The trailing-slash form is the convention for "directory-like" URLs.

## What's deliberately NOT redirected

- `/` itself (already canonical)
- Anything under `/prestamos/*` — the SPA owns its own routes; React Router treats `/games/1` and `/games/1/` as different routes and we don't want to break that
- Paths already ending in `/`
- Paths with a `.` in them (treated as files: `/_assets/*.css`, `/favicon.ico`, `/manifest.json`)

So `/prestamos/games/1` stays as-is, and asset requests aren't molested.

## Test plan

- [x] `caddy validate` passes (verified locally via `docker run caddy:latest`)
- [x] `caddy fmt` clean (the legacy redirect block re-formatted from column-aligned to single-space — that's the formatter's preference)
- [ ] After deploy: `curl -sI https://test.refugiodelsatiro.es/prestamos` → 301 with `Location: /prestamos/`
- [ ] `curl -sI https://test.refugiodelsatiro.es/calendario` → 301 with `Location: /calendario/`
- [ ] `curl -sI https://test.refugiodelsatiro.es/_assets/...css` → 200 (no redirect)
- [ ] `curl -sI https://test.refugiodelsatiro.es/prestamos/games/1` → reaches the SPA, no redirect
- [ ] Browser: navigate to `https://test.refugiodelsatiro.es/prestamos` → lands on the catalog with a clean URL `https://test.refugiodelsatiro.es/prestamos/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)