### PR TITLE
docs: correct stale Catalan-only UI language claims

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -105,7 +105,7 @@ context: |
   - Due dates, overdue tracking, or reminders
   - Reservation or waitlist system
   - Email notifications
-  - i18n infrastructure (UI is Catalan-only in V1)
+  - i18n infrastructure (UI is Spanish-only in V1)
   - Pagination (collection is small enough to load at once)
   - CSS-in-JS or UI component framework (plain CSS with design tokens)
 

--- a/tasks/future-ideas.md
+++ b/tasks/future-ideas.md
@@ -12,9 +12,8 @@ Import association members from a Google Spreadsheet via the Google Sheets API (
 
 Previously tracked as US-003 in the PRD before being deferred.
 
-## UI translations (Spanish and English)
-V1 UI is in Catalan only. Add i18n infrastructure and translations for:
-- Spanish (Castilian) — most members likely speak it
+## UI translations (English)
+V1 UI is in Spanish only. Add i18n infrastructure and a translation for:
 - English — for broader accessibility
 
 Requires choosing an i18n library (e.g., react-i18next), extracting all UI strings, and providing translation files.

--- a/tasks/lending-redesign/current-state.md
+++ b/tasks/lending-redesign/current-state.md
@@ -67,7 +67,6 @@ All routes mounted at `/prestamos` via React Router basename.
 | FilterControl | [components/FilterControl.tsx](../../frontend/src/components/FilterControl.tsx) | Toggle buttons for availability filter |
 | ConfirmDialog | [components/ConfirmDialog.tsx](../../frontend/src/components/ConfirmDialog.tsx) | Modal for borrow/return/delete confirmations; keyboard trap, focus mgmt |
 | LoanHistoryEntry | [components/LoanHistoryEntry.tsx](../../frontend/src/components/LoanHistoryEntry.tsx) | Single loan history row (member, dates) |
-| LanguageSelector | [components/LanguageSelector.tsx](../../frontend/src/components/LanguageSelector.tsx) | Inline language switcher (Catalan/Spanish/English) |
 
 ## 4. Styling Approach
 

--- a/tasks/lending-redesign/style-guide.md
+++ b/tasks/lending-redesign/style-guide.md
@@ -874,11 +874,12 @@ before the frontend team starts coding.
    typography of the main portal"~~ **Resolved 2026-04-21**:
    production uses Oswald for headings and Open Sans for body. Plan
    to self-host both under `frontend/public/fonts/` for GDPR.
-3. **Language.** The prototype is in Spanish (`Solicitar préstamo`,
+3. **Language.** ~~The prototype is in Spanish (`Solicitar préstamo`,
    `Catálogo`, etc.). The club is in Sabadell and the thesis itself is
-   in Catalan. Decide whether to ship ES only, or a CA/ES switcher.
-   The BGG→ES translation is already planned via LibreTranslate; a
-   Catalan variant would be additional scope.
+   in Catalan. Decide whether to ship ES only, or a CA/ES switcher.~~
+   **Resolved (see decisions.md, Decision 2)**: ship Spanish only for
+   v1. The BGG→ES translation is planned via LibreTranslate; a Catalan
+   variant would be additional scope if member demand appears.
 4. **Authentication.** Thesis §3.4.3 explicitly *defers* authentication
    design to a future iteration. There are three plausible options:
    username/password stored in PythonAnywhere, Google OAuth (but some

--- a/tasks/prd-refugio-del-satiro.md
+++ b/tasks/prd-refugio-del-satiro.md
@@ -142,7 +142,7 @@ Préstecs Sàtirs is a web application for the "Refugio del Sátiro" RPG associa
 - [ ] Non-admin users redirected away from `/admin/*` routes
 - [ ] Disabled members cannot log in (auth rejects them)
 - [ ] Admins can re-enable disabled members
-- [ ] All UI text in Catalan
+- [ ] All UI text in Spanish
 - [ ] Typecheck/lint passes
 - [ ] Verify in browser using dev-browser skill
 
@@ -153,7 +153,7 @@ Préstecs Sàtirs is a web application for the "Refugio del Sátiro" RPG associa
 - [ ] Admin clicks "Send access link" for a member
 - [ ] System generates a new password token (48h expiry)
 - [ ] Email sent via configured SMTP with the one-time URL
-- [ ] Email body is in Catalan, simple HTML template
+- [ ] Email body is in Spanish, simple HTML template
 - [ ] If SMTP is not configured, the URL is returned in the API response for manual sharing
 - [ ] Typecheck/lint passes
 
@@ -191,7 +191,7 @@ Préstecs Sàtirs is a web application for the "Refugio del Sátiro" RPG associa
 - No self-registration (admin creates members)
 - No game ratings or reviews
 - No mobile-specific app (responsive web only)
-- No internationalization infrastructure in V1 — UI is in Catalan only (Spanish and English translations are a future idea)
+- No internationalization infrastructure in V1 — UI is in Spanish only (English translation is a future idea)
 - No pagination (collection is small enough to load at once)
 
 ## Design Considerations
@@ -201,7 +201,7 @@ Préstecs Sàtirs is a web application for the "Refugio del Sátiro" RPG associa
 - Clear visual distinction between available and lent-out games
 - Responsive layout that works on phones (members may check at game nights)
 - Borrow and return actions require a confirmation dialog
-- UI language: Catalan
+- UI language: Spanish
 
 ## Technical Considerations
 
@@ -250,7 +250,7 @@ Préstecs Sàtirs is a web application for the "Refugio del Sátiro" RPG associa
 - **Catalog access:** Visible to unauthenticated users (browse-only)
 - **Search:** Client-side debounced filter, all games loaded at once
 - **Borrow/Return:** Confirmation dialog before action
-- **UI language:** Catalan (Spanish and English translations deferred)
+- **UI language:** Spanish (English translation deferred)
 - **API base URL:** `VITE_API_URL` env var, default `/api`
 - **Deployment:** Oracle Cloud Free Tier
 - **Deadline:** None


### PR DESCRIPTION
## Summary
- The shipped UI (`frontend/src`) is already fully Spanish — no live Catalan strings were found anywhere in the app after a repo-wide search, so no pages needed translating.
- Several planning docs (`openspec/config.yaml`, `tasks/prd-refugio-del-satiro.md`, `tasks/future-ideas.md`, `tasks/lending-redesign/style-guide.md`, `tasks/lending-redesign/current-state.md`) still stated or implied "UI is Catalan-only," contradicting the actual shipped Spanish-only decision recorded in `tasks/lending-redesign/decisions.md`. Updated all of them to reflect the current state.
- Removed a dangling reference to a `LanguageSelector` component in `current-state.md` — the component was never built (confirmed via file search and the `SiteFooter` test asserting no language selector renders).
- Left historical/archived docs (`openspec/changes/archive/**`), the decision log itself, and source-material quotes (TFM/Figma mockup text) untouched, since those correctly describe history rather than current state.

No issue link per repo convention — Miquel explicitly said no GitHub issue is needed for this task.

## Test plan
- [x] Repo-wide grep for Catalan-specific words/diacritics across all tracked file types (excluding `node_modules`, `.git`, `openspec/changes/archive`) — only source-material quotes remain, no live app or doc claims left.
- [x] Confirmed `frontend/public/content-mirror/` (scraped Google Sites content) is gitignored and not part of the repo's translatable source.
- N/A no runtime/UI change — docs only, no smoke test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134tywDLfsPk9Zs9XRWn3mk