### PR TITLE
Add web interface to upload members.csv

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import csv
+import io
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
 from backend.api.dependencies import (
@@ -14,6 +16,7 @@ from backend.api.dependencies import (
 )
 from backend.data.email_client import EmailClient
 from backend.domain.entities.member import Member
+from backend.domain.use_cases.import_members import ImportMembersUseCase
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -74,6 +77,18 @@ class SendLinkResponse(BaseModel):
 
 class OkResponse(BaseModel):
     ok: bool = True
+
+
+class ImportedMember(BaseModel):
+    display_name: str
+    email: str
+    token_url: str
+
+
+class ImportMembersResponse(BaseModel):
+    created: list[ImportedMember]
+    total_rows: int
+    skipped_rows: int
 
 
 @router.get("/members", response_model=list[MemberListItem])
@@ -153,6 +168,49 @@ def create_member(
             gender=member.gender,
         ),
         token_url=token_url,
+    )
+
+
+@router.post("/members/import", response_model=ImportMembersResponse)
+async def import_members(
+    file: UploadFile,
+    _admin: AdminMember,
+    member_repo: MemberRepo,
+    token_repo: TokenRepo,
+) -> ImportMembersResponse:
+    raw_bytes = await file.read()
+    try:
+        text = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El archivo debe ser un CSV codificado en UTF-8.",
+        ) from exc
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None or "Email" not in reader.fieldnames:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="El archivo CSV debe tener una columna 'Email'.",
+        )
+
+    raw_members = list(reader)
+    skipped_rows = sum(1 for row in raw_members if not (row.get("Email") or "").strip())
+
+    use_case = ImportMembersUseCase(member_repo, token_repo, _settings.base_url)
+    results = use_case.execute(raw_members)
+
+    return ImportMembersResponse(
+        created=[
+            ImportedMember(
+                display_name=r.member.display_name,
+                email=r.member.email,
+                token_url=r.token_url,
+            )
+            for r in results
+        ],
+        total_rows=len(raw_members),
+        skipped_rows=skipped_rows,
     )
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refugio-frontend",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refugio-frontend",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slider": "^1.4.0",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,3 +20,21 @@ export async function apiFetch<T>(
 
   return response.json() as Promise<T>;
 }
+
+export async function apiUpload<T>(
+  path: string,
+  formData: FormData
+): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: "Error desconegut" }));
+    throw new Error(error.detail ?? error.error ?? `Error ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/frontend/src/pages/AdminMembersPage.css
+++ b/frontend/src/pages/AdminMembersPage.css
@@ -21,6 +21,37 @@
   margin-bottom: 0;
 }
 
+.admin-header-actions {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.admin-file-input {
+  display: none;
+}
+
+/* CSV import results */
+.admin-import-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+}
+
+.admin-import-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.admin-import-name {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
 /* Restricted access */
 .admin-restricted {
   text-align: center;

--- a/frontend/src/pages/AdminMembersPage.css
+++ b/frontend/src/pages/AdminMembersPage.css
@@ -52,6 +52,36 @@
   font-weight: 500;
 }
 
+/* CSV import help dialog */
+.admin-import-help {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.admin-import-help-columns {
+  display: block;
+  padding: var(--space-sm);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.admin-import-help ul {
+  margin: 0;
+  padding-left: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.admin-import-help-actions {
+  margin-top: var(--space-sm);
+}
+
 /* Restricted access */
 .admin-restricted {
   text-align: center;

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "../context/AuthContext";
-import { apiFetch } from "../api/client";
+import { apiFetch, apiUpload } from "../api/client";
 import type {
   AdminMember,
   CreateMemberRequest,
   CreateMemberResponse,
   EditMemberRequest,
+  ImportMembersResponse,
   MemberGender,
   SendLinkResponse,
   OkResponse,
@@ -27,6 +28,9 @@ export function AdminMembersPage() {
   const [sortKey, setSortKey] = useState<keyof AdminMember>("display_name");
   const [sortAsc, setSortAsc] = useState(true);
   const [editTarget, setEditTarget] = useState<AdminMember | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<ImportMembersResponse | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleSort = (key: keyof AdminMember) => {
     if (sortKey === key) {
@@ -116,6 +120,38 @@ export function AdminMembersPage() {
     await navigator.clipboard.writeText(text);
   };
 
+  const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    setTokenBanner(null);
+    setSuccessMessage(null);
+    setImportResult(null);
+    setError(null);
+    setImporting(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await apiUpload<ImportMembersResponse>(
+        "/admin/members/import",
+        formData
+      );
+      if (res.created.length === 0) {
+        setSuccessMessage(
+          "Importación completada. Ningún socio nuevo (socios existentes actualizados)."
+        );
+      } else {
+        setImportResult(res);
+      }
+      void fetchMembers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error importando el CSV.");
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const handleEditSave = async (id: number, req: EditMemberRequest) => {
     try {
       await apiFetch<OkResponse>(`/admin/members/${id}`, {
@@ -157,16 +193,33 @@ export function AdminMembersPage() {
     <div className="admin-members-page">
       <div className="admin-members-header">
         <h1>Gestión de socios</h1>
-        <Button
-          variant="primary"
-          onClick={() => {
-            setShowCreateForm(!showCreateForm);
-            setTokenBanner(null);
-            setSuccessMessage(null);
-          }}
-        >
-          {showCreateForm ? "Cancelar" : "Crear socio"}
-        </Button>
+        <div className="admin-header-actions">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="admin-file-input"
+            aria-label="Seleccionar archivo CSV de socios"
+            onChange={(e) => void handleImportFile(e)}
+          />
+          <Button
+            variant="secondary"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={importing}
+          >
+            {importing ? "Importando..." : "Importar CSV"}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => {
+              setShowCreateForm(!showCreateForm);
+              setTokenBanner(null);
+              setSuccessMessage(null);
+            }}
+          >
+            {showCreateForm ? "Cancelar" : "Crear socio"}
+          </Button>
+        </div>
       </div>
 
       {successMessage && (
@@ -186,6 +239,31 @@ export function AdminMembersPage() {
               Copiar
             </Button>
           </div>
+        </div>
+      )}
+
+      {importResult && (
+        <div className="admin-token-banner">
+          <p>
+            {`${importResult.created.length} socios nuevos, ${importResult.skipped_rows} filas omitidas de ${importResult.total_rows}`}
+          </p>
+          <ul className="admin-import-list">
+            {importResult.created.map((imported) => (
+              <li key={imported.email} className="admin-import-item">
+                <span className="admin-import-name">{imported.display_name}</span>
+                <div className="admin-token-url">
+                  <code>{imported.token_url}</code>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void handleCopy(imported.token_url)}
+                  >
+                    Copiar
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -16,6 +16,26 @@ import { Button } from "../ui/Button";
 import { Dialog } from "../ui/Dialog";
 import "./AdminMembersPage.css";
 
+const CSV_COLUMNS =
+  "Nº Socio,Apellidos,Nombre,Apodo,Telefóno,Email,admin,Última cuota,Género";
+
+const SAMPLE_MEMBERS_CSV = `${CSV_COLUMNS}
+1,García López,Carla,Carla,600 00 00 01,carla@example.com,,24/01/2026,Femenino
+2,Torres Ruiz,Jorge,Jordi,600 00 00 02,jorge@example.com,yes,24/01/2026,Masculino
+`;
+
+function downloadSampleCsv() {
+  const blob = new Blob([SAMPLE_MEMBERS_CSV], {
+    type: "text/csv;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "ejemplo-socios.csv";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
 export function AdminMembersPage() {
   const { member, loading: authLoading } = useAuth();
   const [members, setMembers] = useState<AdminMember[]>([]);
@@ -30,6 +50,7 @@ export function AdminMembersPage() {
   const [editTarget, setEditTarget] = useState<AdminMember | null>(null);
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState<ImportMembersResponse | null>(null);
+  const [showImportHelp, setShowImportHelp] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleSort = (key: keyof AdminMember) => {
@@ -210,6 +231,13 @@ export function AdminMembersPage() {
             {importing ? "Importando..." : "Importar CSV"}
           </Button>
           <Button
+            variant="secondary"
+            aria-label="Ayuda sobre el formato del CSV"
+            onClick={() => setShowImportHelp(true)}
+          >
+            ?
+          </Button>
+          <Button
             variant="primary"
             onClick={() => {
               setShowCreateForm(!showCreateForm);
@@ -354,6 +382,40 @@ export function AdminMembersPage() {
           </table>
         </div>
       )}
+
+      <Dialog
+        open={showImportHelp}
+        onOpenChange={setShowImportHelp}
+        title="¿Cómo preparar el CSV?"
+        description="El archivo debe tener el mismo formato que la exportación CSV de la hoja de cálculo de socios."
+      >
+        <div className="admin-import-help">
+          <p>Columnas esperadas (la primera fila debe ser la cabecera):</p>
+          <code className="admin-import-help-columns">{CSV_COLUMNS}</code>
+          <ul>
+            <li>
+              Las filas sin <strong>Email</strong> se omiten.
+            </li>
+            <li>
+              Si el email ya existe, se actualizan los datos del socio (no se
+              duplica).
+            </li>
+            <li>
+              Los socios nuevos reciben un enlace para establecer su
+              contraseña, que se muestra tras la importación.
+            </li>
+            <li>
+              La columna <code>admin</code> con valor <code>yes</code> marca al
+              socio como administrador.
+            </li>
+          </ul>
+          <div className="admin-import-help-actions">
+            <Button variant="secondary" onClick={downloadSampleCsv}>
+              Descargar CSV de ejemplo
+            </Button>
+          </div>
+        </div>
+      </Dialog>
 
       {editTarget && (
         <EditMemberDialog

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -43,6 +43,18 @@ export interface SendLinkResponse {
   readonly token_url: string;
 }
 
+export interface ImportedMember {
+  readonly display_name: string;
+  readonly email: string;
+  readonly token_url: string;
+}
+
+export interface ImportMembersResponse {
+  readonly created: readonly ImportedMember[];
+  readonly total_rows: number;
+  readonly skipped_rows: number;
+}
+
 export interface OkResponse {
   readonly ok: boolean;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     "typer>=0.12",
     "pyjwt>=2.8",
+    "python-multipart>=0.0.9",
     "bcrypt>=4.1",
     "httpx>=0.27",
     "python-dotenv>=1.0",

--- a/tests/api/test_members.py
+++ b/tests/api/test_members.py
@@ -315,6 +315,141 @@ class TestAdminPatchMember:
         conn.close()
 
 
+class TestAdminImportMembers:
+    CSV_HEADER = (
+        "Nº Socio,Apellidos,Nombre,Apodo,Telefóno,Email,admin,Última cuota,Género"
+    )
+
+    def _csv_bytes(self, rows: list[str]) -> bytes:
+        return "\n".join([self.CSV_HEADER, *rows]).encode("utf-8")
+
+    def _post_import(
+        self, client: TestClient, admin: Member, csv_bytes: bytes
+    ):  # type: ignore[no-untyped-def]
+        return client.post(
+            "/api/admin/members/import",
+            files={"file": ("members.csv", csv_bytes, "text/csv")},
+            headers=_auth_cookie(admin),
+        )
+
+    def _make_admin(self, member_repo: SqliteMemberRepository) -> Member:
+        return _make_member(
+            member_repo,
+            number=1,
+            first_name="Admin",
+            last_name="User",
+            email="admin@test.com",
+            is_admin=True,
+        )
+
+    def test_import_creates_members_and_returns_tokens(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        admin = self._make_admin(member_repo)
+
+        csv_bytes = self._csv_bytes(
+            [
+                "10,García,Ana,Anita,600111222,ana@test.com,,5/02/2022,Femenino",
+                "11,López,Carlos,,600333444,carlos@test.com,,1/01/2023,Masculino",
+            ]
+        )
+        response = self._post_import(client, admin, csv_bytes)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_rows"] == 2
+        assert body["skipped_rows"] == 0
+        assert len(body["created"]) == 2
+
+        by_email = {c["email"]: c for c in body["created"]}
+        assert by_email["ana@test.com"]["display_name"] == "Anita"
+        assert by_email["carlos@test.com"]["display_name"] == "Carlos López"
+        for created in body["created"]:
+            assert "/set-password?token=" in created["token_url"]
+
+        ana = member_repo.get_by_email("ana@test.com")
+        assert ana is not None
+        assert ana.member_number == 10
+        conn.close()
+
+    def test_reimport_same_file_returns_empty_created(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        admin = self._make_admin(member_repo)
+
+        csv_bytes = self._csv_bytes(
+            ["10,García,Ana,,600111222,ana@test.com,,5/02/2022,Femenino"]
+        )
+        first = self._post_import(client, admin, csv_bytes)
+        assert first.status_code == 200
+        assert len(first.json()["created"]) == 1
+
+        second = self._post_import(client, admin, csv_bytes)
+
+        assert second.status_code == 200
+        assert second.json() == {"created": [], "total_rows": 1, "skipped_rows": 0}
+        # Upsert: no duplicate member created (admin + Ana only)
+        assert len(member_repo.list_all()) == 2
+        conn.close()
+
+    def test_blank_email_rows_counted_as_skipped(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        admin = self._make_admin(member_repo)
+
+        csv_bytes = self._csv_bytes(
+            [
+                "10,García,Ana,,600111222,ana@test.com,,,",
+                "11,Sin,Email,,600333444,,,,",
+            ]
+        )
+        response = self._post_import(client, admin, csv_bytes)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_rows"] == 2
+        assert body["skipped_rows"] == 1
+        assert len(body["created"]) == 1
+        assert body["created"][0]["email"] == "ana@test.com"
+        conn.close()
+
+    def test_missing_email_header_returns_400(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        admin = self._make_admin(member_repo)
+
+        csv_bytes = b"Nombre,Apellidos\nAna,Garc\xc3\xada\n"
+        response = self._post_import(client, admin, csv_bytes)
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": "El archivo CSV debe tener una columna 'Email'."
+        }
+        conn.close()
+
+    def test_import_requires_admin(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        regular = _make_member(
+            member_repo,
+            number=1,
+            first_name="Regular",
+            last_name="User",
+            email="regular@test.com",
+            is_admin=False,
+        )
+
+        csv_bytes = self._csv_bytes(["10,García,Ana,,600111222,ana@test.com,,,"])
+        response = client.post(
+            "/api/admin/members/import",
+            files={"file": ("members.csv", csv_bytes, "text/csv")},
+            headers=_auth_cookie(regular),
+        )
+
+        assert response.status_code == 403
+        conn.close()
+
+
 @pytest.mark.parametrize(
     ("gender", "expected_label"),
     [

--- a/tests/cli/test_import_members.py
+++ b/tests/cli/test_import_members.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from typer.testing import CliRunner
 
 from backend.cli.main import app
@@ -10,54 +9,54 @@ from backend.data.repositories.sqlite_member_repository import SqliteMemberRepos
 
 runner = CliRunner()
 
-_CSV_FILE = Path(__file__).resolve().parent.parent.parent / "members.csv"
-CSV_PATH = str(_CSV_FILE)
+_CSV_CONTENT = """\
+Nº Socio,Apellidos,Nombre,Apodo,Telefóno,Email,admin,Última cuota,Género
+1,Adell,Miquel,Miquel,600 00 00 01,admin@test.local,yes,24/01/2026,Masculino
+2,García López,Carla,Carla,600 00 00 02,carla@test.local,,24/01/2026,Femenino
+3,Torres Ruiz,Jorge,,600 00 00 03,,,24/01/2026,Masculino
+"""
 
 
-@pytest.mark.skipif(
-    not _CSV_FILE.exists(),
-    reason="members.csv not present (local-only fixture)",
-)
 def test_import_members_csv(monkeypatch: object, tmp_path: Path) -> None:
-    """Import the actual members.csv and verify correct count and admin flag."""
+    """Import a sample CSV and verify count, admin flag, and email-less skip."""
     import backend.cli.main as cli_module
     from backend.config import Settings
 
     db_path = str(tmp_path / "test.db")
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(_CSV_CONTENT, encoding="utf-8")
 
-    # Patch settings to use temp DB
     monkeypatch.setattr(  # type: ignore[attr-defined]
         cli_module,
         "_get_settings",
         lambda: Settings(db_path=db_path, base_url="http://test.local"),
     )
 
-    result = runner.invoke(app, ["import-members", CSV_PATH])
+    result = runner.invoke(app, ["import-members", str(csv_path)])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
 
-    # Verify the correct number of members were imported
-    # The CSV has 40 rows, but Jorge Torres Ruiz (row 74) has no email => 39 members
     from backend.data.database import get_connection
 
     conn = get_connection(db_path)
     try:
         member_repo = SqliteMemberRepository(conn)
         members = member_repo.list_all()
-        assert len(members) == 39
+        # 3 rows, but Jorge Torres Ruiz has no email => 2 members
+        assert len(members) == 2
 
-        # Verify Miquel Adell is admin
-        miquel = member_repo.get_by_email("miquel.adell@gmail.com")
-        assert miquel is not None
-        assert miquel.is_admin is True
+        admin = member_repo.get_by_email("admin@test.local")
+        assert admin is not None
+        assert admin.is_admin is True
+        assert admin.last_payment == "24/01/2026"
+        assert admin.gender == "Masculino"
 
-        # Verify a non-admin member
-        carles = member_repo.get_by_email("hothgond@gmail.com")
-        assert carles is not None
-        assert carles.is_admin is False
+        carla = member_repo.get_by_email("carla@test.local")
+        assert carla is not None
+        assert carla.is_admin is False
     finally:
         conn.close()
 
     # Output should contain one-time URLs
     assert "set-password?token=" in result.output
-    assert "39 new member(s) imported" in result.output
+    assert "2 new member(s) imported" in result.output

--- a/tests/scraper/test_enumerator.py
+++ b/tests/scraper/test_enumerator.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import pytest
 
 from scraper.config import SKIP_PATHS, ScraperConfig
-from scraper.enumerator import DiscoveredPage, EnumerationResult, enumerate_pages
+from scraper.enumerator import DiscoveredPage, enumerate_pages
 from scraper.fetcher import FetchResult
 
 # ---------------------------------------------------------------------------

--- a/tests/scraper/test_nav_extractor.py
+++ b/tests/scraper/test_nav_extractor.py
@@ -216,7 +216,10 @@ class TestRealMirror:
                 href="/juegos-de-rol",
                 children=(
                     NavItem(label="Campañas", href="/juegos-de-rol/campanas"),
-                    NavItem(label="Oneshots", href="/juegos-de-rol/oneshots"),
+                    NavItem(
+                        label="Oneshot y Aventuras",
+                        href="/juegos-de-rol/oneshot-y-aventuras",
+                    ),
                 ),
             ),
             NavItem(

--- a/uv.lock
+++ b/uv.lock
@@ -768,6 +768,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -844,7 +853,7 @@ wheels = [
 
 [[package]]
 name = "refugio-del-satiro"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -854,6 +863,7 @@ dependencies = [
     { name = "lxml" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -872,7 +882,7 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=4.1" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "lxml", specifier = ">=5.0" },
@@ -882,6 +892,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },


### PR DESCRIPTION
Closes #95

Adds an admin-only CSV import to the web app, so members can be bulk-imported in production where the CLI + local `members.csv` aren't available.

- Backend: `POST /api/admin/members/import` (multipart upload) reusing `ImportMembersUseCase` — same upsert-by-email semantics as the CLI, returns access links for new members only. Adds `python-multipart`.
- Frontend: "Importar CSV" button on the members admin page, with a results banner listing each new member's copyable set-password link and a skipped-rows summary.
- Tests: 5 new API tests (import, idempotent re-import, blank-email skip, missing header 400, non-admin 403). Also fixes two stale tests that were failing before this branch: the CLI import test now uses a synthetic CSV instead of the live git-ignored `members.csv`, and the nav-extractor mirror expectation picks up the "Oneshot y Aventuras" rename.

Full suite: 273 passed. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lche6ijqPzSL9PrRgjX2Y9