### PR TITLE
fix(deploy): replace leftover prestecs references with prestamos

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@
 # Generate a JWT secret with: openssl rand -hex 32
 
 REFUGIO_JWT_SECRET=CHANGE_ME
-REFUGIO_BASE_URL=https://your-domain.com/prestecs
+REFUGIO_BASE_URL=https://your-domain.com/prestamos
 DOMAIN=your-domain.com
 
 # Optional: BGG API bearer token for authenticated access (avoids rate limiting)
@@ -15,4 +15,4 @@ SMTP_HOST=smtp.resend.com
 SMTP_PORT=587
 SMTP_USER=resend
 SMTP_PASSWORD=re_CHANGE_ME
-SMTP_FROM=prestecs@refugiodelsatiro.es
+SMTP_FROM=prestamos@refugiodelsatiro.es

--- a/deploy/RESEND_SETUP.md
+++ b/deploy/RESEND_SETUP.md
@@ -38,7 +38,7 @@ SMTP_HOST=smtp.resend.com
 SMTP_PORT=587
 SMTP_USER=resend
 SMTP_PASSWORD=re_YOUR_API_KEY_HERE
-SMTP_FROM=prestecs@refugiodelsatiro.es
+SMTP_FROM=prestamos@refugiodelsatiro.es
 ```
 
 Then restart:

--- a/deploy/wip/index.html
+++ b/deploy/wip/index.html
@@ -51,7 +51,7 @@
 		<main>
 			<h1>Refugio del Sátiro</h1>
 			<p>Lloc web en construcció.</p>
-			<a href="/prestecs/">Préstecs de jocs</a>
+			<a href="/prestamos/">Préstecs de jocs</a>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #30 (the `/prestecs` → `/prestamos` rename) — a few deployment artifacts still pointed at the old slug, producing broken URLs in password-set / reset emails generated from the production env.

- `.env.production`: `REFUGIO_BASE_URL` slug and `SMTP_FROM` mailbox
- `deploy/wip/index.html`: anchor `href` on the WIP landing page (link text kept in Catalan to match the rest of the page)
- `deploy/RESEND_SETUP.md`: `SMTP_FROM` example in the Resend setup guide

## Note

The live production `.env` on the server still needs to be updated manually for the email links to start pointing at `/prestamos/set-password`:

```bash
ssh root@<server>
nano /root/refugio-del-satiro/.env  # update REFUGIO_BASE_URL and SMTP_FROM
cd /root/refugio-del-satiro && docker compose down && docker compose up -d
```

If the actual SMTP mailbox at `refugiodelsatiro.es` is still `prestecs@` (and was not renamed), revert the two `SMTP_FROM` lines in this PR.

## Related Tasks

No tracking issue. Follow-up to #30.

## Test plan

- [ ] After merging and updating the server `.env`, request a password reset and confirm the email link uses `/prestamos/set-password?token=...`
- [ ] Verify the Resend "From" address still delivers (whether the mailbox is `prestecs@` or `prestamos@`)
- [ ] Check the WIP landing page anchor resolves to `/prestamos/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)