### PR TITLE
feat(nav): rename Préstamos menu label to Ludoteca

### DIFF
--- a/e2e/tests/site-shell.spec.ts
+++ b/e2e/tests/site-shell.spec.ts
@@ -20,27 +20,27 @@ const ADMIN_STATE = resolve(FIXTURES_DIR, "admin.json");
 
 const HOME = "/prestamos/";
 const LOGIN_PATH = "/prestamos/login";
-const PRESTAMOS_LABEL = "Préstamos";
+const LUDOTECA_LABEL = "Ludoteca";
 
 const isMobileProject = (projectName: string) => projectName === "chromium-mobile";
 const isDesktopProject = (projectName: string) => projectName === "chromium-desktop";
 
-async function openPrestamosSubmenuOnMobile(page: Page) {
+async function openLudotecaSubmenuOnMobile(page: Page) {
   await page.getByRole("button", { name: "Abrir menú" }).click();
   await page
     .locator("#mobile-drawer")
-    .getByRole("button", { name: new RegExp(`^${PRESTAMOS_LABEL}`) })
+    .getByRole("button", { name: new RegExp(`^${LUDOTECA_LABEL}`) })
     .click();
 }
 
 /**
  * On desktop the submenu is CSS-revealed via `:hover` / `:focus-within` on
- * the Préstamos parent. Hovering the parent link makes the submenu visible
+ * the Ludoteca parent. Hovering the parent link makes the submenu visible
  * and reachable for accessibility-tree queries.
  */
-async function revealPrestamosSubmenuOnDesktop(page: Page) {
+async function revealLudotecaSubmenuOnDesktop(page: Page) {
   await page
-    .getByRole("link", { name: new RegExp(`^${PRESTAMOS_LABEL}`) })
+    .getByRole("link", { name: new RegExp(`^${LUDOTECA_LABEL}`) })
     .first()
     .hover();
 }
@@ -82,16 +82,16 @@ test.describe("site-shell @ member", () => {
     await page.goto(HOME);
 
     if (isMobileProject(testInfo.project.name)) {
-      await openPrestamosSubmenuOnMobile(page);
+      await openLudotecaSubmenuOnMobile(page);
     } else {
-      await revealPrestamosSubmenuOnDesktop(page);
+      await revealLudotecaSubmenuOnDesktop(page);
     }
 
     await expect(
       page.getByRole("menuitem", { name: "Mis préstamos" }).first(),
     ).toBeVisible();
     // "Cerrar sesión" lives in the header actions slot (desktop) / drawer user row
-    // (mobile), not inside the Préstamos submenu — so its ARIA role is "button".
+    // (mobile), not inside the Ludoteca submenu — so its ARIA role is "button".
     await expect(
       page.getByRole("button", { name: "Cerrar sesión" }).first(),
     ).toBeVisible();
@@ -118,7 +118,7 @@ test.describe("site-shell @ member", () => {
       .toBe("1");
 
     // "Cerrar sesión" is in the header actions slot — always visible on desktop,
-    // no need to hover the Préstamos submenu first.
+    // no need to hover the Ludoteca submenu first.
     await page
       .getByRole("button", { name: "Cerrar sesión" })
       .first()
@@ -141,13 +141,13 @@ test.describe("site-shell @ admin", () => {
     await page.goto(HOME);
 
     if (isMobileProject(testInfo.project.name)) {
-      await openPrestamosSubmenuOnMobile(page);
+      await openLudotecaSubmenuOnMobile(page);
       await page
         .locator("#mobile-drawer")
         .getByRole("button", { name: /Administración/ })
         .click();
     } else {
-      await revealPrestamosSubmenuOnDesktop(page);
+      await revealLudotecaSubmenuOnDesktop(page);
       // Hover the nested Administración trigger so its child list reveals.
       await page
         .getByRole("button", { name: /Administración/ })
@@ -181,14 +181,14 @@ test.describe("site-shell @ static page (guest)", () => {
     await expect(page.locator("#site-shell-root")).toBeVisible();
   });
 
-  test("static-shell-2: Préstamos link href points to /prestamos/", async ({
+  test("static-shell-2: Ludoteca link href points to /prestamos/", async ({
     page,
   }, testInfo) => {
     await page.goto(STATIC_PAGE);
     if (isMobileProject(testInfo.project.name)) {
       await page.getByRole("button", { name: "Abrir menú" }).click();
     }
-    const link = page.getByRole("link", { name: new RegExp(`^${PRESTAMOS_LABEL}`) }).first();
+    const link = page.getByRole("link", { name: new RegExp(`^${LUDOTECA_LABEL}`) }).first();
     await expect(link).toBeVisible();
     // React Router with basename="/prestamos" generates href="/prestamos" (no trailing
     // slash) for <Link to="/">. The Caddyfile 301-redirects /prestamos → /prestamos/

--- a/frontend/src/components/SiteHeader/SiteHeader.test.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.test.tsx
@@ -112,7 +112,7 @@ describe("SiteHeader", () => {
       ]);
     });
 
-    it("renders only the Préstamos parent when status is error", () => {
+    it("renders only the Ludoteca parent when status is error", () => {
       mockNavState = { items: [], status: "error" };
       const { container } = renderHeader();
 
@@ -126,7 +126,7 @@ describe("SiteHeader", () => {
       expect(navLinks).not.toContain("Calendario");
     });
 
-    it("renders only the Préstamos parent when items is empty with ready status", () => {
+    it("renders only the Ludoteca parent when items is empty with ready status", () => {
       mockNavState = { items: [], status: "ready" };
       const { container } = renderHeader();
 
@@ -137,17 +137,17 @@ describe("SiteHeader", () => {
         const link = li.querySelector(":scope > a, :scope > button");
         return link?.textContent ?? "";
       });
-      // With empty items, only Préstamos should be in the top-level nav
-      expect(topLevelItems.map((t) => t.trim())).toEqual(["Préstamos"]);
+      // With empty items, only Ludoteca should be in the top-level nav
+      expect(topLevelItems.map((t) => t.trim())).toEqual(["Ludoteca"]);
     });
   });
 
-  describe("Préstamos submenu — guest", () => {
-    it("renders Préstamos as a plain link with no submenu and no chevron", () => {
+  describe("Ludoteca submenu — guest", () => {
+    it("renders Ludoteca as a plain link with no submenu and no chevron", () => {
       setGuest();
       renderHeader();
 
-      // No menuitem roles at all — Préstamos is a plain link, no submenu rendered
+      // No menuitem roles at all — Ludoteca is a plain link, no submenu rendered
       expect(screen.queryAllByRole("menuitem")).toEqual([]);
       // No aria-haspopup anywhere
       expect(
@@ -188,7 +188,7 @@ describe("SiteHeader", () => {
       expect(loginLinks.length).toEqual(0);
     });
 
-    it("does not show Iniciar sesión inside the Préstamos submenu", () => {
+    it("does not show Iniciar sesión inside the Ludoteca submenu", () => {
       setGuest();
       renderHeader();
 
@@ -222,7 +222,7 @@ describe("SiteHeader", () => {
     });
   });
 
-  describe("Préstamos submenu — member", () => {
+  describe("Ludoteca submenu — member", () => {
     it("renders exactly Mis préstamos in submenu (not Cerrar sesión) for member", () => {
       setMember();
       renderHeader();
@@ -263,7 +263,7 @@ describe("SiteHeader", () => {
     });
   });
 
-  describe("Préstamos submenu — admin", () => {
+  describe("Ludoteca submenu — admin", () => {
     it("renders Mis préstamos in submenu but not Cerrar sesión for admin", () => {
       setAdmin();
       renderHeader();
@@ -349,7 +349,7 @@ describe("SiteHeader", () => {
       expect(menuitems).not.toContain("Cerrar sesión");
     });
 
-    it("does not show Cerrar sesión in Préstamos submenu for member", () => {
+    it("does not show Cerrar sesión in Ludoteca submenu for member", () => {
       setMember();
       renderHeader();
 
@@ -357,7 +357,7 @@ describe("SiteHeader", () => {
       expect(menuitems).toEqual(["Mis préstamos"]);
     });
 
-    it("shows display_name and Cerrar sesión in drawer without expanding Préstamos", () => {
+    it("shows display_name and Cerrar sesión in drawer without expanding Ludoteca", () => {
       setMember();
       mockLogout.mockResolvedValue(undefined);
       const { container } = renderHeader();
@@ -384,26 +384,26 @@ describe("SiteHeader", () => {
   });
 
   describe("active-route highlighting", () => {
-    it("Préstamos parent has active class when at /prestamos/my-loans", () => {
+    it("Ludoteca parent has active class when at /prestamos/my-loans", () => {
       setMember();
       const { container } = renderHeader("/prestamos/my-loans");
 
-      // Find the Préstamos <Link> element in the desktop nav (not the mobile drawer button)
+      // Find the Ludoteca <Link> element in the desktop nav (not the mobile drawer button)
       const desktopNav = container.querySelector("nav[aria-label='Principal']");
-      const prestamosNavItem = Array.from(desktopNav!.querySelectorAll("li")).find(
-        (li) => li.querySelector("a")?.textContent?.includes("Préstamos")
+      const ludotecaNavItem = Array.from(desktopNav!.querySelectorAll("li")).find(
+        (li) => li.querySelector("a")?.textContent?.includes("Ludoteca")
       );
-      expect(prestamosNavItem?.className).toContain("active");
+      expect(ludotecaNavItem?.className).toContain("active");
     });
 
-    it("Préstamos parent has active class when at /prestamos/", () => {
+    it("Ludoteca parent has active class when at /prestamos/", () => {
       const { container } = renderHeader("/prestamos/");
 
       const desktopNav = container.querySelector("nav[aria-label='Principal']");
-      const prestamosNavItem = Array.from(desktopNav!.querySelectorAll("li")).find(
-        (li) => li.querySelector("a")?.textContent?.includes("Préstamos")
+      const ludotecaNavItem = Array.from(desktopNav!.querySelectorAll("li")).find(
+        (li) => li.querySelector("a")?.textContent?.includes("Ludoteca")
       );
-      expect(prestamosNavItem?.className).toContain("active");
+      expect(ludotecaNavItem?.className).toContain("active");
     });
   });
 
@@ -452,7 +452,7 @@ describe("SiteHeader", () => {
       expect(hamburger.getAttribute("aria-expanded")).toEqual("false");
     });
 
-    it("tapping Préstamos in drawer toggles prestamos submenu", () => {
+    it("tapping Ludoteca in drawer toggles ludoteca submenu", () => {
       setMember();
       renderHeader();
 
@@ -460,19 +460,19 @@ describe("SiteHeader", () => {
       const hamburger = screen.getByRole("button", { name: "Abrir menú" });
       fireEvent.click(hamburger);
 
-      // There are two "Préstamos" triggers: one in desktop nav (Link), one in drawer (button)
-      const prestamosButtons = screen.getAllByRole("button").filter(
-        (el) => el.textContent?.includes("Préstamos")
+      // There are two "Ludoteca" triggers: one in desktop nav (Link), one in drawer (button)
+      const ludotecaButtons = screen.getAllByRole("button").filter(
+        (el) => el.textContent?.includes("Ludoteca")
       );
       // The drawer one has aria-haspopup
-      const drawerPrestamos = prestamosButtons.find(
+      const drawerLudoteca = ludotecaButtons.find(
         (el) => el.getAttribute("aria-haspopup") === "menu"
       );
-      expect(drawerPrestamos).toBeDefined();
+      expect(drawerLudoteca).toBeDefined();
 
-      expect(drawerPrestamos!.getAttribute("aria-expanded")).toEqual("false");
-      fireEvent.click(drawerPrestamos!);
-      expect(drawerPrestamos!.getAttribute("aria-expanded")).toEqual("true");
+      expect(drawerLudoteca!.getAttribute("aria-expanded")).toEqual("false");
+      fireEvent.click(drawerLudoteca!);
+      expect(drawerLudoteca!.getAttribute("aria-expanded")).toEqual("true");
     });
 
     // draw-6: nested Administración expands inside drawer
@@ -487,16 +487,16 @@ describe("SiteHeader", () => {
       const drawer = container.querySelector("#mobile-drawer") as HTMLElement;
       expect(drawer).not.toBeNull();
 
-      // Open Préstamos in drawer
-      const drawerPrestamos = within(drawer)
+      // Open Ludoteca in drawer
+      const drawerLudoteca = within(drawer)
         .getAllByRole("button")
         .find(
           (el) =>
-            el.textContent?.includes("Préstamos") &&
+            el.textContent?.includes("Ludoteca") &&
             el.getAttribute("aria-haspopup") === "menu"
         );
-      expect(drawerPrestamos).toBeDefined();
-      fireEvent.click(drawerPrestamos!);
+      expect(drawerLudoteca).toBeDefined();
+      fireEvent.click(drawerLudoteca!);
 
       // Click the Administración nested trigger
       const adminTrigger = within(drawer)
@@ -534,7 +534,7 @@ describe("SiteHeader", () => {
       const drawer = container.querySelector("#mobile-drawer") as HTMLElement;
       expect(drawer).not.toBeNull();
 
-      // Cerrar sesión is at the top of the drawer — no need to expand Préstamos submenu
+      // Cerrar sesión is at the top of the drawer — no need to expand Ludoteca submenu
       const cerrarBtn = within(drawer).getByRole("button", { name: "Cerrar sesión" });
       fireEvent.click(cerrarBtn);
 
@@ -603,16 +603,16 @@ describe("SiteHeader", () => {
       const drawer = container.querySelector("#mobile-drawer") as HTMLElement;
       expect(drawer).not.toBeNull();
 
-      // Open Préstamos in drawer
-      const drawerPrestamos = within(drawer)
+      // Open Ludoteca in drawer
+      const drawerLudoteca = within(drawer)
         .getAllByRole("button")
         .find(
           (el) =>
-            el.textContent?.includes("Préstamos") &&
+            el.textContent?.includes("Ludoteca") &&
             el.getAttribute("aria-haspopup") === "menu"
         );
-      expect(drawerPrestamos).toBeDefined();
-      fireEvent.click(drawerPrestamos!);
+      expect(drawerLudoteca).toBeDefined();
+      fireEvent.click(drawerLudoteca!);
 
       // Find Administración nested trigger inside drawer
       const adminTrigger = within(drawer)
@@ -630,57 +630,57 @@ describe("SiteHeader", () => {
 
   // chev-1: chevron SVG presence by auth state
   describe("chevron SVG presence (chev-1)", () => {
-    it("Préstamos parent in desktop nav contains a chevron SVG for member", () => {
+    it("Ludoteca parent in desktop nav contains a chevron SVG for member", () => {
       setMember();
       const { container } = renderHeader();
 
       const desktopNav = container.querySelector("nav[aria-label='Principal']");
       expect(desktopNav).not.toBeNull();
 
-      // The Préstamos link element contains the ChevronDown SVG
-      const prestamosLi = Array.from(desktopNav!.querySelectorAll("li")).find(
-        (li) => li.textContent?.includes("Préstamos")
+      // The Ludoteca link element contains the ChevronDown SVG
+      const ludotecaLi = Array.from(desktopNav!.querySelectorAll("li")).find(
+        (li) => li.textContent?.includes("Ludoteca")
       );
-      expect(prestamosLi).toBeDefined();
-      const chevrons = prestamosLi!.querySelectorAll("svg");
+      expect(ludotecaLi).toBeDefined();
+      const chevrons = ludotecaLi!.querySelectorAll("svg");
       expect(chevrons.length).toEqual(1);
     });
 
-    it("Préstamos parent in desktop nav contains a chevron SVG for admin", () => {
+    it("Ludoteca parent in desktop nav contains a chevron SVG for admin", () => {
       setAdmin();
       const { container } = renderHeader();
 
       const desktopNav = container.querySelector("nav[aria-label='Principal']");
       expect(desktopNav).not.toBeNull();
 
-      const prestamosLi = Array.from(desktopNav!.querySelectorAll("li")).find(
-        (li) => li.textContent?.includes("Préstamos")
+      const ludotecaLi = Array.from(desktopNav!.querySelectorAll("li")).find(
+        (li) => li.textContent?.includes("Ludoteca")
       );
-      expect(prestamosLi).toBeDefined();
-      // Admin: 2 SVGs — one for Préstamos link chevron, one for Administración nested trigger chevron
-      const chevrons = prestamosLi!.querySelectorAll("svg");
+      expect(ludotecaLi).toBeDefined();
+      // Admin: 2 SVGs — one for Ludoteca link chevron, one for Administración nested trigger chevron
+      const chevrons = ludotecaLi!.querySelectorAll("svg");
       expect(chevrons.length).toEqual(2);
     });
 
-    it("Préstamos item in desktop nav has no chevron SVG for guest", () => {
+    it("Ludoteca item in desktop nav has no chevron SVG for guest", () => {
       setGuest();
       const { container } = renderHeader();
 
       const desktopNav = container.querySelector("nav[aria-label='Principal']");
       expect(desktopNav).not.toBeNull();
 
-      const prestamosLi = Array.from(desktopNav!.querySelectorAll("li")).find(
-        (li) => li.textContent?.trim() === "Préstamos"
+      const ludotecaLi = Array.from(desktopNav!.querySelectorAll("li")).find(
+        (li) => li.textContent?.trim() === "Ludoteca"
       );
-      expect(prestamosLi).toBeDefined();
-      const chevrons = prestamosLi!.querySelectorAll("svg");
+      expect(ludotecaLi).toBeDefined();
+      const chevrons = ludotecaLi!.querySelectorAll("svg");
       expect(chevrons.length).toEqual(0);
     });
   });
 
-  // err-2: rapid double-click on drawer Préstamos trigger leaves aria-expanded deterministic
+  // err-2: rapid double-click on drawer Ludoteca trigger leaves aria-expanded deterministic
   describe("rapid toggle is deterministic (err-2)", () => {
-    it("double-click on drawer Préstamos trigger results in closed state", () => {
+    it("double-click on drawer Ludoteca trigger results in closed state", () => {
       setMember();
       renderHeader();
 
@@ -688,20 +688,20 @@ describe("SiteHeader", () => {
       const hamburger = screen.getByRole("button", { name: "Abrir menú" });
       fireEvent.click(hamburger);
 
-      const drawerPrestamos = screen
+      const drawerLudoteca = screen
         .getAllByRole("button")
         .find(
           (el) =>
-            el.textContent?.includes("Préstamos") &&
+            el.textContent?.includes("Ludoteca") &&
             el.getAttribute("aria-haspopup") === "menu"
         );
-      expect(drawerPrestamos).toBeDefined();
+      expect(drawerLudoteca).toBeDefined();
 
       // Rapid double-click: open then immediately close
-      fireEvent.click(drawerPrestamos!);
-      fireEvent.click(drawerPrestamos!);
+      fireEvent.click(drawerLudoteca!);
+      fireEvent.click(drawerLudoteca!);
 
-      expect(drawerPrestamos!.getAttribute("aria-expanded")).toEqual("false");
+      expect(drawerLudoteca!.getAttribute("aria-expanded")).toEqual("false");
     });
   });
 });

--- a/frontend/src/components/SiteHeader/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.tsx
@@ -45,7 +45,7 @@ type SubmenuItem = LinkSubmenuItem | NestedSubmenuItem;
 
 // `to` values are router-relative (inside `<BrowserRouter basename="/prestamos">`),
 // so they omit the `/prestamos` prefix — the router prepends it.
-const PRESTAMOS_SUBMENU: readonly SubmenuItem[] = [
+const LUDOTECA_SUBMENU: readonly SubmenuItem[] = [
   { type: "link", label: "Mis préstamos", to: "/my-loans", roles: ["member", "admin"] },
   {
     type: "nested",
@@ -101,22 +101,22 @@ function AdminNestedSubmenu({
   );
 }
 
-// ─── PrestamosSubmenu ─────────────────────────────────────────────────────────
+// ─── LudotecaSubmenu ──────────────────────────────────────────────────────────
 
-interface PrestamosSubmenuProps {
+interface LudotecaSubmenuProps {
   readonly role: SubmenuRole;
   readonly adminExpanded: boolean;
   readonly onToggleAdmin: () => void;
   readonly onItemClick?: () => void;
 }
 
-function PrestamosSubmenu({
+function LudotecaSubmenu({
   role,
   adminExpanded,
   onToggleAdmin,
   onItemClick,
-}: PrestamosSubmenuProps) {
-  const visibleItems = PRESTAMOS_SUBMENU.filter((item) =>
+}: LudotecaSubmenuProps) {
+  const visibleItems = LUDOTECA_SUBMENU.filter((item) =>
     item.roles.includes(role)
   );
 
@@ -153,7 +153,7 @@ export function SiteHeader() {
   const { member, logout } = useAuth();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [expandedDrawerHref, setExpandedDrawerHref] = useState<string | null>(null);
-  const [prestamosExpanded, setPrestamosExpanded] = useState(false);
+  const [ludotecaExpanded, setLudotecaExpanded] = useState(false);
   const [adminExpanded, setAdminExpanded] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
 
@@ -162,7 +162,7 @@ export function SiteHeader() {
   // location. In tests we mount under a plain MemoryRouter where the path
   // does start with "/prestamos". Cover both by also checking the raw
   // browser pathname when it's available.
-  const isPrestamosActive =
+  const isLudotecaActive =
     useMatch("/prestamos/*") !== null ||
     (typeof window !== "undefined" &&
       window.location.pathname.startsWith("/prestamos"));
@@ -176,7 +176,7 @@ export function SiteHeader() {
         ? "member"
         : "guest";
 
-  const hasPrestamosSubmenu = PRESTAMOS_SUBMENU.some((item) =>
+  const hasLudotecaSubmenu = LUDOTECA_SUBMENU.some((item) =>
     item.roles.includes(role)
   );
 
@@ -207,7 +207,7 @@ export function SiteHeader() {
   const closeDrawer = () => {
     setDrawerOpen(false);
     setExpandedDrawerHref(null);
-    setPrestamosExpanded(false);
+    setLudotecaExpanded(false);
     setAdminExpanded(false);
   };
 
@@ -257,26 +257,26 @@ export function SiteHeader() {
                 );
               })}
 
-            {/* Préstamos parent */}
+            {/* Ludoteca parent */}
             <li
-              className={`${styles.navItem} ${hasPrestamosSubmenu ? styles.hasSubmenu : ""} ${
-                isPrestamosActive ? styles.active : ""
+              className={`${styles.navItem} ${hasLudotecaSubmenu ? styles.hasSubmenu : ""} ${
+                isLudotecaActive ? styles.active : ""
               }`}
             >
-              {hasPrestamosSubmenu ? (
+              {hasLudotecaSubmenu ? (
                 <>
                   <Link to="/" aria-haspopup="menu" aria-expanded={false}>
-                    Préstamos
+                    Ludoteca
                     <ChevronDown />
                   </Link>
-                  <PrestamosSubmenu
+                  <LudotecaSubmenu
                     role={role}
                     adminExpanded={false}
                     onToggleAdmin={() => undefined}
                   />
                 </>
               ) : (
-                <Link to="/">Préstamos</Link>
+                <Link to="/">Ludoteca</Link>
               )}
             </li>
           </ul>
@@ -395,22 +395,22 @@ export function SiteHeader() {
                 );
               })}
 
-            {/* Préstamos in drawer */}
+            {/* Ludoteca in drawer */}
             <li className={styles.drawerItem}>
-              {hasPrestamosSubmenu ? (
+              {hasLudotecaSubmenu ? (
                 <>
                   <button
                     type="button"
                     className={styles.drawerParent}
                     aria-haspopup="menu"
-                    aria-expanded={prestamosExpanded}
-                    onClick={() => setPrestamosExpanded((prev) => !prev)}
+                    aria-expanded={ludotecaExpanded}
+                    onClick={() => setLudotecaExpanded((prev) => !prev)}
                   >
-                    Préstamos
+                    Ludoteca
                     <ChevronDown />
                   </button>
-                  {prestamosExpanded && (
-                    <PrestamosSubmenu
+                  {ludotecaExpanded && (
+                    <LudotecaSubmenu
                       role={role}
                       adminExpanded={adminExpanded}
                       onToggleAdmin={() => setAdminExpanded((prev) => !prev)}
@@ -420,7 +420,7 @@ export function SiteHeader() {
                 </>
               ) : (
                 <Link to="/" onClick={closeDrawer}>
-                  Préstamos
+                  Ludoteca
                 </Link>
               )}
             </li>


### PR DESCRIPTION
Renames the top-level navigation menu item from "Préstamos" to "Ludoteca" to match the original Google Sites site name.

The URL path `/prestamos` and all routing remain unchanged — only the visible label and related code identifiers are updated.

## Changes

- `SiteHeader.tsx` — display text (4 occurrences) + identifier renames (`LUDOTECA_SUBMENU`, `LudotecaSubmenu`, `ludotecaExpanded`, `isLudotecaActive`, `hasLudotecaSubmenu`)
- `SiteHeader.test.tsx` — test descriptions and DOM text queries updated to match new label
- `e2e/tests/site-shell.spec.ts` — `LUDOTECA_LABEL` constant, helper functions renamed (`openLudotecaSubmenuOnMobile`, `revealLudotecaSubmenuOnDesktop`)

## Related Tasks

- Closes #58

## Test plan

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All 101 unit tests pass (`vitest run`)
- [ ] E2E `site-shell` suite passes against a running server