### PR TITLE
fix(header): prevent menu overflow at 1280px with logged-in user

### DIFF
--- a/frontend/src/components/SiteHeader/SiteHeader.module.css
+++ b/frontend/src/components/SiteHeader/SiteHeader.module.css
@@ -44,7 +44,7 @@
   margin-left: var(--space-sm);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1399px) {
   .logoText {
     display: none;
   }
@@ -447,6 +447,25 @@
 }
 
 /* ─── Breakpoints ────────────────────────────────────────────────────── */
+
+/* Tight desktop range: logo text already hidden above; also reduce
+   inner gap and nav item padding so everything fits at 1280 px. */
+@media (min-width: 768px) and (max-width: 1399px) {
+  .inner {
+    gap: var(--space-sm);
+    padding: 0 var(--space-md);
+  }
+
+  .navItem > a,
+  .navItem > button {
+    padding: var(--space-sm) var(--space-sm);
+  }
+
+  .headerActions {
+    margin-left: var(--space-sm);
+    gap: var(--space-xs);
+  }
+}
 
 @media (max-width: 767px) {
   .desktopNav {


### PR DESCRIPTION
## Summary
- At 1280 px the logo text + nav items + username + logout button overflowed the header row.
- Hides the logo text (shows icon only) below 1400 px.
- Reduces inner gap and nav-item padding in the 768–1399 px range to give everything room.
- Layout at ≥ 1400 px is unchanged — logo text and full spacing are preserved.

## Related Tasks
- Closes #81

## Test plan
- [ ] At 1280 px with a logged-in user (any name): header is a single row, all items visible, nothing wraps.
- [ ] At 1440 px+ with a logged-in user: logo text "El Refugio del Sátiro" is visible alongside the full nav.
- [ ] Mobile (≤ 767 px): hamburger still shown, desktop nav hidden — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)