### PR TITLE
feat(lending): move borrow/return to detail page and enforce borrower-name privacy

### DIFF
--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from backend.api.dependencies import (
+    OptionalMember,
     get_game_history_use_case,
     get_game_use_case,
     get_list_games_use_case,
@@ -39,12 +40,12 @@ class GameResponse(BaseModel):
 
 
 class LoanHistoryEntryResponse(BaseModel):
-    member_display_name: str
+    member_display_name: str | None
     borrowed_at: datetime
     returned_at: datetime | None
 
 
-def _to_response(g: GameWithStatus) -> GameResponse:
+def _to_response(g: GameWithStatus, *, is_authenticated: bool) -> GameResponse:
     return GameResponse(
         id=g.id,
         bgg_id=g.bgg_id,
@@ -61,22 +62,27 @@ def _to_response(g: GameWithStatus) -> GameResponse:
         created_at=g.created_at,
         updated_at=g.updated_at,
         status=g.status,
-        borrower_display_name=g.borrower_display_name,
-        loan_id=g.loan_id,
+        borrower_display_name=g.borrower_display_name if is_authenticated else None,
+        loan_id=g.loan_id if is_authenticated else None,
     )
 
 
 @router.get("", response_model=list[GameResponse])
 def list_games(
     use_case: Annotated[ListGamesUseCase, Depends(get_list_games_use_case)],
+    member: OptionalMember,
 ) -> list[GameResponse]:
-    return [_to_response(g) for g in use_case.execute()]
+    is_authenticated = member is not None
+    return [
+        _to_response(g, is_authenticated=is_authenticated) for g in use_case.execute()
+    ]
 
 
 @router.get("/{slug}", response_model=GameResponse)
 def get_game(
     slug: str,
     use_case: Annotated[GetGameUseCase, Depends(get_game_use_case)],
+    member: OptionalMember,
 ) -> GameResponse:
     game = use_case.execute(slug)
     if game is None:
@@ -84,20 +90,24 @@ def get_game(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Juego no encontrado.",
         )
-    return _to_response(game)
+    return _to_response(game, is_authenticated=member is not None)
 
 
 @router.get("/{slug}/history", response_model=list[LoanHistoryEntryResponse])
 def get_game_history(
     slug: str,
     use_case: Annotated[GetGameHistoryUseCase, Depends(get_game_history_use_case)],
+    member: OptionalMember,
 ) -> list[LoanHistoryEntryResponse]:
     entries = use_case.execute(slug)
     if entries is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Juego no encontrado.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Juego no encontrado."
+        )
+    is_authenticated = member is not None
     return [
         LoanHistoryEntryResponse(
-            member_display_name=e.member_display_name,
+            member_display_name=e.member_display_name if is_authenticated else None,
             borrowed_at=e.borrowed_at,
             returned_at=e.returned_at,
         )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/frontend/src/components/GameCard.css
+++ b/frontend/src/components/GameCard.css
@@ -111,10 +111,3 @@
   color: var(--color-warning);
 }
 
-.game-card-actions {
-  padding: 0 var(--space-md) var(--space-md);
-}
-
-.game-card-actions button {
-  width: 100%;
-}

--- a/frontend/src/components/GameCard.test.tsx
+++ b/frontend/src/components/GameCard.test.tsx
@@ -1,0 +1,65 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { GameCard } from "./GameCard";
+import type { GameWithStatus } from "../types/game";
+
+const baseGame: GameWithStatus = {
+  id: 1,
+  bgg_id: 100,
+  name: "Catan",
+  slug: "catan",
+  thumbnail_url: "https://example.com/catan.jpg",
+  image_url: "https://example.com/catan-large.jpg",
+  year_published: 1995,
+  min_players: 3,
+  max_players: 4,
+  playing_time: 90,
+  bgg_rating: 7.2,
+  location: "armario",
+  status: "available",
+  borrower_display_name: null,
+  loan_id: null,
+};
+
+function renderCard(overrides: Partial<GameWithStatus> = {}) {
+  return render(
+    <MemoryRouter>
+      <GameCard game={{ ...baseGame, ...overrides }} />
+    </MemoryRouter>,
+  );
+}
+
+describe("GameCard", () => {
+  it("never renders borrow or return action buttons", () => {
+    renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("never renders the borrower name, even when the payload includes it", () => {
+    renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
+
+    expect(screen.queryByText(/Alice/)).toBeNull();
+  });
+
+  it("renders 'Disponible' for an available game", () => {
+    renderCard({ status: "available" });
+
+    expect(screen.getByText("Disponible")).toBeInTheDocument();
+  });
+
+  it("renders the no-name 'Prestado' badge for a lent game", () => {
+    renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
+
+    expect(screen.getByText("Prestado")).toBeInTheDocument();
+  });
+
+  it("links to the game detail page using the slug", () => {
+    renderCard();
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/juegos/catan");
+  });
+});

--- a/frontend/src/components/GameCard.tsx
+++ b/frontend/src/components/GameCard.tsx
@@ -1,60 +1,12 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
-import { apiFetch } from "../api/client";
-import { ConfirmDialog } from "./ConfirmDialog";
-import { Button } from "../ui/Button";
 import type { GameWithStatus } from "../types/game";
 import "./GameCard.css";
 
 interface GameCardProps {
   readonly game: GameWithStatus;
-  readonly onAction: () => void;
 }
 
-export function GameCard({ game, onAction }: GameCardProps) {
-  const { member } = useAuth();
-  const [confirmAction, setConfirmAction] = useState<"borrow" | "return" | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const canBorrow = member !== null && game.status === "available";
-  const canReturn =
-    member !== null &&
-    game.status === "lent" &&
-    game.loan_id !== null &&
-    (member.is_admin || game.borrower_display_name === member.display_name);
-
-  const handleBorrow = async () => {
-    setLoading(true);
-    try {
-      await apiFetch<unknown>("/loans", {
-        method: "POST",
-        body: JSON.stringify({ game_id: game.id }),
-      });
-      onAction();
-    } catch {
-      /* error handled silently — game list will refetch */
-    } finally {
-      setLoading(false);
-      setConfirmAction(null);
-    }
-  };
-
-  const handleReturn = async () => {
-    setLoading(true);
-    try {
-      await apiFetch<unknown>(`/loans/${game.loan_id}/return`, {
-        method: "PATCH",
-      });
-      onAction();
-    } catch {
-      /* error handled silently — game list will refetch */
-    } finally {
-      setLoading(false);
-      setConfirmAction(null);
-    }
-  };
-
+export function GameCard({ game }: GameCardProps) {
   return (
     <div className="game-card">
       <Link to={`/juegos/${game.slug}`} className="game-card-link">
@@ -95,51 +47,10 @@ export function GameCard({ game, onAction }: GameCardProps) {
             )}
           </div>
           <span className={`game-card-status ${game.status}`}>
-            {game.status === "available"
-              ? "Disponible"
-              : `Prestado a ${game.borrower_display_name}`}
+            {game.status === "available" ? "Disponible" : "Prestado"}
           </span>
         </div>
       </Link>
-
-      <div className="game-card-actions">
-        {canBorrow && (
-          <Button
-            variant="primary"
-            onClick={() => setConfirmAction("borrow")}
-            disabled={loading}
-          >
-            Tomar prestado
-          </Button>
-        )}
-        {canReturn && (
-          <Button
-            variant="secondary"
-            onClick={() => setConfirmAction("return")}
-            disabled={loading}
-          >
-            Devolver
-          </Button>
-        )}
-      </div>
-
-      {confirmAction === "borrow" && (
-        <ConfirmDialog
-          message={`¿Quieres tomar prestado "${game.name}"?`}
-          onConfirm={() => void handleBorrow()}
-          onCancel={() => setConfirmAction(null)}
-          confirmLabel="Tomar prestado"
-        />
-      )}
-
-      {confirmAction === "return" && (
-        <ConfirmDialog
-          message={`¿Quieres devolver "${game.name}"?`}
-          onConfirm={() => void handleReturn()}
-          onCancel={() => setConfirmAction(null)}
-          confirmLabel="Devolver"
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/LoanHistoryEntry.tsx
+++ b/frontend/src/components/LoanHistoryEntry.tsx
@@ -16,7 +16,7 @@ function formatDate(iso: string): string {
 export function LoanHistoryEntry({ entry }: LoanHistoryEntryProps) {
   return (
     <div className="loan-history-entry">
-      <span className="loan-history-member">{entry.member_display_name}</span>
+      <span className="loan-history-member">{entry.member_display_name ?? "Socio"}</span>
       <span className="loan-history-dates">
         {formatDate(entry.borrowed_at)}
         {" — "}

--- a/frontend/src/hooks/useGameHistory.ts
+++ b/frontend/src/hooks/useGameHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "../api/client";
 import type { LoanHistoryEntry } from "../types/loan";
 import type { GameWithStatus } from "../types/game";
@@ -8,6 +8,7 @@ interface UseGameHistoryResult {
   readonly history: readonly LoanHistoryEntry[];
   readonly loading: boolean;
   readonly error: string | null;
+  readonly refetch: () => void;
 }
 
 export function useGameHistory(slug: string | undefined): UseGameHistoryResult {
@@ -16,7 +17,7 @@ export function useGameHistory(slug: string | undefined): UseGameHistoryResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchAll = useCallback(() => {
     if (!slug) {
       setLoading(false);
       setError("Identificador de juego no válido");
@@ -26,19 +27,21 @@ export function useGameHistory(slug: string | undefined): UseGameHistoryResult {
     setLoading(true);
     setError(null);
 
-    const fetchAll = async () => {
-      const [found, entries] = await Promise.all([
-        apiFetch<GameWithStatus>(`/juegos/${slug}`),
-        apiFetch<readonly LoanHistoryEntry[]>(`/juegos/${slug}/history`),
-      ]);
-      setGame(found);
-      setHistory(entries);
-    };
-
-    fetchAll()
+    Promise.all([
+      apiFetch<GameWithStatus>(`/juegos/${slug}`),
+      apiFetch<readonly LoanHistoryEntry[]>(`/juegos/${slug}/history`),
+    ])
+      .then(([found, entries]) => {
+        setGame(found);
+        setHistory(entries);
+      })
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));
   }, [slug]);
 
-  return { game, history, loading, error };
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  return { game, history, loading, error, refetch: fetchAll };
 }

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -56,7 +56,7 @@ function matchesTimePreset(playingTime: number, preset: TimePreset): boolean {
 const DESKTOP_MQ = "(min-width: 641px)";
 
 export function CatalogPage() {
-  const { games, loading, error, refetch } = useGames();
+  const { games, loading, error } = useGames();
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<FilterValue>("all");
   const [location, setLocation] = useState<LocationValue>("all");
@@ -378,7 +378,7 @@ export function CatalogPage() {
       ) : (
         <div className="catalog-grid">
           {filteredGames.map((game) => (
-            <GameCard key={game.id} game={game} onAction={refetch} />
+            <GameCard key={game.id} game={game} />
           ))}
         </div>
       )}

--- a/frontend/src/pages/GameDetailPage.css
+++ b/frontend/src/pages/GameDetailPage.css
@@ -53,6 +53,13 @@
   color: var(--color-warning);
 }
 
+.game-detail-actions {
+  margin-top: var(--space-md);
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
 .game-detail-bgg {
   margin-top: var(--space-md);
 }

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -1,0 +1,213 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GameDetailPage } from "./GameDetailPage";
+import type { GameWithStatus } from "../types/game";
+import type { LoanHistoryEntry } from "../types/loan";
+import type { CurrentMember } from "../types/member";
+
+const refetch = vi.fn();
+const useGameHistoryMock = vi.fn();
+const useAuthMock = vi.fn();
+const apiFetchMock = vi.fn();
+
+vi.mock("../hooks/useGameHistory", () => ({
+  useGameHistory: () => useGameHistoryMock(),
+}));
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("../api/client", () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+const game: GameWithStatus = {
+  id: 1,
+  bgg_id: 100,
+  name: "Catan",
+  slug: "catan",
+  thumbnail_url: "https://example.com/catan.jpg",
+  image_url: "https://example.com/catan-large.jpg",
+  year_published: 1995,
+  min_players: 3,
+  max_players: 4,
+  playing_time: 90,
+  bgg_rating: 7.2,
+  location: "armario",
+  status: "available",
+  borrower_display_name: null,
+  loan_id: null,
+};
+
+const member: CurrentMember = {
+  id: 42,
+  display_name: "Alice Smith",
+  email: "alice@example.com",
+  is_admin: false,
+};
+
+const admin: CurrentMember = {
+  id: 99,
+  display_name: "Admin User",
+  email: "admin@example.com",
+  is_admin: true,
+};
+
+function setHook(
+  overrides: Partial<{
+    game: GameWithStatus | null;
+    history: readonly LoanHistoryEntry[];
+    loading: boolean;
+    error: string | null;
+  }> = {},
+) {
+  useGameHistoryMock.mockReturnValue({
+    game,
+    history: [],
+    loading: false,
+    error: null,
+    refetch,
+    ...overrides,
+  });
+}
+
+function setMember(value: CurrentMember | null) {
+  useAuthMock.mockReturnValue({ member: value });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/juegos/catan"]}>
+      <Routes>
+        <Route path="/juegos/:slug" element={<GameDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("GameDetailPage", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({});
+  });
+
+  it("hides borrower name and shows the no-name 'Prestado' badge when payload omits the name (anonymous)", () => {
+    setHook({
+      game: { ...game, status: "lent", borrower_display_name: null, loan_id: null },
+    });
+    setMember(null);
+
+    renderPage();
+
+    expect(screen.getByText("Prestado")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Tomar prestado/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Devolver/i })).toBeNull();
+  });
+
+  it("shows borrower name when authenticated payload includes it", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: "Bob Jones",
+        loan_id: 7,
+      },
+    });
+    setMember(member);
+
+    renderPage();
+
+    expect(screen.getByText("Prestado a Bob Jones")).toBeInTheDocument();
+  });
+
+  it("shows the borrow CTA only for an available game with a logged-in member", () => {
+    setHook();
+    setMember(member);
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Tomar prestado" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Devolver" })).toBeNull();
+  });
+
+  it("hides the borrow CTA when the viewer is anonymous", () => {
+    setHook();
+    setMember(null);
+
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: "Tomar prestado" })).toBeNull();
+  });
+
+  it("shows the return CTA to the borrower of a lent game", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: member.display_name,
+        loan_id: 7,
+      },
+    });
+    setMember(member);
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Devolver" })).toBeInTheDocument();
+  });
+
+  it("shows the return CTA to an admin even when the loan is someone else's", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: "Bob Jones",
+        loan_id: 7,
+      },
+    });
+    setMember(admin);
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "Devolver" })).toBeInTheDocument();
+  });
+
+  it("hides the return CTA from a non-admin who is not the borrower", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: "Bob Jones",
+        loan_id: 7,
+      },
+    });
+    setMember(member);
+
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: "Devolver" })).toBeNull();
+  });
+
+  it("calls POST /loans and refetches after confirming a borrow", async () => {
+    setHook();
+    setMember(member);
+
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Tomar prestado" }));
+    // The dialog confirm button reuses the same label; the trigger is also still in the DOM.
+    const buttons = screen.getAllByRole("button", { name: "Tomar prestado" });
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(apiFetchMock).toHaveBeenCalledWith("/loans", {
+      method: "POST",
+      body: JSON.stringify({ game_id: 1 }),
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -1,11 +1,19 @@
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { useGameHistory } from "../hooks/useGameHistory";
+import { apiFetch } from "../api/client";
+import { ConfirmDialog } from "../components/ConfirmDialog";
 import { LoanHistoryEntry } from "../components/LoanHistoryEntry";
+import { useAuth } from "../context/AuthContext";
+import { useGameHistory } from "../hooks/useGameHistory";
+import { Button } from "../ui/Button";
 import "./GameDetailPage.css";
 
 export function GameDetailPage() {
   const { slug } = useParams<{ slug: string }>();
-  const { game, history, loading, error } = useGameHistory(slug);
+  const { game, history, loading, error, refetch } = useGameHistory(slug);
+  const { member } = useAuth();
+  const [confirmAction, setConfirmAction] = useState<"borrow" | "return" | null>(null);
+  const [acting, setActing] = useState(false);
 
   if (loading) {
     return (
@@ -26,6 +34,51 @@ export function GameDetailPage() {
     );
   }
 
+  const canBorrow = member !== null && game.status === "available";
+  const canReturn =
+    member !== null &&
+    game.status === "lent" &&
+    game.loan_id !== null &&
+    (member.is_admin || game.borrower_display_name === member.display_name);
+
+  const handleBorrow = async () => {
+    setActing(true);
+    try {
+      await apiFetch<unknown>("/loans", {
+        method: "POST",
+        body: JSON.stringify({ game_id: game.id }),
+      });
+      refetch();
+    } catch {
+      /* error handled silently — refetch on close keeps UI in sync */
+    } finally {
+      setActing(false);
+      setConfirmAction(null);
+    }
+  };
+
+  const handleReturn = async () => {
+    setActing(true);
+    try {
+      await apiFetch<unknown>(`/loans/${game.loan_id}/return`, {
+        method: "PATCH",
+      });
+      refetch();
+    } catch {
+      /* error handled silently — refetch on close keeps UI in sync */
+    } finally {
+      setActing(false);
+      setConfirmAction(null);
+    }
+  };
+
+  const statusLabel =
+    game.status === "available"
+      ? "Disponible"
+      : game.borrower_display_name
+        ? `Prestado a ${game.borrower_display_name}`
+        : "Prestado";
+
   return (
     <div className="game-detail-page">
       <Link to="/" className="game-detail-back">
@@ -41,11 +94,29 @@ export function GameDetailPage() {
         <div className="game-detail-info">
           <h1>{game.name}</h1>
           <div className="game-detail-year">{game.year_published}</div>
-          <span className={`game-detail-status ${game.status}`}>
-            {game.status === "available"
-              ? "Disponible"
-              : `Prestado a ${game.borrower_display_name}`}
-          </span>
+          <span className={`game-detail-status ${game.status}`}>{statusLabel}</span>
+          {(canBorrow || canReturn) && (
+            <div className="game-detail-actions">
+              {canBorrow && (
+                <Button
+                  variant="primary"
+                  onClick={() => setConfirmAction("borrow")}
+                  disabled={acting}
+                >
+                  Tomar prestado
+                </Button>
+              )}
+              {canReturn && (
+                <Button
+                  variant="secondary"
+                  onClick={() => setConfirmAction("return")}
+                  disabled={acting}
+                >
+                  Devolver
+                </Button>
+              )}
+            </div>
+          )}
           <div className="game-detail-bgg">
             <a
               href={`https://boardgamegeek.com/boardgame/${game.bgg_id}`}
@@ -61,9 +132,7 @@ export function GameDetailPage() {
       <div className="game-detail-history">
         <h2>Historial de préstamos</h2>
         {history.length === 0 ? (
-          <p className="game-detail-no-history">
-            Este juego nunca ha sido prestado.
-          </p>
+          <p className="game-detail-no-history">Este juego nunca ha sido prestado.</p>
         ) : (
           <div className="game-detail-history-list">
             {history.map((entry, i) => (
@@ -72,6 +141,24 @@ export function GameDetailPage() {
           </div>
         )}
       </div>
+
+      {confirmAction === "borrow" && (
+        <ConfirmDialog
+          message={`¿Quieres tomar prestado "${game.name}"?`}
+          onConfirm={() => void handleBorrow()}
+          onCancel={() => setConfirmAction(null)}
+          confirmLabel="Tomar prestado"
+        />
+      )}
+
+      {confirmAction === "return" && (
+        <ConfirmDialog
+          message={`¿Quieres devolver "${game.name}"?`}
+          onConfirm={() => void handleReturn()}
+          onCancel={() => setConfirmAction(null)}
+          confirmLabel="Devolver"
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/types/loan.ts
+++ b/frontend/src/types/loan.ts
@@ -8,7 +8,7 @@ export interface ActiveLoan {
 }
 
 export interface LoanHistoryEntry {
-  readonly member_display_name: string;
+  readonly member_display_name: string | null;
   readonly borrowed_at: string;
   readonly returned_at: string | null;
 }

--- a/openspec/changes/lending-privacy-and-detail-actions/proposal.md
+++ b/openspec/changes/lending-privacy-and-detail-actions/proposal.md
@@ -1,0 +1,30 @@
+# Lending UX move + borrower-name privacy
+
+## Goals
+
+- Move borrow / return actions out of the catalog list and into the game detail page, matching the TFM Figma proto where the catalog is a browse surface and the lending interaction lives on the detail screen.
+- Prevent anonymous (logged-out) visitors from seeing **who** has a game lent to them. Anonymous users may only see whether a game is available or not.
+- Keep the borrower's name visible to authenticated members on the game detail page so they know who to contact.
+
+## Non-goals
+
+- Changing the borrow / return endpoints themselves (`POST /api/loans`, `PATCH /api/loans/{id}/return`).
+- Reservations, due dates, or notifications — still excluded per project non-goals.
+- Hiding borrower identity from authenticated members. The privacy boundary is anonymous vs. authenticated, not member vs. member.
+
+## User impact
+
+- **Anonymous visitors** lose the borrower name everywhere (today they see it on the catalog and on the detail page). They keep the available / lent status signal so they can still decide whether to come pick a game up.
+- **Authenticated members** can no longer borrow or return from the catalog list — they must open the game's detail page first. This is one extra click but produces a single primary CTA per screen, which the Figma indicates is the intended flow. Borrower names remain visible to them on the detail page.
+- **Catalog cards** become quieter: thumbnail, name, year, players, time, rating, and a status badge. No buttons, no names.
+
+## Compatibility
+
+- API response shape is unchanged. `borrower_display_name` and `loan_id` on `/api/juegos` and `/api/juegos/{slug}`, plus `member_display_name` on `/api/juegos/{slug}/history`, become `null` for anonymous responses but the fields themselves remain present.
+- The frontend already treats `borrower_display_name` and `loan_id` as nullable (`string | null`, `number | null`) in `frontend/src/types/game.ts`, so existing clients deserialize without changes.
+- `member_display_name` on history entries flips from `string` to `string | null`. Frontend type and rendering adapt; no third-party consumers are known.
+
+## Rollback plan
+
+- Code is reversible by reverting the merge commit. No DB schema changes, no migrations, no irreversible data modifications.
+- If the privacy enforcement is found to break a downstream consumer, the backend filter can be toggled off in `backend/api/routes/games.py` independently from the frontend changes — both layers degrade gracefully (backend always returns the field, frontend renders the no-name fallback when null).

--- a/openspec/changes/lending-privacy-and-detail-actions/specs/lending/spec.md
+++ b/openspec/changes/lending-privacy-and-detail-actions/specs/lending/spec.md
@@ -1,0 +1,28 @@
+# Lending capability
+
+## Borrower-name visibility
+
+- **GET /api/juegos**, anonymous request: every entry has `borrower_display_name = null` and `loan_id = null`, regardless of whether the game is currently lent. The `status` field still reflects reality (`"available"` or `"lent"`).
+- **GET /api/juegos**, authenticated request: each lent game returns the real borrower's `borrower_display_name` and the real `loan_id`. Available games return `null` for both.
+- **GET /api/juegos/{slug}**, anonymous request: returns `borrower_display_name = null` and `loan_id = null`. Authenticated request returns the real values.
+- **GET /api/juegos/{slug}/history**, anonymous request: every entry returns `member_display_name = null`. Dates remain.
+- **GET /api/juegos/{slug}/history**, authenticated request: every entry returns the real `member_display_name`.
+
+The privacy rule is enforced server-side. Client code must not be the only thing that hides borrower identity.
+
+## Catalog list UI
+
+- The catalog list shows a status badge per card: "Disponible" when available, "Prestado" when lent.
+- The catalog list never displays the borrower's name, regardless of who is viewing it. Borrower identity is reserved for the game detail screen.
+- The catalog cards do not expose borrow or return action buttons. The card is a navigation surface only; clicking it opens the detail page at `/juegos/{slug}`.
+
+## Game detail UI
+
+- When the game is available and the viewer is an authenticated member, the detail page shows a primary "Tomar prestado" CTA that triggers `POST /api/loans` after a confirmation dialog.
+- When the game is lent and the viewer is either the borrower or an admin, the detail page shows a "Devolver" CTA that triggers `PATCH /api/loans/{loan_id}/return` after a confirmation dialog.
+- When the game is lent and the API returned a non-null `borrower_display_name`, the detail page shows "Prestado a {name}". Otherwise it falls back to "Prestado".
+- After a successful borrow or return, the detail page refreshes its data without a full page reload.
+
+## Loan history UI
+
+- The detail page renders the loan history. When a history entry's `member_display_name` is null (anonymous viewer), the entry shows a generic placeholder ("Socio"). Dates are always shown.

--- a/openspec/changes/lending-privacy-and-detail-actions/tasks.md
+++ b/openspec/changes/lending-privacy-and-detail-actions/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Backend
+
+- [x] [BE] Inject `OptionalMember` into `list_games`, `get_game`, and `get_game_history` route handlers (`backend/api/routes/games.py`).
+- [x] [BE] When the request is unauthenticated, force `borrower_display_name=None` and `loan_id=None` on every `GameResponse`.
+- [x] [BE] Change `LoanHistoryEntryResponse.member_display_name` to `str | None`. When the request is unauthenticated, set it to `None` for every entry.
+- [x] [BE] Add API tests covering anonymous vs authenticated responses for `/api/juegos`, `/api/juegos/{slug}`, and `/api/juegos/{slug}/history`, asserting concrete values for the privacy-sensitive fields.
+
+## Frontend
+
+- [x] [FE] Strip lending state, handlers, and buttons from `frontend/src/components/GameCard.tsx`. Remove the `onAction` prop. Replace the borrower-name status text with a name-less "Prestado" badge.
+- [x] [FE] Drop the `onAction` prop from `<GameCard>` consumers (`frontend/src/pages/CatalogPage.tsx`); remove the post-action refetch wiring tied to it.
+- [x] [FE] Refactor `frontend/src/hooks/useGameHistory.ts` to expose a `refetch` function alongside `{ game, history, loading, error }`.
+- [x] [FE] In `frontend/src/pages/GameDetailPage.tsx`, lift the borrow / return logic from the old GameCard. Render a primary CTA in the header that fires the relevant action through a `ConfirmDialog` and calls `refetch` on success. When the API returned `borrower_display_name = null`, show the no-name "Prestado" badge.
+- [x] [FE] Update `frontend/src/types/loan.ts` so `LoanHistoryEntry.member_display_name` is `string | null`. Update `frontend/src/components/LoanHistoryEntry.tsx` to render "Socio" when null.
+- [x] [FE] Remove the now-unused `.game-card-actions` CSS rules in `frontend/src/components/GameCard.css`.
+- [x] [FE] Add `test` and `typecheck` scripts to `frontend/package.json`.
+
+## Tests
+
+- [x] [FE] Add GameCard tests: assert no buttons rendered, no borrower name in any state, status badge shows the no-name copy when lent, link uses the slug-based URL.
+- [x] [FE] Add GameDetailPage tests: borrow CTA shown only when status is `available` and a member is logged in; return CTA shown only to the borrower or an admin; confirm flow calls the API and triggers a refetch; when `borrower_display_name` is null the page shows the no-name fallback.
+
+## Specs
+
+- [ ] [BE/FE] After implementation, archive this change folder into `openspec/specs/lending/` per the openspec-archive-change flow.

--- a/tests/api/test_games.py
+++ b/tests/api/test_games.py
@@ -5,11 +5,13 @@ import sqlite3
 from fastapi.testclient import TestClient
 
 from backend.api.app import create_app
-from backend.api.dependencies import get_db_conn
+from backend.api.auth import create_jwt
+from backend.api.dependencies import _settings, get_db_conn
 from backend.data.database import get_memory_connection
 from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
 from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
 from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
+from backend.domain.entities.member import Member
 from backend.migrations.runner import run_migrations
 
 
@@ -33,6 +35,32 @@ def _setup_client() -> tuple[TestClient, sqlite3.Connection]:
     return client, conn
 
 
+def _auth_cookie(member: Member) -> dict[str, str]:
+    token = create_jwt(member.id, _settings.jwt_secret)
+    return {"Cookie": f"session_token={token}"}
+
+
+def _make_member(
+    member_repo: SqliteMemberRepository,
+    *,
+    number: int,
+    first_name: str,
+    last_name: str,
+    email: str,
+    is_admin: bool = False,
+) -> Member:
+    return member_repo.upsert_by_email(
+        member_number=number,
+        first_name=first_name,
+        last_name=last_name,
+        nickname=None,
+        phone=None,
+        email=email,
+        display_name=f"{first_name} {last_name}",
+        is_admin=is_admin,
+    )
+
+
 class TestListGames:
     def test_empty_catalog(self) -> None:
         client, conn = _setup_client()
@@ -43,50 +71,99 @@ class TestListGames:
         assert response.json() == []
         conn.close()
 
-    def test_games_with_status(self) -> None:
+    def test_anonymous_request_hides_borrower_identity(self) -> None:
         client, conn = _setup_client()
 
         game_repo = SqliteGameRepository(conn)
         member_repo = SqliteMemberRepository(conn)
         loan_repo = SqliteLoanRepository(conn)
 
-        game1 = game_repo.upsert_by_bgg_id(
-            bgg_id=100, name="Catan", thumbnail_url="https://example.com/catan.jpg", year_published=1995
+        game_repo.upsert_by_bgg_id(
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
         )
         game2 = game_repo.upsert_by_bgg_id(
-            bgg_id=200, name="Pandemic", thumbnail_url="https://example.com/pandemic.jpg", year_published=2008
+            bgg_id=200,
+            name="Pandemic",
+            thumbnail_url="https://example.com/pandemic.jpg",
+            year_published=2008,
         )
 
-        member = member_repo.upsert_by_email(
-            member_number=1,
+        alice = _make_member(
+            member_repo,
+            number=1,
             first_name="Alice",
             last_name="Smith",
-            nickname=None,
-            phone=None,
             email="alice@example.com",
-            display_name="Alice Smith",
-            is_admin=False,
         )
-
-        loan_repo.create(game_id=game2.id, member_id=member.id)
+        loan_repo.create(game_id=game2.id, member_id=alice.id)
 
         response = client.get("/api/juegos")
 
         assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 2
+        by_name = {g["name"]: g for g in response.json()}
 
-        by_name = {g["name"]: g for g in data}
-
-        assert by_name["Catan"]["slug"] == "catan"
         assert by_name["Catan"]["status"] == "available"
         assert by_name["Catan"]["borrower_display_name"] is None
         assert by_name["Catan"]["loan_id"] is None
 
-        assert by_name["Pandemic"]["slug"] == "pandemic"
+        # Privacy rule: anonymous viewers see lent status but not who has it.
+        assert by_name["Pandemic"]["status"] == "lent"
+        assert by_name["Pandemic"]["borrower_display_name"] is None
+        assert by_name["Pandemic"]["loan_id"] is None
+
+        conn.close()
+
+    def test_authenticated_request_exposes_borrower_identity(self) -> None:
+        client, conn = _setup_client()
+
+        game_repo = SqliteGameRepository(conn)
+        member_repo = SqliteMemberRepository(conn)
+        loan_repo = SqliteLoanRepository(conn)
+
+        game_repo.upsert_by_bgg_id(
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
+        )
+        game2 = game_repo.upsert_by_bgg_id(
+            bgg_id=200,
+            name="Pandemic",
+            thumbnail_url="https://example.com/pandemic.jpg",
+            year_published=2008,
+        )
+
+        alice = _make_member(
+            member_repo,
+            number=1,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
+        )
+        bob = _make_member(
+            member_repo,
+            number=2,
+            first_name="Bob",
+            last_name="Jones",
+            email="bob@example.com",
+        )
+
+        loan = loan_repo.create(game_id=game2.id, member_id=alice.id)
+
+        response = client.get("/api/juegos", headers=_auth_cookie(bob))
+
+        assert response.status_code == 200
+        by_name = {g["name"]: g for g in response.json()}
+
+        assert by_name["Catan"]["borrower_display_name"] is None
+        assert by_name["Catan"]["loan_id"] is None
+
         assert by_name["Pandemic"]["status"] == "lent"
         assert by_name["Pandemic"]["borrower_display_name"] == "Alice Smith"
-        assert by_name["Pandemic"]["loan_id"] is not None
+        assert by_name["Pandemic"]["loan_id"] == loan.id
 
         conn.close()
 
@@ -106,7 +183,10 @@ class TestGetGame:
         game_repo = SqliteGameRepository(conn)
 
         game = game_repo.upsert_by_bgg_id(
-            bgg_id=100, name="Catan", thumbnail_url="https://example.com/catan.jpg", year_published=1995
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
         )
 
         response = client.get(f"/api/juegos/{game.slug}")
@@ -121,28 +201,65 @@ class TestGetGame:
         assert data["loan_id"] is None
         conn.close()
 
-    def test_lent_game(self) -> None:
+    def test_lent_game_anonymous_hides_borrower(self) -> None:
         client, conn = _setup_client()
         game_repo = SqliteGameRepository(conn)
         member_repo = SqliteMemberRepository(conn)
         loan_repo = SqliteLoanRepository(conn)
 
         game = game_repo.upsert_by_bgg_id(
-            bgg_id=100, name="Catan", thumbnail_url="https://example.com/catan.jpg", year_published=1995
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
         )
-        member = member_repo.upsert_by_email(
-            member_number=1,
+        alice = _make_member(
+            member_repo,
+            number=1,
             first_name="Alice",
             last_name="Smith",
-            nickname=None,
-            phone=None,
             email="alice@example.com",
-            display_name="Alice Smith",
-            is_admin=False,
         )
-        loan = loan_repo.create(game_id=game.id, member_id=member.id)
+        loan_repo.create(game_id=game.id, member_id=alice.id)
 
         response = client.get(f"/api/juegos/{game.slug}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "lent"
+        assert data["borrower_display_name"] is None
+        assert data["loan_id"] is None
+        conn.close()
+
+    def test_lent_game_authenticated_exposes_borrower(self) -> None:
+        client, conn = _setup_client()
+        game_repo = SqliteGameRepository(conn)
+        member_repo = SqliteMemberRepository(conn)
+        loan_repo = SqliteLoanRepository(conn)
+
+        game = game_repo.upsert_by_bgg_id(
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
+        )
+        alice = _make_member(
+            member_repo,
+            number=1,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
+        )
+        bob = _make_member(
+            member_repo,
+            number=2,
+            first_name="Bob",
+            last_name="Jones",
+            email="bob@example.com",
+        )
+        loan = loan_repo.create(game_id=game.id, member_id=alice.id)
+
+        response = client.get(f"/api/juegos/{game.slug}", headers=_auth_cookie(bob))
 
         assert response.status_code == 200
         data = response.json()
@@ -153,6 +270,39 @@ class TestGetGame:
 
 
 class TestGetGameHistory:
+    def _seed_history(self, conn: sqlite3.Connection) -> tuple[str, Member]:
+        game_repo = SqliteGameRepository(conn)
+        member_repo = SqliteMemberRepository(conn)
+        loan_repo = SqliteLoanRepository(conn)
+
+        game = game_repo.upsert_by_bgg_id(
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
+        )
+
+        alice = _make_member(
+            member_repo,
+            number=1,
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
+        )
+        bob = _make_member(
+            member_repo,
+            number=2,
+            first_name="Bob",
+            last_name="Jones",
+            email="bob@example.com",
+        )
+
+        loan1 = loan_repo.create(game_id=game.id, member_id=alice.id)
+        loan_repo.mark_returned(loan1.id)
+        loan_repo.create(game_id=game.id, member_id=bob.id)
+
+        return game.slug, alice
+
     def test_unknown_slug_returns_404(self) -> None:
         client, conn = _setup_client()
 
@@ -166,7 +316,10 @@ class TestGetGameHistory:
 
         game_repo = SqliteGameRepository(conn)
         game_repo.upsert_by_bgg_id(
-            bgg_id=100, name="Catan", thumbnail_url="https://example.com/catan.jpg", year_published=1995
+            bgg_id=100,
+            name="Catan",
+            thumbnail_url="https://example.com/catan.jpg",
+            year_published=1995,
         )
 
         response = client.get("/api/juegos/catan/history")
@@ -175,47 +328,31 @@ class TestGetGameHistory:
         assert response.json() == []
         conn.close()
 
-    def test_game_with_history(self) -> None:
+    def test_anonymous_request_hides_history_member_names(self) -> None:
         client, conn = _setup_client()
+        slug, _ = self._seed_history(conn)
 
-        game_repo = SqliteGameRepository(conn)
-        member_repo = SqliteMemberRepository(conn)
-        loan_repo = SqliteLoanRepository(conn)
+        response = client.get(f"/api/juegos/{slug}/history")
 
-        game = game_repo.upsert_by_bgg_id(
-            bgg_id=100, name="Catan", thumbnail_url="https://example.com/catan.jpg", year_published=1995
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+        # Names hidden, dates preserved.
+        assert data[0]["member_display_name"] is None
+        assert data[0]["returned_at"] is None
+        assert data[1]["member_display_name"] is None
+        assert data[1]["returned_at"] is not None
+
+        conn.close()
+
+    def test_authenticated_request_exposes_history_member_names(self) -> None:
+        client, conn = _setup_client()
+        slug, alice = self._seed_history(conn)
+
+        response = client.get(
+            f"/api/juegos/{slug}/history", headers=_auth_cookie(alice)
         )
-
-        alice = member_repo.upsert_by_email(
-            member_number=1,
-            first_name="Alice",
-            last_name="Smith",
-            nickname=None,
-            phone=None,
-            email="alice@example.com",
-            display_name="Alice Smith",
-            is_admin=False,
-        )
-
-        bob = member_repo.upsert_by_email(
-            member_number=2,
-            first_name="Bob",
-            last_name="Jones",
-            nickname=None,
-            phone=None,
-            email="bob@example.com",
-            display_name="Bob Jones",
-            is_admin=False,
-        )
-
-        # Alice borrowed and returned
-        loan1 = loan_repo.create(game_id=game.id, member_id=alice.id)
-        loan_repo.mark_returned(loan1.id)
-
-        # Bob currently has it
-        loan_repo.create(game_id=game.id, member_id=bob.id)
-
-        response = client.get(f"/api/juegos/{game.slug}/history")
 
         assert response.status_code == 200
         data = response.json()


### PR DESCRIPTION
## Summary

- Anonymous viewers no longer see the borrower's name. `GET /api/games` and `GET /api/games/{id}/history` strip `borrower_display_name`, `loan_id`, and `member_display_name` to `null` for unauthenticated requests; status (available/lent) is preserved. Privacy is enforced server-side, not just on the UI.
- Borrow and return actions move out of the catalog list onto the game detail page, matching the TFM Figma proto. The catalog cards become a quieter browse surface (status badge only — no name, no buttons).
- New OpenSpec change `lending-privacy-and-detail-actions` records the rule so it outlives this implementation.

## Related Tasks

No GitHub Issue tracked this work yet — happy to open a retroactive one or amend this PR description if you'd like to link one.

## Test plan

- [x] Backend: `pytest tests/api/test_games.py` — 6 tests cover anon vs authenticated for both endpoints (asserting concrete `None` / real-name values).
- [x] Backend: full suite passes (1 pre-existing CLI failure unrelated to this change).
- [x] Frontend: `npm test` — 13 new component/page tests cover the no-name card, borrow/return CTA visibility rules, and the borrow confirm flow.
- [x] Frontend: `npm run typecheck` clean. `npm run lint` matches baseline (no new errors introduced).
- [ ] Manual: hit the dev stack as anonymous + as a member + as an admin and verify the catalog card and detail page behave as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)