### PR TITLE
feat(bgg): treat BGG as source of truth on re-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Stop with `docker compose down` (volumes survive) or `docker compose down -v`
 
 ```bash
 refugio migrate                          # Run migrations
-refugio import-games data/bgg_collection.json  # Import board games from JSON
-refugio import-games                     # Import board games from BGG API (requires BGG_BEARER_TOKEN)
-refugio import-rol                       # Import RPG items (libros de rol) from BGG API
+refugio import-games data/bgg_collection.json  # Import board games from JSON (no reconciliation)
+refugio import-games                     # Import board games from BGG API — BGG is the source of truth (requires BGG_BEARER_TOKEN)
+refugio import-rol                       # Import RPG items (libros de rol) from BGG API — same reconciliation
 refugio import-members members.csv       # Import members from CSV
 refugio import-members --email x@y.com --name "First Last"  # Add a single member
 
@@ -180,6 +180,18 @@ page under `/ludoteca/admin/bgg` shows the last import date and has a
 "Reimportar desde BGG" button, so this no longer requires shell access to
 the server. It runs the same BGG-API-first, HTML-scrape-fallback import as
 the CLI command above.
+
+Re-importing from the BGG API (`import-games` and `import-rol`, but not the
+JSON-seed form) treats BGG as the source of truth: an item that has
+disappeared from the club's BGG collection is removed. If it's not
+currently on loan, it's hard-deleted; if it is, it's hidden from the
+catalog (but its loan can still be returned normally) and gets deleted on
+a later import once returned — unless it has past loan history, in which
+case it stays hidden indefinitely rather than losing that history. As a
+safety guard, if the BGG fetch comes back empty or would newly remove more
+than 50% of the current active catalog, that run skips removing
+newly-missing items (still applying updates and cleaning up already-hidden
+ones) and reports a warning instead.
 
 ## Tests
 

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -89,7 +89,9 @@ def get_game_history_use_case(
     loan_repo: LoanRepo,
     member_repo: MemberRepo,
 ) -> GetGameHistoryUseCase:
-    return GetGameHistoryUseCase(game_repo, loan_repo, member_repo)
+    return GetGameHistoryUseCase(
+        game_repo, loan_repo, member_repo, item_type="boardgame"
+    )
 
 
 def get_list_rpg_items_use_case(
@@ -113,7 +115,7 @@ def get_rpg_item_history_use_case(
     loan_repo: LoanRepo,
     member_repo: MemberRepo,
 ) -> GetGameHistoryUseCase:
-    return GetGameHistoryUseCase(game_repo, loan_repo, member_repo)
+    return GetGameHistoryUseCase(game_repo, loan_repo, member_repo, item_type="rpgitem")
 
 
 def get_authenticate_use_case(member_repo: MemberRepo) -> AuthenticateUseCase:

--- a/backend/api/routes/bgg.py
+++ b/backend/api/routes/bgg.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
-from backend.api.dependencies import CurrentMember, GameRepo, _settings
+from backend.api.dependencies import CurrentMember, GameRepo, LoanRepo, _settings
 from backend.data.bgg_client import BggClient
 from backend.domain.entities.member import Member
 from backend.domain.use_cases.import_games import ImportGamesUseCase
@@ -36,6 +36,9 @@ class BggImportResponse(BaseModel):
     created: int
     updated: int
     total: int
+    deleted: int
+    deactivated: int
+    skip_reason: str | None
     last_imported_at: datetime | None
 
 
@@ -45,15 +48,20 @@ def get_status(_admin: AdminMember, game_repo: GameRepo) -> BggStatusResponse:
 
 
 @router.post("/import", response_model=BggImportResponse)
-def import_games(_admin: AdminMember, game_repo: GameRepo) -> BggImportResponse:
+def import_games(
+    _admin: AdminMember, game_repo: GameRepo, loan_repo: LoanRepo
+) -> BggImportResponse:
     bgg_client = BggClient(
         username="RefugioDelSatiro", bearer_token=_settings.bgg_bearer_token
     )
-    use_case = ImportGamesUseCase(game_repo, bgg_client)
+    use_case = ImportGamesUseCase(game_repo, bgg_client, loan_repo)
     result = use_case.execute()
     return BggImportResponse(
         created=result.created,
         updated=result.updated,
         total=result.total,
+        deleted=result.deleted,
+        deactivated=result.deactivated,
+        skip_reason=result.skip_reason,
         last_imported_at=game_repo.get_last_updated_at(),
     )

--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -91,15 +91,11 @@ def get_game(
 @router.get("/{slug}/history", response_model=list[LoanHistoryEntryResponse])
 def get_game_history(
     slug: str,
-    game_use_case: Annotated[GetGameUseCase, Depends(get_game_use_case)],
-    history_use_case: Annotated[GetGameHistoryUseCase, Depends(get_game_history_use_case)],
+    history_use_case: Annotated[
+        GetGameHistoryUseCase, Depends(get_game_history_use_case)
+    ],
     member: OptionalMember,
 ) -> list[LoanHistoryEntryResponse]:
-    # Guard: history is only exposed for boardgames via this endpoint.
-    if game_use_case.execute(slug) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Juego no encontrado."
-        )
     entries = history_use_case.execute(slug)
     if entries is None:
         raise HTTPException(

--- a/backend/api/routes/rpg_items.py
+++ b/backend/api/routes/rpg_items.py
@@ -60,7 +60,10 @@ def list_rpg_items(
     member: OptionalMember,
 ) -> list[RpgItemResponse]:
     is_authenticated = member is not None
-    return [_to_response(item, is_authenticated=is_authenticated) for item in use_case.execute()]
+    return [
+        _to_response(item, is_authenticated=is_authenticated)
+        for item in use_case.execute()
+    ]
 
 
 @router.get("/{slug}/history", response_model=list[LoanHistoryEntryResponse])

--- a/backend/cli/main.py
+++ b/backend/cli/main.py
@@ -54,6 +54,7 @@ def import_games(
     import json
 
     from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
+    from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
     from backend.domain.use_cases.import_games import ImportGamesUseCase
 
     settings = _get_settings()
@@ -63,7 +64,10 @@ def import_games(
         game_repo = SqliteGameRepository(conn)
 
         if json_file:
-            # Import from JSON seed file
+            # Import from JSON seed file. No reconciliation here: seed files
+            # are partial/test fixtures, not full collection dumps, so
+            # diffing against them would wrongly delete/deactivate the real
+            # catalog.
             path = Path(json_file)
             if not path.exists():
                 typer.echo(f"Error: file not found: {json_file}", err=True)
@@ -122,13 +126,18 @@ def import_games(
             bgg_client = BggClient(
                 username="RefugioDelSatiro", bearer_token=settings.bgg_bearer_token
             )
-            use_case = ImportGamesUseCase(game_repo, bgg_client)
+            loan_repo = SqliteLoanRepository(conn)
+            use_case = ImportGamesUseCase(game_repo, bgg_client, loan_repo)
 
             typer.echo("Fetching games from BGG (this may take a moment)...")
             result = use_case.execute()
             typer.echo(
-                f"Done. {result.created} new, {result.updated} updated, {result.total} total."
+                f"Done. {result.created} new, {result.updated} updated, "
+                f"{result.deleted} deleted, {result.deactivated} deactivated "
+                f"(on loan), {result.total} total."
             )
+            if result.skip_reason:
+                typer.echo(f"Warning: {result.skip_reason}", err=True)
     finally:
         conn.close()
 
@@ -181,6 +190,7 @@ def import_rol() -> None:
     """Import RPG items (libros de rol) from BGG API."""
     from backend.data.bgg_client import BggClient
     from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
+    from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
     from backend.domain.use_cases.import_rpg_items import ImportRpgItemsUseCase
 
     settings = _get_settings()
@@ -199,13 +209,18 @@ def import_rol() -> None:
         bgg_client = BggClient(
             username="RefugioDelSatiro", bearer_token=settings.bgg_bearer_token
         )
-        use_case = ImportRpgItemsUseCase(game_repo, bgg_client)
+        loan_repo = SqliteLoanRepository(conn)
+        use_case = ImportRpgItemsUseCase(game_repo, bgg_client, loan_repo)
 
         typer.echo("Fetching RPG items from BGG (this may take a moment)...")
         result = use_case.execute()
         typer.echo(
-            f"Done. {result.created} new, {result.updated} updated, {result.total} total."
+            f"Done. {result.created} new, {result.updated} updated, "
+            f"{result.deleted} deleted, {result.deactivated} deactivated "
+            f"(on loan), {result.total} total."
         )
+        if result.skip_reason:
+            typer.echo(f"Warning: {result.skip_reason}", err=True)
     finally:
         conn.close()
 

--- a/backend/data/repositories/sqlite_game_repository.py
+++ b/backend/data/repositories/sqlite_game_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Collection
 from datetime import UTC, datetime
 
 from backend.domain.entities.game import Game
@@ -26,6 +27,7 @@ def _row_to_game(row: sqlite3.Row) -> Game:
         updated_at=datetime.fromisoformat(row["updated_at"]),
         item_type=row["item_type"] if "item_type" in keys else "boardgame",
         description=row["description"] if "description" in keys else "",
+        is_active=bool(row["is_active"]) if "is_active" in keys else True,
     )
 
 
@@ -57,9 +59,46 @@ class SqliteGameRepository:
 
     def list_by_type(self, item_type: str) -> list[Game]:
         rows = self._conn.execute(
+            "SELECT * FROM games WHERE item_type = ? AND is_active = 1 ORDER BY name",
+            (item_type,),
+        ).fetchall()
+        return [_row_to_game(row) for row in rows]
+
+    def list_by_type_including_inactive(self, item_type: str) -> list[Game]:
+        rows = self._conn.execute(
             "SELECT * FROM games WHERE item_type = ? ORDER BY name", (item_type,)
         ).fetchall()
         return [_row_to_game(row) for row in rows]
+
+    def deactivate_by_bgg_ids(self, bgg_ids: Collection[int]) -> int:
+        if not bgg_ids:
+            return 0
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        placeholders = ",".join("?" for _ in bgg_ids)
+        cursor = self._conn.execute(
+            f"UPDATE games SET is_active = 0, updated_at = ? "
+            f"WHERE bgg_id IN ({placeholders}) AND is_active = 1",
+            (now, *bgg_ids),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def delete_by_bgg_ids(
+        self, bgg_ids: Collection[int]
+    ) -> tuple[frozenset[int], frozenset[int]]:
+        deleted: set[int] = set()
+        blocked: set[int] = set()
+        for bgg_id in bgg_ids:
+            try:
+                cursor = self._conn.execute(
+                    "DELETE FROM games WHERE bgg_id = ?", (bgg_id,)
+                )
+                self._conn.commit()
+                if cursor.rowcount:
+                    deleted.add(bgg_id)
+            except sqlite3.IntegrityError:
+                blocked.add(bgg_id)
+        return frozenset(deleted), frozenset(blocked)
 
     def get_last_updated_at(self) -> datetime | None:
         row = self._conn.execute("SELECT MAX(updated_at) AS last FROM games").fetchone()
@@ -98,9 +137,9 @@ class SqliteGameRepository:
             INSERT INTO games (
                 bgg_id, name, slug, thumbnail_url, image_url, year_published,
                 min_players, max_players, playing_time, bgg_rating, location,
-                item_type, description, created_at, updated_at
+                item_type, description, is_active, created_at, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
             ON CONFLICT(bgg_id) DO UPDATE SET
                 name = excluded.name,
                 slug = excluded.slug,
@@ -114,6 +153,7 @@ class SqliteGameRepository:
                 location = excluded.location,
                 item_type = excluded.item_type,
                 description = excluded.description,
+                is_active = 1,
                 updated_at = ?
             """,
             (

--- a/backend/domain/entities/game.py
+++ b/backend/domain/entities/game.py
@@ -22,3 +22,4 @@ class Game:
     updated_at: datetime
     item_type: str = field(default="boardgame")
     description: str = field(default="")
+    is_active: bool = field(default=True)

--- a/backend/domain/repositories/game_repository.py
+++ b/backend/domain/repositories/game_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from datetime import datetime
 from typing import Protocol
 
@@ -15,7 +16,18 @@ class GameRepository(Protocol):
 
     def list_all(self) -> list[Game]: ...
 
-    def list_by_type(self, item_type: str) -> list[Game]: ...
+    def list_by_type(self, item_type: str) -> list[Game]: ...  # active items only
+
+    def list_by_type_including_inactive(self, item_type: str) -> list[Game]: ...
+
+    # active and inactive (soft-deleted) items — used by BGG reconciliation,
+    # which must see previously soft-deleted rows too
+
+    def deactivate_by_bgg_ids(self, bgg_ids: Collection[int]) -> int: ...
+
+    def delete_by_bgg_ids(
+        self, bgg_ids: Collection[int]
+    ) -> tuple[frozenset[int], frozenset[int]]: ...  # (deleted, blocked_by_history)
 
     def get_last_updated_at(self) -> datetime | None: ...
 

--- a/backend/domain/use_cases/bgg_reconciliation.py
+++ b/backend/domain/use_cases/bgg_reconciliation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEACTIVATION_GUARD_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class ReconciliationOutcome:
+    missing_bgg_ids: frozenset[int]
+    skip_reason: str | None
+
+
+def compute_reconciliation(
+    existing_active_bgg_ids: frozenset[int],
+    fetched_bgg_ids: frozenset[int],
+    item_type: str,
+) -> ReconciliationOutcome:
+    if not fetched_bgg_ids:
+        return ReconciliationOutcome(
+            missing_bgg_ids=frozenset(),
+            skip_reason=(
+                f"BGG fetch for '{item_type}' returned no items; "
+                "skipping removal of newly-missing items"
+            ),
+        )
+
+    missing = existing_active_bgg_ids - fetched_bgg_ids
+    if existing_active_bgg_ids and (
+        len(missing) / len(existing_active_bgg_ids) > DEACTIVATION_GUARD_RATIO
+    ):
+        return ReconciliationOutcome(
+            missing_bgg_ids=frozenset(),
+            skip_reason=(
+                f"{len(missing)} of {len(existing_active_bgg_ids)} active "
+                f"'{item_type}' items are missing from the BGG fetch "
+                f"(> {DEACTIVATION_GUARD_RATIO:.0%}); skipping removal of "
+                "newly-missing items"
+            ),
+        )
+
+    return ReconciliationOutcome(missing_bgg_ids=missing, skip_reason=None)

--- a/backend/domain/use_cases/borrow_game.py
+++ b/backend/domain/use_cases/borrow_game.py
@@ -20,7 +20,7 @@ class BorrowGameUseCase:
 
     def execute(self, game_id: int, member_id: int) -> Loan:
         game = self._game_repo.get_by_id(game_id)
-        if game is None:
+        if game is None or not game.is_active:
             raise BorrowGameError("Juego no encontrado.")
 
         active_loan = self._loan_repo.get_active_by_game_id(game_id)

--- a/backend/domain/use_cases/get_game.py
+++ b/backend/domain/use_cases/get_game.py
@@ -19,6 +19,6 @@ class GetGameUseCase:
 
     def execute(self, slug: str) -> GameWithStatus | None:
         game = self._game_repo.get_by_slug(slug)
-        if game is None or game.item_type != "boardgame":
+        if game is None or game.item_type != "boardgame" or not game.is_active:
             return None
         return build_game_with_status(game, self._loan_repo, self._member_repo)

--- a/backend/domain/use_cases/get_game_history.py
+++ b/backend/domain/use_cases/get_game_history.py
@@ -21,19 +21,25 @@ class GetGameHistoryUseCase:
         game_repo: GameRepository,
         loan_repo: LoanRepository,
         member_repo: MemberRepository,
+        item_type: str | None = None,
     ) -> None:
         self._game_repo = game_repo
         self._loan_repo = loan_repo
         self._member_repo = member_repo
+        self._item_type = item_type
 
     def execute(self, slug: str) -> list[LoanHistoryEntry] | None:
         """Return loan history for the game identified by ``slug``.
 
         Returns ``None`` when no game matches the slug, so the caller can
         distinguish "no such game" (404) from "game has no history" ([]).
+        Deliberately ignores ``is_active`` — loan history for a removed game
+        must stay reachable.
         """
         game = self._game_repo.get_by_slug(slug)
         if game is None:
+            return None
+        if self._item_type is not None and game.item_type != self._item_type:
             return None
         loans = self._loan_repo.list_by_game_id(game.id)
         return [

--- a/backend/domain/use_cases/get_rpg_item.py
+++ b/backend/domain/use_cases/get_rpg_item.py
@@ -22,6 +22,6 @@ class GetRpgItemUseCase:
 
     def execute(self, slug: str) -> RpgItemWithStatus | None:
         game = self._game_repo.get_by_slug(slug)
-        if game is None or game.item_type != "rpgitem":
+        if game is None or game.item_type != "rpgitem" or not game.is_active:
             return None
         return build_rpg_with_status(game, self._loan_repo, self._member_repo)

--- a/backend/domain/use_cases/import_games.py
+++ b/backend/domain/use_cases/import_games.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 
 from backend.data.bgg_client import BggClient
 from backend.domain.repositories.game_repository import GameRepository
+from backend.domain.repositories.loan_repository import LoanRepository
+from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
+
+ITEM_TYPE = "boardgame"
 
 
 @dataclass(frozen=True)
@@ -11,6 +15,9 @@ class ImportResult:
     created: int
     updated: int
     total: int
+    deactivated: int
+    deleted: int
+    skip_reason: str | None = None
 
 
 class ImportGamesUseCase:
@@ -18,15 +25,21 @@ class ImportGamesUseCase:
         self,
         game_repo: GameRepository,
         bgg_client: BggClient,
+        loan_repo: LoanRepository,
     ) -> None:
         self._game_repo = game_repo
         self._bgg_client = bgg_client
+        self._loan_repo = loan_repo
 
     def execute(self) -> ImportResult:
+        all_local_items = self._game_repo.list_by_type_including_inactive(ITEM_TYPE)
+        active_bgg_ids = frozenset(g.bgg_id for g in all_local_items if g.is_active)
+
         bgg_games = self._bgg_client.fetch_owned_games()
+        fetched_bgg_ids = frozenset(g.bgg_id for g in bgg_games)
+
         created = 0
         updated = 0
-
         for bgg_game in bgg_games:
             existing = self._game_repo.get_by_bgg_id(bgg_game.bgg_id)
             self._game_repo.upsert_by_bgg_id(
@@ -41,8 +54,37 @@ class ImportGamesUseCase:
             else:
                 updated += 1
 
+        outcome = compute_reconciliation(active_bgg_ids, fetched_bgg_ids, ITEM_TYPE)
+
+        # Previously soft-deleted items are re-evaluated every run, independent
+        # of the guard above — they're already hidden, so there's no new risk.
+        stale_inactive_ids = frozenset(
+            g.bgg_id
+            for g in all_local_items
+            if not g.is_active and g.bgg_id not in fetched_bgg_ids
+        )
+        removal_candidates = outcome.missing_bgg_ids | stale_inactive_ids
+
+        lent_ids = frozenset(
+            bgg_id
+            for bgg_id in removal_candidates
+            if (game := self._game_repo.get_by_bgg_id(bgg_id)) is not None
+            and self._loan_repo.get_active_by_game_id(game.id) is not None
+        )
+        unlent_ids = removal_candidates - lent_ids
+
+        newly_deactivated = self._game_repo.deactivate_by_bgg_ids(lent_ids)
+        deleted_ids, blocked_ids = self._game_repo.delete_by_bgg_ids(unlent_ids)
+        if blocked_ids:
+            # Has loan history (FK RESTRICT) but isn't lent right now — keep it
+            # hidden since it can't be physically removed.
+            self._game_repo.deactivate_by_bgg_ids(blocked_ids)
+
         return ImportResult(
             created=created,
             updated=updated,
             total=len(bgg_games),
+            deactivated=newly_deactivated + len(blocked_ids),
+            deleted=len(deleted_ids),
+            skip_reason=outcome.skip_reason,
         )

--- a/backend/domain/use_cases/import_rpg_items.py
+++ b/backend/domain/use_cases/import_rpg_items.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 
 from backend.data.bgg_client import BggClient
 from backend.domain.repositories.game_repository import GameRepository
+from backend.domain.repositories.loan_repository import LoanRepository
+from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
+
+ITEM_TYPE = "rpgitem"
 
 
 @dataclass(frozen=True)
@@ -11,6 +15,9 @@ class ImportRpgResult:
     created: int
     updated: int
     total: int
+    deactivated: int
+    deleted: int
+    skip_reason: str | None = None
 
 
 class ImportRpgItemsUseCase:
@@ -18,15 +25,21 @@ class ImportRpgItemsUseCase:
         self,
         game_repo: GameRepository,
         bgg_client: BggClient,
+        loan_repo: LoanRepository,
     ) -> None:
         self._game_repo = game_repo
         self._bgg_client = bgg_client
+        self._loan_repo = loan_repo
 
     def execute(self) -> ImportRpgResult:
+        all_local_items = self._game_repo.list_by_type_including_inactive(ITEM_TYPE)
+        active_bgg_ids = frozenset(g.bgg_id for g in all_local_items if g.is_active)
+
         rpg_items = self._bgg_client.fetch_owned_rpg_items()
+        fetched_bgg_ids = frozenset(item.bgg_id for item in rpg_items)
+
         created = 0
         updated = 0
-
         for item in rpg_items:
             existing = self._game_repo.get_by_bgg_id(item.bgg_id)
             self._game_repo.upsert_by_bgg_id(
@@ -37,15 +50,44 @@ class ImportRpgItemsUseCase:
                 year_published=item.year_published,
                 bgg_rating=item.bgg_rating,
                 description=item.description,
-                item_type="rpgitem",
+                item_type=ITEM_TYPE,
             )
             if existing is None:
                 created += 1
             else:
                 updated += 1
 
+        outcome = compute_reconciliation(active_bgg_ids, fetched_bgg_ids, ITEM_TYPE)
+
+        # Previously soft-deleted items are re-evaluated every run, independent
+        # of the guard above — they're already hidden, so there's no new risk.
+        stale_inactive_ids = frozenset(
+            g.bgg_id
+            for g in all_local_items
+            if not g.is_active and g.bgg_id not in fetched_bgg_ids
+        )
+        removal_candidates = outcome.missing_bgg_ids | stale_inactive_ids
+
+        lent_ids = frozenset(
+            bgg_id
+            for bgg_id in removal_candidates
+            if (game := self._game_repo.get_by_bgg_id(bgg_id)) is not None
+            and self._loan_repo.get_active_by_game_id(game.id) is not None
+        )
+        unlent_ids = removal_candidates - lent_ids
+
+        newly_deactivated = self._game_repo.deactivate_by_bgg_ids(lent_ids)
+        deleted_ids, blocked_ids = self._game_repo.delete_by_bgg_ids(unlent_ids)
+        if blocked_ids:
+            # Has loan history (FK RESTRICT) but isn't lent right now — keep it
+            # hidden since it can't be physically removed.
+            self._game_repo.deactivate_by_bgg_ids(blocked_ids)
+
         return ImportRpgResult(
             created=created,
             updated=updated,
             total=len(rpg_items),
+            deactivated=newly_deactivated + len(blocked_ids),
+            deleted=len(deleted_ids),
+            skip_reason=outcome.skip_reason,
         )

--- a/backend/migrations/008_add_game_is_active.sql
+++ b/backend/migrations/008_add_game_is_active.sql
@@ -1,0 +1,3 @@
+-- Add is_active column to games table so BGG re-import can soft-delete
+-- items still on loan instead of hard-deleting them
+ALTER TABLE games ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;

--- a/docs/generate_diagrams.py
+++ b/docs/generate_diagrams.py
@@ -992,7 +992,7 @@ def diagram_password_setup() -> None:
     els.append(rect("link-example", 60, y + 150, 700, 35, bg="#f3f0ff", stroke="#6741d9", frame_id=fid,
                      bound=[{"id": "link-example-t", "type": "text"}]))
     els.append(text("link-example-t", 0, 0,
-                     "Output:  Maria (maria@example.com): https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9...",
+                     "Output:  Maria (TEST_email@domain.com): https://refugidelsatiro.cat/prestamos/set-password?token=a3f8c9...",
                      size=13, font=3, container_id="link-example", stroke="#6741d9", frame_id=fid))
 
     # --- Phase 2: How the link reaches the member (two options) ---

--- a/e2e/scripts/seed-auth-states.ts
+++ b/e2e/scripts/seed-auth-states.ts
@@ -42,12 +42,12 @@ interface TestUser {
 const users: ReadonlyArray<TestUser> = [
   {
     role: "member",
-    email: process.env.TEST_MEMBER_EMAIL ?? "e2e-member@test.local",
+    email: process.env.TEST_MEMBER_EMAIL ?? "TEST_email@domain.com",
     password: process.env.TEST_MEMBER_PASSWORD ?? "e2e-test-password-member",
   },
   {
     role: "admin",
-    email: process.env.TEST_ADMIN_EMAIL ?? "e2e-admin@test.local",
+    email: process.env.TEST_ADMIN_EMAIL ?? "TEST_email@domain.com",
     password: process.env.TEST_ADMIN_PASSWORD ?? "e2e-test-password-admin",
   },
 ];

--- a/frontend/src/pages/AdminBggPage.tsx
+++ b/frontend/src/pages/AdminBggPage.tsx
@@ -12,6 +12,9 @@ type BggImportResponse = {
   created: number;
   updated: number;
   total: number;
+  deleted: number;
+  deactivated: number;
+  skip_reason: string | null;
   last_imported_at: string | null;
 };
 
@@ -104,8 +107,14 @@ export function AdminBggPage() {
 
       {result && (
         <p className="admin-bgg-result">
-          {result.created} nuevos, {result.updated} actualizados, {result.total} en total.
+          {result.created} nuevos, {result.updated} actualizados, {result.deleted}{" "}
+          eliminados, {result.deactivated} ocultados (prestados), {result.total} en
+          total.
         </p>
+      )}
+
+      {result?.skip_reason && (
+        <p className="admin-bgg-error">{result.skip_reason}</p>
       )}
     </div>
   );

--- a/scripts/seed_test_users.py
+++ b/scripts/seed_test_users.py
@@ -9,9 +9,9 @@ Usage:
     python scripts/seed_test_users.py
 
 Env vars:
-    TEST_MEMBER_EMAIL    (default: e2e-member@test.local)
+    TEST_MEMBER_EMAIL    (default: TEST_email@domain.com)
     TEST_MEMBER_PASSWORD (default: e2e-test-password-member)
-    TEST_ADMIN_EMAIL     (default: e2e-admin@test.local)
+    TEST_ADMIN_EMAIL     (default: TEST_email@domain.com)
     TEST_ADMIN_PASSWORD  (default: e2e-test-password-admin)
     REFUGIO_DB_PATH      (resolved via backend.config.Settings)
 """
@@ -53,7 +53,7 @@ def _accounts_from_env() -> list[TestAccount]:
     return [
         TestAccount(
             label="TEST_MEMBER",
-            email=os.environ.get("TEST_MEMBER_EMAIL", "e2e-member@test.local"),
+            email=os.environ.get("TEST_MEMBER_EMAIL", "TEST_email@domain.com"),
             password=os.environ.get("TEST_MEMBER_PASSWORD", "e2e-test-password-member"),
             first_name="E2E",
             last_name="Member",
@@ -64,7 +64,7 @@ def _accounts_from_env() -> list[TestAccount]:
         ),
         TestAccount(
             label="TEST_ADMIN",
-            email=os.environ.get("TEST_ADMIN_EMAIL", "e2e-admin@test.local"),
+            email=os.environ.get("TEST_ADMIN_EMAIL", "TEST_email@domain.com"),
             password=os.environ.get("TEST_ADMIN_PASSWORD", "e2e-test-password-admin"),
             first_name="E2E",
             last_name="Admin",

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -35,15 +35,15 @@ class TestLogin:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(
-            member_repo.get_by_email("test@test.com").id,  # type: ignore[union-attr]
+            member_repo.get_by_email("TEST_email@domain.com").id,  # type: ignore[union-attr]
             hash_password("mypassword"),
         )
 
         response = client.post(
-            "/api/login", json={"email": "test@test.com", "password": "mypassword"}
+            "/api/login", json={"email": "TEST_email@domain.com", "password": "mypassword"}
         )
         assert response.status_code == 200
         assert response.json() == {"ok": True}
@@ -53,22 +53,22 @@ class TestLogin:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(
-            member_repo.get_by_email("test@test.com").id,  # type: ignore[union-attr]
+            member_repo.get_by_email("TEST_email@domain.com").id,  # type: ignore[union-attr]
             hash_password("mypassword"),
         )
 
         response = client.post(
-            "/api/login", json={"email": "test@test.com", "password": "wrong"}
+            "/api/login", json={"email": "TEST_email@domain.com", "password": "wrong"}
         )
         assert response.status_code == 401
 
     def test_login_nonexistent_email(self) -> None:
         client, _ = _setup_test_client()
         response = client.post(
-            "/api/login", json={"email": "nobody@test.com", "password": "test"}
+            "/api/login", json={"email": "TEST_email@domain.com", "password": "test"}
         )
         assert response.status_code == 401
 
@@ -76,11 +76,11 @@ class TestLogin:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
 
         response = client.post(
-            "/api/login", json={"email": "test@test.com", "password": "anything"}
+            "/api/login", json={"email": "TEST_email@domain.com", "password": "anything"}
         )
         assert response.status_code == 401
 
@@ -98,10 +98,10 @@ class TestGetMe:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", True
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", True
         )
         member_repo.set_password_hash(
-            member_repo.get_by_email("test@test.com").id,  # type: ignore[union-attr]
+            member_repo.get_by_email("TEST_email@domain.com").id,  # type: ignore[union-attr]
             hash_password("mypassword"),
         )
 
@@ -109,7 +109,7 @@ class TestGetMe:
         from backend.api.auth import create_jwt
         from backend.api.dependencies import _settings
 
-        member = member_repo.get_by_email("test@test.com")
+        member = member_repo.get_by_email("TEST_email@domain.com")
         assert member is not None
         token = create_jwt(member.id, _settings.jwt_secret)
 
@@ -117,7 +117,7 @@ class TestGetMe:
         assert response.status_code == 200
         data = response.json()
         assert data["display_name"] == "Test User"
-        assert data["email"] == "test@test.com"
+        assert data["email"] == "TEST_email@domain.com"
         assert data["is_admin"] is True
 
     def test_get_me_unauthenticated(self) -> None:
@@ -138,7 +138,7 @@ class TestChangePassword:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(member.id, hash_password("oldpassword"))
 
@@ -151,7 +151,7 @@ class TestChangePassword:
 
         login_response = client.post(
             "/api/login",
-            json={"email": "test@test.com", "password": "newpassword"},
+            json={"email": "TEST_email@domain.com", "password": "newpassword"},
         )
         assert login_response.status_code == 200
 
@@ -159,7 +159,7 @@ class TestChangePassword:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(member.id, hash_password("oldpassword"))
 
@@ -186,7 +186,7 @@ class TestSetPassword:
         member_repo = SqliteMemberRepository(conn)
         token_repo = SqlitePasswordTokenRepository(conn)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         password_token = token_repo.create(member.id)
 
@@ -203,7 +203,7 @@ class TestSetPassword:
         login_response = client.post(
             "/api/login",
             json={
-                "email": "test@test.com",
+                "email": "TEST_email@domain.com",
                 "password": "newpassword123",
             },
         )
@@ -225,7 +225,7 @@ class TestSetPassword:
         member_repo = SqliteMemberRepository(conn)
         token_repo = SqlitePasswordTokenRepository(conn)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         password_token = token_repo.create(member.id)
         token_repo.mark_used(password_token.id)

--- a/tests/api/test_bgg.py
+++ b/tests/api/test_bgg.py
@@ -36,9 +36,7 @@ def _auth_cookie(member: Member) -> dict[str, str]:
     return {"Cookie": f"session_token={token}"}
 
 
-def _make_member(
-    member_repo: SqliteMemberRepository, *, is_admin: bool
-) -> Member:
+def _make_member(member_repo: SqliteMemberRepository, *, is_admin: bool) -> Member:
     return member_repo.upsert_by_email(
         member_number=1,
         first_name="Ada",
@@ -110,12 +108,17 @@ class TestBggImport:
                 BggGame(230802, "Azul", "https://a.jpg", 2017),
             ],
         ):
-            response = client.post("/api/admin/bgg/import", headers=_auth_cookie(member))
+            response = client.post(
+                "/api/admin/bgg/import", headers=_auth_cookie(member)
+            )
 
         assert response.status_code == 200
         body = response.json()
         assert body["created"] == 2
         assert body["updated"] == 0
         assert body["total"] == 2
+        assert body["deleted"] == 0
+        assert body["deactivated"] == 0
+        assert body["skip_reason"] is None
         assert body["last_imported_at"] is not None
         conn.close()

--- a/tests/api/test_bgg.py
+++ b/tests/api/test_bgg.py
@@ -45,7 +45,7 @@ def _make_member(
         last_name="Admin",
         nickname=None,
         phone=None,
-        email="ada@example.com",
+        email="TEST_email@domain.com",
         display_name="Ada Admin",
         is_admin=is_admin,
     )

--- a/tests/api/test_forgot_password.py
+++ b/tests/api/test_forgot_password.py
@@ -31,10 +31,10 @@ class TestForgotPassword:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
 
-        response = client.post("/api/forgot-password", json={"email": "test@test.com"})
+        response = client.post("/api/forgot-password", json={"email": "TEST_email@domain.com"})
 
         assert response.status_code == 200
         assert response.json() == {"ok": True}
@@ -43,7 +43,7 @@ class TestForgotPassword:
         client, _ = _setup_test_client()
 
         response = client.post(
-            "/api/forgot-password", json={"email": "nobody@test.com"}
+            "/api/forgot-password", json={"email": "TEST_email@domain.com"}
         )
 
         assert response.status_code == 200
@@ -53,11 +53,11 @@ class TestForgotPassword:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_active(member.id, False)
 
-        response = client.post("/api/forgot-password", json={"email": "test@test.com"})
+        response = client.post("/api/forgot-password", json={"email": "TEST_email@domain.com"})
 
         assert response.status_code == 200
         assert response.json() == {"ok": True}
@@ -66,10 +66,10 @@ class TestForgotPassword:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
 
-        client.post("/api/forgot-password", json={"email": "test@test.com"})
+        client.post("/api/forgot-password", json={"email": "TEST_email@domain.com"})
 
         row = conn.execute("SELECT COUNT(*) FROM password_tokens").fetchone()
         assert row[0] == 1
@@ -77,7 +77,7 @@ class TestForgotPassword:
     def test_does_not_create_token_for_nonexistent_email(self) -> None:
         client, conn = _setup_test_client()
 
-        client.post("/api/forgot-password", json={"email": "nobody@test.com"})
+        client.post("/api/forgot-password", json={"email": "TEST_email@domain.com"})
 
         row = conn.execute("SELECT COUNT(*) FROM password_tokens").fetchone()
         assert row[0] == 0

--- a/tests/api/test_games.py
+++ b/tests/api/test_games.py
@@ -96,7 +96,7 @@ class TestListGames:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan_repo.create(game_id=game2.id, member_id=alice.id)
 
@@ -141,14 +141,14 @@ class TestListGames:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         bob = _make_member(
             member_repo,
             number=2,
             first_name="Bob",
             last_name="Jones",
-            email="bob@example.com",
+            email="TEST_email@domain.com",
         )
 
         loan = loan_repo.create(game_id=game2.id, member_id=alice.id)
@@ -218,7 +218,7 @@ class TestGetGame:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan_repo.create(game_id=game.id, member_id=alice.id)
 
@@ -248,14 +248,14 @@ class TestGetGame:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         bob = _make_member(
             member_repo,
             number=2,
             first_name="Bob",
             last_name="Jones",
-            email="bob@example.com",
+            email="TEST_email@domain.com",
         )
         loan = loan_repo.create(game_id=game.id, member_id=alice.id)
 
@@ -339,14 +339,14 @@ class TestGetGameHistory:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         bob = _make_member(
             member_repo,
             number=2,
             first_name="Bob",
             last_name="Jones",
-            email="bob@example.com",
+            email="TEST_email@domain.com",
         )
 
         loan1 = loan_repo.create(game_id=game.id, member_id=alice.id)

--- a/tests/api/test_members.py
+++ b/tests/api/test_members.py
@@ -79,7 +79,7 @@ class TestValidateMember:
             number=42,
             first_name="Carlos",
             last_name="López",
-            email="carlos@test.com",
+            email="TEST_email@domain.com",
             gender="Masculino",
             last_payment="5/02/2022",
         )
@@ -105,7 +105,7 @@ class TestValidateMember:
             number=7,
             first_name="Ana",
             last_name="García",
-            email="ana@test.com",
+            email="TEST_email@domain.com",
             gender="Femenino",
             last_payment="1/01/2023",
         )
@@ -131,7 +131,7 @@ class TestValidateMember:
             number=15,
             first_name="Jordan",
             last_name="Martínez",
-            email="jordan@test.com",
+            email="TEST_email@domain.com",
             gender=None,
             last_payment=None,
         )
@@ -157,7 +157,7 @@ class TestValidateMember:
             number=99,
             first_name="Inactivo",
             last_name="Prueba",
-            email="inactivo@test.com",
+            email="TEST_email@domain.com",
             gender="Masculino",
             is_active=False,
         )
@@ -193,7 +193,7 @@ class TestValidateMember:
             number=1,
             first_name="Public",
             last_name="Member",
-            email="pub@test.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.get("/api/members/validate?number=1")
@@ -211,7 +211,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
         target = _make_member(
@@ -219,7 +219,7 @@ class TestAdminPatchMember:
             number=2,
             first_name="Target",
             last_name="Member",
-            email="target@test.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.patch(
@@ -227,7 +227,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Target",
                 "last_name": "Member",
-                "email": "target@test.com",
+                "email": "TEST_email@domain.com",
                 "last_payment": "10/03/2024",
                 "gender": "Femenino",
             },
@@ -251,7 +251,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
         target = _make_member(
@@ -259,7 +259,7 @@ class TestAdminPatchMember:
             number=2,
             first_name="Target",
             last_name="Member",
-            email="target@test.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.patch(
@@ -267,7 +267,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Renamed",
                 "last_name": "Person",
-                "email": "renamed@test.com",
+                "email": "TEST_email@domain.com",
                 "nickname": "Ren",
                 "phone": "600 11 22 33",
                 "member_number": 42,
@@ -281,7 +281,7 @@ class TestAdminPatchMember:
         assert updated is not None
         assert updated.first_name == "Renamed"
         assert updated.last_name == "Person"
-        assert updated.email == "renamed@test.com"
+        assert updated.email == "TEST_email@domain.com"
         assert updated.nickname == "Ren"
         assert updated.phone == "600 11 22 33"
         assert updated.member_number == 42
@@ -297,7 +297,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
         target = _make_member(
@@ -305,7 +305,7 @@ class TestAdminPatchMember:
             number=2,
             first_name="Target",
             last_name="Member",
-            email="target@test.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.patch(
@@ -313,7 +313,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Target",
                 "last_name": "Member",
-                "email": "admin@test.com",
+                "email": "TEST_email@domain.com",
             },
             headers=_auth_cookie(admin),
         )
@@ -329,7 +329,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
         target = _make_member(
@@ -337,7 +337,7 @@ class TestAdminPatchMember:
             number=2,
             first_name="Target",
             last_name="Member",
-            email="target@test.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.patch(
@@ -345,7 +345,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Target",
                 "last_name": "Member",
-                "email": "target@test.com",
+                "email": "TEST_email@domain.com",
                 "member_number": 1,
             },
             headers=_auth_cookie(admin),
@@ -362,7 +362,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
         target = _make_member(
@@ -370,7 +370,7 @@ class TestAdminPatchMember:
             number=2,
             first_name="Target",
             last_name="Member",
-            email="target@test.com",
+            email="TEST_email@domain.com",
             last_payment="5/02/2022",
             gender="Masculino",
         )
@@ -380,7 +380,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Target",
                 "last_name": "Member",
-                "email": "target@test.com",
+                "email": "TEST_email@domain.com",
                 "last_payment": None,
                 "gender": None,
             },
@@ -402,7 +402,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
 
@@ -411,7 +411,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Ghost",
                 "last_name": "Member",
-                "email": "ghost@test.com",
+                "email": "TEST_email@domain.com",
                 "last_payment": "1/01/2024",
             },
             headers=_auth_cookie(admin),
@@ -429,7 +429,7 @@ class TestAdminPatchMember:
             number=1,
             first_name="Regular",
             last_name="User",
-            email="regular@test.com",
+            email="TEST_email@domain.com",
             is_admin=False,
         )
 
@@ -438,7 +438,7 @@ class TestAdminPatchMember:
             json={
                 "first_name": "Regular",
                 "last_name": "User",
-                "email": "regular@test.com",
+                "email": "TEST_email@domain.com",
                 "last_payment": "1/01/2024",
             },
             headers=_auth_cookie(regular),
@@ -471,7 +471,7 @@ class TestAdminImportMembers:
             number=1,
             first_name="Admin",
             last_name="User",
-            email="admin@test.com",
+            email="TEST_email@domain.com",
             is_admin=True,
         )
 
@@ -482,8 +482,8 @@ class TestAdminImportMembers:
 
         csv_bytes = self._csv_bytes(
             [
-                "10,García,Ana,Anita,600111222,ana@test.com,,5/02/2022,Femenino",
-                "11,López,Carlos,,600333444,carlos@test.com,,1/01/2023,Masculino",
+                "10,García,Ana,Anita,600111222,TEST_email@domain.com,,5/02/2022,Femenino",
+                "11,López,Carlos,,600333444,TEST_email@domain.com,,1/01/2023,Masculino",
             ]
         )
         response = self._post_import(client, admin, csv_bytes)
@@ -495,12 +495,12 @@ class TestAdminImportMembers:
         assert len(body["created"]) == 2
 
         by_email = {c["email"]: c for c in body["created"]}
-        assert by_email["ana@test.com"]["display_name"] == "Anita"
-        assert by_email["carlos@test.com"]["display_name"] == "Carlos López"
+        assert by_email["TEST_email@domain.com"]["display_name"] == "Anita"
+        assert by_email["TEST_email@domain.com"]["display_name"] == "Carlos López"
         for created in body["created"]:
             assert "/set-password?token=" in created["token_url"]
 
-        ana = member_repo.get_by_email("ana@test.com")
+        ana = member_repo.get_by_email("TEST_email@domain.com")
         assert ana is not None
         assert ana.member_number == 10
         conn.close()
@@ -511,7 +511,7 @@ class TestAdminImportMembers:
         admin = self._make_admin(member_repo)
 
         csv_bytes = self._csv_bytes(
-            ["10,García,Ana,,600111222,ana@test.com,,5/02/2022,Femenino"]
+            ["10,García,Ana,,600111222,TEST_email@domain.com,,5/02/2022,Femenino"]
         )
         first = self._post_import(client, admin, csv_bytes)
         assert first.status_code == 200
@@ -532,7 +532,7 @@ class TestAdminImportMembers:
 
         csv_bytes = self._csv_bytes(
             [
-                "10,García,Ana,,600111222,ana@test.com,,,",
+                "10,García,Ana,,600111222,TEST_email@domain.com,,,",
                 "11,Sin,Email,,600333444,,,,",
             ]
         )
@@ -543,7 +543,7 @@ class TestAdminImportMembers:
         assert body["total_rows"] == 2
         assert body["skipped_rows"] == 1
         assert len(body["created"]) == 1
-        assert body["created"][0]["email"] == "ana@test.com"
+        assert body["created"][0]["email"] == "TEST_email@domain.com"
         conn.close()
 
     def test_missing_email_header_returns_400(self) -> None:
@@ -568,11 +568,11 @@ class TestAdminImportMembers:
             number=1,
             first_name="Regular",
             last_name="User",
-            email="regular@test.com",
+            email="TEST_email@domain.com",
             is_admin=False,
         )
 
-        csv_bytes = self._csv_bytes(["10,García,Ana,,600111222,ana@test.com,,,"])
+        csv_bytes = self._csv_bytes(["10,García,Ana,,600111222,TEST_email@domain.com,,,"])
         response = client.post(
             "/api/admin/members/import",
             files={"file": ("members.csv", csv_bytes, "text/csv")},

--- a/tests/api/test_rpg_items.py
+++ b/tests/api/test_rpg_items.py
@@ -157,7 +157,7 @@ class TestListRpgItems:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan_repo.create(game_id=rpg.id, member_id=alice.id)
 
@@ -189,14 +189,14 @@ class TestListRpgItems:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         bob = _make_member(
             member_repo,
             number=2,
             first_name="Bob",
             last_name="Jones",
-            email="bob@example.com",
+            email="TEST_email@domain.com",
         )
         loan = loan_repo.create(game_id=rpg.id, member_id=alice.id)
 
@@ -283,7 +283,7 @@ class TestGetRpgItem:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan_repo.create(game_id=rpg.id, member_id=alice.id)
 
@@ -313,14 +313,14 @@ class TestGetRpgItem:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         bob = _make_member(
             member_repo,
             number=2,
             first_name="Bob",
             last_name="Jones",
-            email="bob@example.com",
+            email="TEST_email@domain.com",
         )
         loan = loan_repo.create(game_id=rpg.id, member_id=alice.id)
 
@@ -378,7 +378,7 @@ class TestRpgItemHistory:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan = loan_repo.create(game_id=rpg.id, member_id=alice.id)
         loan_repo.mark_returned(loan.id)
@@ -409,7 +409,7 @@ class TestRpgItemHistory:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
         loan = loan_repo.create(game_id=rpg.id, member_id=alice.id)
         loan_repo.mark_returned(loan.id)
@@ -458,7 +458,7 @@ class TestLendingGuards:
             number=1,
             first_name="Alice",
             last_name="Smith",
-            email="alice@example.com",
+            email="TEST_email@domain.com",
         )
 
         response = client.post(

--- a/tests/api/test_rpg_items.py
+++ b/tests/api/test_rpg_items.py
@@ -383,7 +383,9 @@ class TestRpgItemHistory:
         loan = loan_repo.create(game_id=rpg.id, member_id=alice.id)
         loan_repo.mark_returned(loan.id)
 
-        response = client.get(f"/api/rol/{rpg.slug}/history", headers=_auth_cookie(alice))
+        response = client.get(
+            f"/api/rol/{rpg.slug}/history", headers=_auth_cookie(alice)
+        )
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/cli/test_import_members.py
+++ b/tests/cli/test_import_members.py
@@ -11,8 +11,8 @@ runner = CliRunner()
 
 _CSV_CONTENT = """\
 Nº Socio,Apellidos,Nombre,Apodo,Telefóno,Email,admin,Última cuota,Género
-1,Adell,Miquel,Miquel,600 00 00 01,admin@test.local,yes,24/01/2026,Masculino
-2,García López,Carla,Carla,600 00 00 02,carla@test.local,,24/01/2026,Femenino
+1,Adell,Miquel,Miquel,600 00 00 01,TEST_email@domain.com,yes,24/01/2026,Masculino
+2,García López,Carla,Carla,600 00 00 02,TEST_email@domain.com,,24/01/2026,Femenino
 3,Torres Ruiz,Jorge,,600 00 00 03,,,24/01/2026,Masculino
 """
 
@@ -45,13 +45,13 @@ def test_import_members_csv(monkeypatch: object, tmp_path: Path) -> None:
         # 3 rows, but Jorge Torres Ruiz has no email => 2 members
         assert len(members) == 2
 
-        admin = member_repo.get_by_email("admin@test.local")
+        admin = member_repo.get_by_email("TEST_email@domain.com")
         assert admin is not None
         assert admin.is_admin is True
         assert admin.last_payment == "24/01/2026"
         assert admin.gender == "Masculino"
 
-        carla = member_repo.get_by_email("carla@test.local")
+        carla = member_repo.get_by_email("TEST_email@domain.com")
         assert carla is not None
         assert carla.is_admin is False
     finally:

--- a/tests/data/repositories/test_sqlite_game_repository.py
+++ b/tests/data/repositories/test_sqlite_game_repository.py
@@ -1,4 +1,6 @@
 from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
+from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
+from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
 
 
 class TestSqliteGameRepository:
@@ -134,3 +136,87 @@ class TestSqliteGameRepository:
         )
         assert boardgame.slug == "aventura"
         assert rpg.slug == "aventura-2"
+
+    def test_upsert_defaults_is_active_true(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        assert game.is_active is True
+
+    def test_list_by_type_excludes_inactive(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_bgg_ids([13])
+        assert game_repo.list_by_type("boardgame") == []
+
+    def test_list_by_type_including_inactive_includes_it(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_bgg_ids([13])
+        games = game_repo.list_by_type_including_inactive("boardgame")
+        assert [g.bgg_id for g in games] == [13]
+        assert games[0].is_active is False
+
+    def test_deactivate_by_bgg_ids_marks_inactive_and_returns_count(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        count = game_repo.deactivate_by_bgg_ids([13, 14])
+        assert count == 2
+        assert game_repo.get_by_bgg_id(13).is_active is False
+        assert game_repo.get_by_bgg_id(14).is_active is False
+
+    def test_deactivate_by_bgg_ids_no_ops_on_empty_input(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        assert game_repo.deactivate_by_bgg_ids([]) == 0
+
+    def test_delete_by_bgg_ids_removes_never_borrowed_game(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        deleted, blocked = game_repo.delete_by_bgg_ids([13])
+        assert deleted == frozenset({13})
+        assert blocked == frozenset()
+        assert game_repo.get_by_bgg_id(13) is None
+
+    def test_upsert_reactivates_previously_inactive_row(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_bgg_ids([13])
+        reactivated = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        assert reactivated.is_active is True
+
+    def test_point_lookups_return_inactive_rows(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_bgg_ids([13])
+        assert game_repo.get_by_bgg_id(13) is not None
+        assert game_repo.get_by_slug(game.slug) is not None
+
+    def test_delete_blocked_by_returned_loan_history(
+        self,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        """A game with past (returned) loan history can never be hard-deleted,
+        because SQLite's FK constraint on loans.game_id doesn't distinguish
+        active from historical loans."""
+        game = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        member = member_repo.upsert_by_email(
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
+        )
+        loan = loan_repo.create(game.id, member.id)
+        loan_repo.mark_returned(loan.id)
+
+        deleted, blocked = game_repo.delete_by_bgg_ids([13])
+
+        assert deleted == frozenset()
+        assert blocked == frozenset({13})
+        assert game_repo.get_by_bgg_id(13) is not None

--- a/tests/data/repositories/test_sqlite_loan_repository.py
+++ b/tests/data/repositories/test_sqlite_loan_repository.py
@@ -16,7 +16,7 @@ def _seed_data(
     g1 = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
     g2 = game_repo.upsert_by_bgg_id(2, "Azul", "https://a.jpg", 2017)
     m = member_repo.upsert_by_email(
-        1, "Test", "User", None, None, "test@test.com", "Test User", False
+        1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
     )
     return g1.id, g2.id, m.id
 

--- a/tests/data/repositories/test_sqlite_member_repository.py
+++ b/tests/data/repositories/test_sqlite_member_repository.py
@@ -23,7 +23,7 @@ class TestSqliteMemberRepository:
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member_repo.upsert_by_email(
-            66, "Miquel", "Adell", None, None, "miquel@test.com", "Miquel Adell", False
+            66, "Miquel", "Adell", None, None, "TEST_email@domain.com", "Miquel Adell", False
         )
         updated = member_repo.upsert_by_email(
             66,
@@ -31,7 +31,7 @@ class TestSqliteMemberRepository:
             "Adell Borràs",
             None,
             "620 01 58 60",
-            "miquel@test.com",
+            "TEST_email@domain.com",
             "Miquel Adell Borràs",
             True,
         )
@@ -48,7 +48,7 @@ class TestSqliteMemberRepository:
             "Adell",
             None,
             None,
-            "miquel@test.com",
+            "TEST_email@domain.com",
             "Miquel Adell",
             is_admin=True,
             is_active=False,
@@ -59,7 +59,7 @@ class TestSqliteMemberRepository:
             "Adell Borràs",
             None,
             "620 01 58 60",
-            "miquel@test.com",
+            "TEST_email@domain.com",
             "Miquel Adell Borràs",
             is_admin=False,
             is_active=True,
@@ -76,7 +76,7 @@ class TestSqliteMemberRepository:
             "Member",
             None,
             None,
-            "new@test.com",
+            "TEST_email@domain.com",
             "New Member",
             is_admin=True,
             is_active=False,
@@ -86,7 +86,7 @@ class TestSqliteMemberRepository:
 
     def test_set_admin(self, member_repo: SqliteMemberRepository) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_admin(member.id, True)
         updated = member_repo.get_by_id(member.id)
@@ -95,23 +95,23 @@ class TestSqliteMemberRepository:
 
     def test_get_by_email(self, member_repo: SqliteMemberRepository) -> None:
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@example.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
-        found = member_repo.get_by_email("test@example.com")
+        found = member_repo.get_by_email("TEST_email@domain.com")
         assert found is not None
         assert found.first_name == "Test"
 
     def test_get_by_email_not_found(self, member_repo: SqliteMemberRepository) -> None:
-        assert member_repo.get_by_email("nobody@example.com") is None
+        assert member_repo.get_by_email("TEST_email@domain.com") is None
 
     def test_list_all_sorted_by_member_number(
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member_repo.upsert_by_email(
-            50, "B", "User", None, None, "b@test.com", "B User", False
+            50, "B", "User", None, None, "TEST_email@domain.com", "B User", False
         )
         member_repo.upsert_by_email(
-            10, "A", "User", None, None, "a@test.com", "A User", False
+            10, "A", "User", None, None, "TEST_email@domain.com", "A User", False
         )
         members = member_repo.list_all()
         numbers = [m.member_number for m in members]
@@ -119,13 +119,13 @@ class TestSqliteMemberRepository:
 
     def test_nullable_member_number(self, member_repo: SqliteMemberRepository) -> None:
         member = member_repo.upsert_by_email(
-            None, "No", "Number", None, None, "no@test.com", "No Number", False
+            None, "No", "Number", None, None, "TEST_email@domain.com", "No Number", False
         )
         assert member.member_number is None
 
     def test_update_display_name(self, member_repo: SqliteMemberRepository) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", "Nick", None, "test@test.com", "Nick", False
+            1, "Test", "User", "Nick", None, "TEST_email@domain.com", "Nick", False
         )
         member_repo.update_display_name(member.id, "Test User")
         updated = member_repo.get_by_id(member.id)
@@ -134,7 +134,7 @@ class TestSqliteMemberRepository:
 
     def test_set_password_hash(self, member_repo: SqliteMemberRepository) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         assert member.password_hash is None
         member_repo.set_password_hash(member.id, "$2b$12$fakehash")
@@ -149,7 +149,7 @@ class TestSqliteMemberRepository:
             "Navío Enríquez",
             None,
             None,
-            "jesus@test.com",
+            "TEST_email@domain.com",
             "Jesús Navío Enríquez",
             False,
         )

--- a/tests/data/repositories/test_sqlite_password_token_repository.py
+++ b/tests/data/repositories/test_sqlite_password_token_repository.py
@@ -12,7 +12,7 @@ class TestSqlitePasswordTokenRepository:
             "User",
             None,
             None,
-            "test@test.com",
+            "TEST_email@domain.com",
             "Test User",
             False,
         )

--- a/tests/domain/entities/test_member.py
+++ b/tests/domain/entities/test_member.py
@@ -39,7 +39,7 @@ class TestMember:
             last_name="User",
             nickname=None,
             phone=None,
-            email="test@example.com",
+            email="TEST_email@domain.com",
             display_name="Test User",
             password_hash=None,
             is_admin=False,
@@ -60,7 +60,7 @@ class TestMember:
             last_name="Codina Busqueta",
             nickname="Caradras",
             phone="639 01 03 75",
-            email="hothgond@gmail.com",
+            email="TEST_email@domain.com",
             display_name="Caradras",
             password_hash=None,
             is_admin=False,
@@ -80,7 +80,7 @@ class TestMember:
             last_name="User",
             nickname=None,
             phone=None,
-            email="test@example.com",
+            email="TEST_email@domain.com",
             display_name="Test User",
             password_hash=None,
             is_admin=False,
@@ -89,7 +89,7 @@ class TestMember:
             updated_at=now,
         )
         try:
-            member.email = "changed@example.com"  # type: ignore[misc]
+            member.email = "TEST_email@domain.com"  # type: ignore[misc]
             raise AssertionError("Should have raised FrozenInstanceError")
         except AttributeError:
             pass

--- a/tests/domain/use_cases/conftest.py
+++ b/tests/domain/use_cases/conftest.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from backend.domain.entities.game import Game
+from backend.domain.entities.loan import Loan
+from backend.domain.slug import ensure_unique, slugify
+
+
+class FakeGameRepository:
+    """Shared fake for import-reconciliation tests.
+
+    ``blocked_bgg_ids`` is a test-only escape hatch: populate it directly to
+    simulate a game that has loan history and is therefore FK-blocked from
+    hard deletion, without reimplementing real SQLite FK semantics here.
+    """
+
+    def __init__(self) -> None:
+        self._games: dict[int, Game] = {}
+        self._next_id = 1
+        self.blocked_bgg_ids: set[int] = set()
+
+    def get_by_id(self, game_id: int) -> Game | None:
+        return self._games.get(game_id)
+
+    def get_by_slug(self, slug: str) -> Game | None:
+        return next((g for g in self._games.values() if g.slug == slug), None)
+
+    def get_by_bgg_id(self, bgg_id: int) -> Game | None:
+        return next((g for g in self._games.values() if g.bgg_id == bgg_id), None)
+
+    def list_all(self) -> list[Game]:
+        return sorted(self._games.values(), key=lambda g: g.name)
+
+    def list_by_type(self, item_type: str) -> list[Game]:
+        return sorted(
+            (
+                g
+                for g in self._games.values()
+                if g.item_type == item_type and g.is_active
+            ),
+            key=lambda g: g.name,
+        )
+
+    def list_by_type_including_inactive(self, item_type: str) -> list[Game]:
+        return sorted(
+            (g for g in self._games.values() if g.item_type == item_type),
+            key=lambda g: g.name,
+        )
+
+    def deactivate_by_bgg_ids(self, bgg_ids: object) -> int:
+        count = 0
+        for bgg_id in bgg_ids:
+            game = self.get_by_bgg_id(bgg_id)
+            if game is not None and game.is_active:
+                self._games[game.id] = _replace_is_active(game, is_active=False)
+                count += 1
+        return count
+
+    def delete_by_bgg_ids(
+        self, bgg_ids: object
+    ) -> tuple[frozenset[int], frozenset[int]]:
+        deleted: set[int] = set()
+        blocked: set[int] = set()
+        for bgg_id in bgg_ids:
+            if bgg_id in self.blocked_bgg_ids:
+                blocked.add(bgg_id)
+                continue
+            game = self.get_by_bgg_id(bgg_id)
+            if game is not None:
+                del self._games[game.id]
+                deleted.add(bgg_id)
+        return frozenset(deleted), frozenset(blocked)
+
+    def upsert_by_bgg_id(
+        self,
+        bgg_id: int,
+        name: str,
+        thumbnail_url: str,
+        image_url: str = "",
+        year_published: int = 0,
+        min_players: int = 0,
+        max_players: int = 0,
+        playing_time: int = 0,
+        bgg_rating: float = 0.0,
+        location: str = "armari",
+        item_type: str = "boardgame",
+        description: str = "",
+    ) -> Game:
+        now = datetime.now(UTC)
+        existing = self.get_by_bgg_id(bgg_id)
+        slug = (
+            existing.slug
+            if existing and slugify(existing.name) == slugify(name)
+            else ensure_unique(
+                slugify(name),
+                (g.slug for g in self._games.values() if g.bgg_id != bgg_id),
+            )
+        )
+        game = Game(
+            id=existing.id if existing else self._next_id,
+            bgg_id=bgg_id,
+            name=name,
+            slug=slug,
+            thumbnail_url=thumbnail_url,
+            image_url=image_url,
+            year_published=year_published,
+            min_players=min_players,
+            max_players=max_players,
+            playing_time=playing_time,
+            bgg_rating=bgg_rating,
+            location=location,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+            item_type=item_type,
+            description=description,
+            is_active=True,
+        )
+        self._games[game.id] = game
+        if existing is None:
+            self._next_id += 1
+        return game
+
+
+def _replace_is_active(game: Game, *, is_active: bool) -> Game:
+    return Game(
+        id=game.id,
+        bgg_id=game.bgg_id,
+        name=game.name,
+        slug=game.slug,
+        thumbnail_url=game.thumbnail_url,
+        image_url=game.image_url,
+        year_published=game.year_published,
+        min_players=game.min_players,
+        max_players=game.max_players,
+        playing_time=game.playing_time,
+        bgg_rating=game.bgg_rating,
+        location=game.location,
+        created_at=game.created_at,
+        updated_at=game.updated_at,
+        item_type=game.item_type,
+        description=game.description,
+        is_active=is_active,
+    )
+
+
+class FakeLoanRepository:
+    """Settable "active loan for this game_id" mapping."""
+
+    def __init__(self) -> None:
+        self._active_by_game_id: dict[int, Loan] = {}
+
+    def set_active_loan(self, game_id: int, loan: Loan) -> None:
+        self._active_by_game_id[game_id] = loan
+
+    def get_active_by_game_id(self, game_id: int) -> Loan | None:
+        return self._active_by_game_id.get(game_id)
+
+
+@pytest.fixture
+def fake_game_repo() -> FakeGameRepository:
+    return FakeGameRepository()
+
+
+@pytest.fixture
+def fake_loan_repo() -> FakeLoanRepository:
+    return FakeLoanRepository()

--- a/tests/domain/use_cases/test_bgg_import_reconciliation.py
+++ b/tests/domain/use_cases/test_bgg_import_reconciliation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from backend.data.bgg_client import BggGame
+from backend.domain.use_cases.import_games import ImportGamesUseCase
+from backend.domain.use_cases.import_rpg_items import ImportRpgItemsUseCase
+from tests.domain.use_cases.conftest import FakeGameRepository, FakeLoanRepository
+from tests.domain.use_cases.test_import_rpg_items import (
+    _PF_RPG_ITEM,
+    FakeBggClientRpg,
+)
+
+
+class BggGamesClient:
+    def __init__(self, games: list[BggGame]) -> None:
+        self._games = games
+
+    def fetch_owned_games(self) -> list[BggGame]:
+        return self._games
+
+
+class TestItemTypeScoping:
+    def test_boardgame_import_never_touches_rpgitem(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(
+            1001, "D&D PHB", "https://dnd.jpg", item_type="rpgitem"
+        )
+        bgg_client = BggGamesClient([])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        use_case.execute()
+
+        rpg_item = fake_game_repo.get_by_bgg_id(1001)
+        assert rpg_item is not None
+        assert rpg_item.is_active is True
+
+    def test_rpgitem_import_never_touches_boardgame(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(
+            13, "Catan", "https://c.jpg", item_type="boardgame"
+        )
+        bgg_client = FakeBggClientRpg([_PF_RPG_ITEM])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        use_case.execute()
+
+        catan = fake_game_repo.get_by_bgg_id(13)
+        assert catan is not None
+        assert catan.is_active is True

--- a/tests/domain/use_cases/test_bgg_reconciliation.py
+++ b/tests/domain/use_cases/test_bgg_reconciliation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
+
+
+class TestComputeReconciliation:
+    def test_no_missing_ids(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset({1, 2}),
+            fetched_bgg_ids=frozenset({1, 2}),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.skip_reason is None
+
+    def test_missing_ids_under_guard(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
+            fetched_bgg_ids=frozenset({1, 2, 3}),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset({4})
+        assert outcome.skip_reason is None
+
+    def test_empty_fetch_skips(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset({1, 2}),
+            fetched_bgg_ids=frozenset(),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.skip_reason is not None
+
+    def test_over_50_percent_drop_skips(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
+            fetched_bgg_ids=frozenset({1}),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.skip_reason is not None
+
+    def test_exactly_50_percent_drop_does_not_skip(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
+            fetched_bgg_ids=frozenset({1, 2}),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset({3, 4})
+        assert outcome.skip_reason is None
+
+    def test_first_ever_import_does_not_skip_or_divide_by_zero(self) -> None:
+        outcome = compute_reconciliation(
+            existing_active_bgg_ids=frozenset(),
+            fetched_bgg_ids=frozenset({1, 2}),
+            item_type="boardgame",
+        )
+        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.skip_reason is None

--- a/tests/domain/use_cases/test_borrow_game.py
+++ b/tests/domain/use_cases/test_borrow_game.py
@@ -17,7 +17,7 @@ class TestBorrowGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "t@t.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         use_case = BorrowGameUseCase(game_repo, loan_repo)
         loan = use_case.execute(game.id, member.id)
@@ -33,10 +33,10 @@ class TestBorrowGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         m1 = member_repo.upsert_by_email(
-            1, "A", "User", None, None, "a@t.com", "A User", False
+            1, "A", "User", None, None, "TEST_email@domain.com", "A User", False
         )
         m2 = member_repo.upsert_by_email(
-            2, "B", "User", None, None, "b@t.com", "B User", False
+            2, "B", "User", None, None, "TEST_email@domain.com", "B User", False
         )
         use_case = BorrowGameUseCase(game_repo, loan_repo)
         use_case.execute(game.id, m1.id)
@@ -65,7 +65,7 @@ class TestBorrowGameUseCase:
             item_type="rpgitem",
         )
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "t@t.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         use_case = BorrowGameUseCase(game_repo, loan_repo)
         loan = use_case.execute(rpg.id, member.id)

--- a/tests/domain/use_cases/test_borrow_game.py
+++ b/tests/domain/use_cases/test_borrow_game.py
@@ -6,6 +6,7 @@ from backend.data.repositories.sqlite_game_repository import SqliteGameRepositor
 from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
 from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
 from backend.domain.use_cases.borrow_game import BorrowGameError, BorrowGameUseCase
+from backend.domain.use_cases.return_game import ReturnGameUseCase
 
 
 class TestBorrowGameUseCase:
@@ -51,6 +52,40 @@ class TestBorrowGameUseCase:
         use_case = BorrowGameUseCase(game_repo, loan_repo)
         with pytest.raises(BorrowGameError, match="no encontrado"):
             use_case.execute(999, 1)
+
+    def test_cannot_borrow_deactivated_game(
+        self,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_bgg_ids([1])
+        member = member_repo.upsert_by_email(
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
+        )
+        use_case = BorrowGameUseCase(game_repo, loan_repo)
+        with pytest.raises(BorrowGameError, match="no encontrado"):
+            use_case.execute(game.id, member.id)
+
+    def test_returning_loan_succeeds_on_deactivated_game(
+        self,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        member = member_repo.upsert_by_email(
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
+        )
+        borrow_use_case = BorrowGameUseCase(game_repo, loan_repo)
+        loan = borrow_use_case.execute(game.id, member.id)
+        game_repo.deactivate_by_bgg_ids([game.bgg_id])
+
+        return_use_case = ReturnGameUseCase(loan_repo)
+        returned = return_use_case.execute(loan.id, member)
+
+        assert returned.returned_at is not None
 
     def test_borrow_rpg_item_succeeds(
         self,

--- a/tests/domain/use_cases/test_change_password.py
+++ b/tests/domain/use_cases/test_change_password.py
@@ -15,7 +15,7 @@ class TestChangePassword:
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(member.id, hash_password("oldpassword"))
         member = member_repo.get_by_id(member.id)
@@ -33,7 +33,7 @@ class TestChangePassword:
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(member.id, hash_password("oldpassword"))
         member = member_repo.get_by_id(member.id)
@@ -47,7 +47,7 @@ class TestChangePassword:
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         use_case = ChangePasswordUseCase(member_repo)
 
@@ -58,7 +58,7 @@ class TestChangePassword:
         self, member_repo: SqliteMemberRepository
     ) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_password_hash(member.id, hash_password("oldpassword"))
         member = member_repo.get_by_id(member.id)

--- a/tests/domain/use_cases/test_get_game.py
+++ b/tests/domain/use_cases/test_get_game.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+
 from backend.domain.use_cases.get_game import GetGameUseCase
 from tests.domain.use_cases.test_list_games import (
     FakeGameRepository,
@@ -55,3 +57,13 @@ class TestGetGameUseCase:
         assert result.status == "lent"
         assert result.borrower_display_name == "Bob"
         assert result.loan_id == 100
+
+    def test_returns_none_for_deactivated_game(self) -> None:
+        game = dataclasses.replace(_make_game(1, "Catan"), is_active=False)
+        use_case = GetGameUseCase(
+            game_repo=FakeGameRepository([game]),
+            loan_repo=FakeLoanRepository(),
+            member_repo=FakeMemberRepository(),
+        )
+
+        assert use_case.execute("catan") is None

--- a/tests/domain/use_cases/test_get_game_history.py
+++ b/tests/domain/use_cases/test_get_game_history.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from datetime import UTC, datetime
 
 from backend.domain.entities.game import Game
@@ -218,3 +219,45 @@ class TestGetGameHistoryUseCase:
         assert result[1].member_display_name == "Alice"
         assert result[1].borrowed_at == borrowed_earlier
         assert result[1].returned_at == returned_date
+
+    def test_deactivated_game_history_still_returns_entries(self) -> None:
+        """Loan history for a soft-deleted (deactivated) game must stay
+        reachable — is_active is deliberately ignored."""
+        game = dataclasses.replace(_make_game(1, "catan"), is_active=False)
+        loan = _make_loan(
+            id=10, game_id=1, member_id=1, borrowed_at=NOW, returned_at=NOW
+        )
+        member = _make_member(1, "Alice")
+
+        use_case = GetGameHistoryUseCase(
+            game_repo=FakeGameRepository([game]),
+            loan_repo=FakeLoanRepository([loan]),
+            member_repo=FakeMemberRepository([member]),
+        )
+
+        result = use_case.execute(slug="catan")
+
+        assert result is not None
+        assert len(result) == 1
+
+    def test_item_type_scoping_returns_none_for_wrong_type(self) -> None:
+        boardgame = _make_game(1, "catan")
+        use_case = GetGameHistoryUseCase(
+            game_repo=FakeGameRepository([boardgame]),
+            loan_repo=FakeLoanRepository(),
+            member_repo=FakeMemberRepository(),
+            item_type="rpgitem",
+        )
+
+        assert use_case.execute(slug="catan") is None
+
+    def test_item_type_scoping_allows_matching_type(self) -> None:
+        boardgame = _make_game(1, "catan")
+        use_case = GetGameHistoryUseCase(
+            game_repo=FakeGameRepository([boardgame]),
+            loan_repo=FakeLoanRepository(),
+            member_repo=FakeMemberRepository(),
+            item_type="boardgame",
+        )
+
+        assert use_case.execute(slug="catan") == []

--- a/tests/domain/use_cases/test_get_rpg_item.py
+++ b/tests/domain/use_cases/test_get_rpg_item.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+
 from backend.domain.use_cases.get_rpg_item import GetRpgItemUseCase
 from tests.domain.use_cases.test_list_games import (
     FakeGameRepository,
@@ -68,3 +70,13 @@ class TestGetRpgItemUseCase:
         assert result.status == "lent"
         assert result.borrower_display_name == "Alice"
         assert result.loan_id == 100
+
+    def test_returns_none_for_deactivated_rpg_item(self) -> None:
+        rpg = dataclasses.replace(_make_rpg_item(1, "Pathfinder"), is_active=False)
+        use_case = GetRpgItemUseCase(
+            game_repo=FakeGameRepository([rpg]),
+            loan_repo=FakeLoanRepository(),
+            member_repo=FakeMemberRepository(),
+        )
+
+        assert use_case.execute("pathfinder") is None

--- a/tests/domain/use_cases/test_import_games.py
+++ b/tests/domain/use_cases/test_import_games.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from backend.data.bgg_client import BggGame
-from backend.domain.entities.game import Game
-from backend.domain.slug import ensure_unique, slugify
+from backend.domain.entities.loan import Loan
 from backend.domain.use_cases.import_games import ImportGamesUseCase
+from tests.domain.use_cases.conftest import FakeGameRepository, FakeLoanRepository
 
 
 class FakeBggClient:
@@ -16,138 +16,205 @@ class FakeBggClient:
         return self._games
 
 
-class FakeGameRepository:
-    def __init__(self) -> None:
-        self._games: dict[int, Game] = {}
-        self._next_id = 1
-
-    def get_by_id(self, game_id: int) -> Game | None:
-        return self._games.get(game_id)
-
-    def get_by_slug(self, slug: str) -> Game | None:
-        return next((g for g in self._games.values() if g.slug == slug), None)
-
-    def get_by_bgg_id(self, bgg_id: int) -> Game | None:
-        return next((g for g in self._games.values() if g.bgg_id == bgg_id), None)
-
-    def list_all(self) -> list[Game]:
-        return sorted(self._games.values(), key=lambda g: g.name)
-
-    def upsert_by_bgg_id(
-        self,
-        bgg_id: int,
-        name: str,
-        thumbnail_url: str,
-        image_url: str = "",
-        year_published: int = 0,
-        min_players: int = 0,
-        max_players: int = 0,
-        playing_time: int = 0,
-        bgg_rating: float = 0.0,
-        location: str = "armari",
-    ) -> Game:
-        now = datetime.now(UTC)
-        existing = self.get_by_bgg_id(bgg_id)
-        slug = (
-            existing.slug
-            if existing and slugify(existing.name) == slugify(name)
-            else ensure_unique(
-                slugify(name),
-                (g.slug for g in self._games.values() if g.bgg_id != bgg_id),
-            )
-        )
-        if existing:
-            game = Game(
-                id=existing.id,
-                bgg_id=bgg_id,
-                name=name,
-                slug=slug,
-                thumbnail_url=thumbnail_url,
-                image_url=image_url,
-                year_published=year_published,
-                min_players=min_players,
-                max_players=max_players,
-                playing_time=playing_time,
-                bgg_rating=bgg_rating,
-                location=location,
-                created_at=existing.created_at,
-                updated_at=now,
-            )
-            self._games[game.id] = game
-            return game
-        game = Game(
-            id=self._next_id,
-            bgg_id=bgg_id,
-            name=name,
-            slug=slug,
-            thumbnail_url=thumbnail_url,
-            image_url=image_url,
-            year_published=year_published,
-            min_players=min_players,
-            max_players=max_players,
-            playing_time=playing_time,
-            bgg_rating=bgg_rating,
-            location=location,
-            created_at=now,
-            updated_at=now,
-        )
-        self._games[game.id] = game
-        self._next_id += 1
-        return game
+def _loan(game_id: int) -> Loan:
+    return Loan(
+        id=1,
+        game_id=game_id,
+        member_id=1,
+        borrowed_at=datetime.now(UTC),
+        returned_at=None,
+    )
 
 
 class TestImportGamesUseCase:
-    def test_imports_new_games(self) -> None:
+    def test_imports_new_games(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClient(
             [
                 BggGame(13, "Catan", "https://c.jpg", 1995),
                 BggGame(230802, "Azul", "https://a.jpg", 2017),
             ]
         )
-        repo = FakeGameRepository()
-        use_case = ImportGamesUseCase(repo, bgg_client)
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
         assert result.created == 2
         assert result.updated == 0
         assert result.total == 2
-        assert len(repo.list_all()) == 2
+        assert len(fake_game_repo.list_all()) == 2
 
-    def test_updates_existing_games(self) -> None:
-        repo = FakeGameRepository()
-        repo.upsert_by_bgg_id(13, "Catan", "https://old.jpg", 1995)
+    def test_updates_existing_games(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://old.jpg", 1995)
         bgg_client = FakeBggClient(
-            [
-                BggGame(13, "Catan: 25th Anniversary", "https://new.jpg", 1995),
-            ]
+            [BggGame(13, "Catan: 25th Anniversary", "https://new.jpg", 1995)]
         )
-        use_case = ImportGamesUseCase(repo, bgg_client)
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
         assert result.created == 0
         assert result.updated == 1
-        game = repo.get_by_bgg_id(13)
+        game = fake_game_repo.get_by_bgg_id(13)
         assert game is not None
         assert game.name == "Catan: 25th Anniversary"
 
-    def test_mixed_create_and_update(self) -> None:
-        repo = FakeGameRepository()
-        repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+    def test_mixed_create_and_update(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
         bgg_client = FakeBggClient(
             [
                 BggGame(13, "Catan", "https://c.jpg", 1995),
                 BggGame(230802, "Azul", "https://a.jpg", 2017),
             ]
         )
-        use_case = ImportGamesUseCase(repo, bgg_client)
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
         assert result.created == 1
         assert result.updated == 1
         assert result.total == 2
 
-    def test_empty_collection(self) -> None:
+    def test_empty_collection(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClient([])
-        repo = FakeGameRepository()
-        use_case = ImportGamesUseCase(repo, bgg_client)
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
         assert result.created == 0
         assert result.updated == 0
         assert result.total == 0
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.skip_reason is not None
+
+    def test_missing_and_not_lent_is_hard_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 1
+        assert result.deactivated == 0
+        assert fake_game_repo.get_by_bgg_id(13) is None
+
+    def test_missing_and_currently_lent_is_soft_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        game = fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        fake_loan_repo.set_active_loan(game.id, _loan(game.id))
+        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deactivated == 1
+        assert result.deleted == 0
+        stored = fake_game_repo.get_by_bgg_id(13)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_present_items_are_untouched(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert fake_game_repo.get_by_bgg_id(13) is not None
+
+    def test_previously_soft_deleted_still_lent_stays_soft_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        game = fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_bgg_ids([13])
+        fake_loan_repo.set_active_loan(game.id, _loan(game.id))
+        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        stored = fake_game_repo.get_by_bgg_id(13)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_previously_soft_deleted_no_longer_lent_is_hard_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_bgg_ids([13])
+        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 1
+        assert fake_game_repo.get_by_bgg_id(13) is None
+
+    def test_previously_soft_deleted_fk_blocked_stays_soft_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_bgg_ids([13])
+        fake_game_repo.blocked_bgg_ids.add(13)
+        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 1
+        stored = fake_game_repo.get_by_bgg_id(13)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_drastic_drop_skips_newly_missing_but_not_stale_inactive(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.upsert_by_bgg_id(15, "Pandemic", "https://p.jpg", 2008)
+        fake_game_repo.upsert_by_bgg_id(16, "Ticket to Ride", "https://t.jpg", 2004)
+        fake_game_repo.deactivate_by_bgg_ids([16])
+        # only 1 of 3 active items remains -> > 50% missing, guard trips
+        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.skip_reason is not None
+        # newly-missing (14, 15) are neither deleted nor deactivated
+        assert fake_game_repo.get_by_bgg_id(14) is not None
+        assert fake_game_repo.get_by_bgg_id(14).is_active is True
+        assert fake_game_repo.get_by_bgg_id(15) is not None
+        assert fake_game_repo.get_by_bgg_id(15).is_active is True
+        # already-inactive stale item (16) is still reconciled regardless
+        assert fake_game_repo.get_by_bgg_id(16) is None
+        assert result.deleted == 1
+
+    def test_reappearing_item_is_reactivated(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.deactivate_by_bgg_ids([13])
+        assert fake_game_repo.get_by_bgg_id(13).is_active is False
+
+        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        use_case.execute()
+
+        stored = fake_game_repo.get_by_bgg_id(13)
+        assert stored is not None
+        assert stored.is_active is True

--- a/tests/domain/use_cases/test_import_members.py
+++ b/tests/domain/use_cases/test_import_members.py
@@ -224,7 +224,7 @@ def _make_raw(
     nombre: str = "Test",
     apellidos: str = "User",
     apodo: str = "",
-    email: str = "test@example.com",
+    email: str = "TEST_email@domain.com",
     telefono: str = "",
     socio: str = "",
     admin: str = "",
@@ -260,13 +260,13 @@ def test_display_name_uses_nickname_when_unique() -> None:
                 nombre="Carles",
                 apellidos="Codina",
                 apodo="Caradras",
-                email="a@test.com",
+                email="TEST_email@domain.com",
             ),
             _make_raw(
                 nombre="Lucas",
                 apellidos="De la Cruz",
                 apodo="Borkyl",
-                email="b@test.com",
+                email="TEST_email@domain.com",
             ),
         ]
     )
@@ -285,9 +285,9 @@ def test_display_name_falls_back_when_nickname_not_unique() -> None:
     results = uc.execute(
         [
             _make_raw(
-                nombre="Alice", apellidos="Smith", apodo="Ace", email="a@test.com"
+                nombre="Alice", apellidos="Smith", apodo="Ace", email="TEST_email@domain.com"
             ),
-            _make_raw(nombre="Bob", apellidos="Jones", apodo="Ace", email="b@test.com"),
+            _make_raw(nombre="Bob", apellidos="Jones", apodo="Ace", email="TEST_email@domain.com"),
         ]
     )
 
@@ -305,12 +305,12 @@ def test_members_without_email_are_skipped() -> None:
     results = uc.execute(
         [
             _make_raw(nombre="Jorge", apellidos="Torres", email=""),
-            _make_raw(nombre="Valid", apellidos="User", email="valid@test.com"),
+            _make_raw(nombre="Valid", apellidos="User", email="TEST_email@domain.com"),
         ]
     )
 
     assert len(results) == 1
-    assert results[0].member.email == "valid@test.com"
+    assert results[0].member.email == "TEST_email@domain.com"
     assert len(member_repo.list_all()) == 1
 
 
@@ -320,18 +320,18 @@ def test_upsert_updates_existing_members() -> None:
     uc = ImportMembersUseCase(member_repo, token_repo, BASE_URL)
 
     # First import
-    uc.execute([_make_raw(nombre="Old", apellidos="Name", email="x@test.com")])
+    uc.execute([_make_raw(nombre="Old", apellidos="Name", email="TEST_email@domain.com")])
 
     # Second import with updated name
     results = uc.execute(
-        [_make_raw(nombre="New", apellidos="Name", email="x@test.com")]
+        [_make_raw(nombre="New", apellidos="Name", email="TEST_email@domain.com")]
     )
 
     # No new members, so no tokens
     assert len(results) == 0
 
     # But member was updated
-    member = member_repo.get_by_email("x@test.com")
+    member = member_repo.get_by_email("TEST_email@domain.com")
     assert member is not None
     assert member.first_name == "New"
 
@@ -345,20 +345,20 @@ def test_password_tokens_generated_for_new_members_only() -> None:
     uc = ImportMembersUseCase(member_repo, token_repo, BASE_URL)
 
     # Import first member
-    results1 = uc.execute([_make_raw(nombre="A", apellidos="B", email="a@test.com")])
+    results1 = uc.execute([_make_raw(nombre="A", apellidos="B", email="TEST_email@domain.com")])
     assert len(results1) == 1  # new member gets token
 
     # Import both old and new member
     results2 = uc.execute(
         [
-            _make_raw(nombre="A", apellidos="B", email="a@test.com"),
-            _make_raw(nombre="C", apellidos="D", email="c@test.com"),
+            _make_raw(nombre="A", apellidos="B", email="TEST_email@domain.com"),
+            _make_raw(nombre="C", apellidos="D", email="TEST_email@domain.com"),
         ]
     )
 
     # Only the new member gets a token
     assert len(results2) == 1
-    assert results2[0].member.email == "c@test.com"
+    assert results2[0].member.email == "TEST_email@domain.com"
     assert "set-password?token=" in results2[0].token_url
 
 
@@ -369,9 +369,9 @@ def test_display_name_recomputation_on_collision() -> None:
 
     # First import: nickname "Ace" is unique
     uc.execute(
-        [_make_raw(nombre="Alice", apellidos="Smith", apodo="Ace", email="a@test.com")]
+        [_make_raw(nombre="Alice", apellidos="Smith", apodo="Ace", email="TEST_email@domain.com")]
     )
-    m = member_repo.get_by_email("a@test.com")
+    m = member_repo.get_by_email("TEST_email@domain.com")
     assert m is not None
     assert m.display_name == "Ace"
 
@@ -379,15 +379,15 @@ def test_display_name_recomputation_on_collision() -> None:
     uc.execute(
         [
             _make_raw(
-                nombre="Alice", apellidos="Smith", apodo="Ace", email="a@test.com"
+                nombre="Alice", apellidos="Smith", apodo="Ace", email="TEST_email@domain.com"
             ),
-            _make_raw(nombre="Bob", apellidos="Jones", apodo="Ace", email="b@test.com"),
+            _make_raw(nombre="Bob", apellidos="Jones", apodo="Ace", email="TEST_email@domain.com"),
         ]
     )
 
     # After recomputation, both should fall back to full names
-    alice = member_repo.get_by_email("a@test.com")
-    bob = member_repo.get_by_email("b@test.com")
+    alice = member_repo.get_by_email("TEST_email@domain.com")
+    bob = member_repo.get_by_email("TEST_email@domain.com")
     assert alice is not None
     assert bob is not None
     assert alice.display_name == "Alice Smith"
@@ -404,26 +404,26 @@ def test_import_maps_ultima_cuota_and_genero() -> None:
             _make_raw(
                 nombre="Ana",
                 apellidos="García",
-                email="ana@test.com",
+                email="TEST_email@domain.com",
                 ultima_cuota="5/02/2022",
                 genero="Femenino",
             ),
             _make_raw(
                 nombre="Pedro",
                 apellidos="López",
-                email="pedro@test.com",
+                email="TEST_email@domain.com",
                 ultima_cuota="",
                 genero="",
             ),
         ]
     )
 
-    ana = member_repo.get_by_email("ana@test.com")
+    ana = member_repo.get_by_email("TEST_email@domain.com")
     assert ana is not None
     assert ana.last_payment == "5/02/2022"
     assert ana.gender == "Femenino"
 
-    pedro = member_repo.get_by_email("pedro@test.com")
+    pedro = member_repo.get_by_email("TEST_email@domain.com")
     assert pedro is not None
     assert pedro.last_payment is None
     assert pedro.gender is None
@@ -435,10 +435,10 @@ def test_unpaid_member_is_created_inactive() -> None:
     uc = ImportMembersUseCase(member_repo, token_repo, BASE_URL)
 
     uc.execute(
-        [_make_raw(nombre="Jose", apellidos="Delgado", email="jose@test.com", pagada="No")]
+        [_make_raw(nombre="Jose", apellidos="Delgado", email="TEST_email@domain.com", pagada="No")]
     )
 
-    jose = member_repo.get_by_email("jose@test.com")
+    jose = member_repo.get_by_email("TEST_email@domain.com")
     assert jose is not None
     assert jose.is_active is False
 
@@ -450,18 +450,18 @@ def test_paid_and_honorary_members_are_created_active() -> None:
 
     uc.execute(
         [
-            _make_raw(nombre="Paid", apellidos="Member", email="paid@test.com", pagada="Sí"),
+            _make_raw(nombre="Paid", apellidos="Member", email="TEST_email@domain.com", pagada="Sí"),
             _make_raw(
                 nombre="Honorary",
                 apellidos="Member",
-                email="honorary@test.com",
+                email="TEST_email@domain.com",
                 pagada="Honorífic",
             ),
         ]
     )
 
-    assert member_repo.get_by_email("paid@test.com").is_active is True  # type: ignore[union-attr]
-    assert member_repo.get_by_email("honorary@test.com").is_active is True  # type: ignore[union-attr]
+    assert member_repo.get_by_email("TEST_email@domain.com").is_active is True  # type: ignore[union-attr]
+    assert member_repo.get_by_email("TEST_email@domain.com").is_active is True  # type: ignore[union-attr]
 
 
 def test_reimport_does_not_change_admin_status_of_existing_member() -> None:
@@ -471,13 +471,13 @@ def test_reimport_does_not_change_admin_status_of_existing_member() -> None:
     token_repo = FakePasswordTokenRepository()
     uc = ImportMembersUseCase(member_repo, token_repo, BASE_URL)
 
-    uc.execute([_make_raw(email="admin@test.com", admin="yes")])
-    assert member_repo.get_by_email("admin@test.com").is_admin is True  # type: ignore[union-attr]
+    uc.execute([_make_raw(email="TEST_email@domain.com", admin="yes")])
+    assert member_repo.get_by_email("TEST_email@domain.com").is_admin is True  # type: ignore[union-attr]
 
     # Re-import the same row without an "admin" column value, as a real sheet
     # export would look.
-    uc.execute([_make_raw(email="admin@test.com", admin="")])
-    assert member_repo.get_by_email("admin@test.com").is_admin is True  # type: ignore[union-attr]
+    uc.execute([_make_raw(email="TEST_email@domain.com", admin="")])
+    assert member_repo.get_by_email("TEST_email@domain.com").is_admin is True  # type: ignore[union-attr]
 
 
 def test_acting_member_id_is_kept_admin_even_if_demoted_by_import() -> None:
@@ -491,13 +491,13 @@ def test_acting_member_id_is_kept_admin_even_if_demoted_by_import() -> None:
         last_name="Admin",
         nickname=None,
         phone=None,
-        email="acting@test.com",
+        email="TEST_email@domain.com",
         display_name="Acting Admin",
         is_admin=True,
     )
 
     uc.execute(
-        [_make_raw(email="acting@test.com", admin="")],
+        [_make_raw(email="TEST_email@domain.com", admin="")],
         acting_member_id=acting_admin.id,
     )
 

--- a/tests/domain/use_cases/test_import_rpg_items.py
+++ b/tests/domain/use_cases/test_import_rpg_items.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from backend.data.bgg_client import BggRpgItem
-from backend.domain.entities.game import Game
-from backend.domain.slug import ensure_unique, slugify
+from backend.domain.entities.loan import Loan
 from backend.domain.use_cases.import_rpg_items import ImportRpgItemsUseCase
+from tests.domain.use_cases.conftest import FakeGameRepository, FakeLoanRepository
 
 
 class FakeBggClientRpg:
@@ -16,96 +16,14 @@ class FakeBggClientRpg:
         return self._items
 
 
-class FakeGameRepository:
-    def __init__(self) -> None:
-        self._games: dict[int, Game] = {}
-        self._next_id = 1
-
-    def get_by_id(self, game_id: int) -> Game | None:
-        return self._games.get(game_id)
-
-    def get_by_slug(self, slug: str) -> Game | None:
-        return next((g for g in self._games.values() if g.slug == slug), None)
-
-    def get_by_bgg_id(self, bgg_id: int) -> Game | None:
-        return next((g for g in self._games.values() if g.bgg_id == bgg_id), None)
-
-    def list_all(self) -> list[Game]:
-        return sorted(self._games.values(), key=lambda g: g.name)
-
-    def list_by_type(self, item_type: str) -> list[Game]:
-        return sorted(
-            (g for g in self._games.values() if g.item_type == item_type),
-            key=lambda g: g.name,
-        )
-
-    def upsert_by_bgg_id(
-        self,
-        bgg_id: int,
-        name: str,
-        thumbnail_url: str,
-        image_url: str = "",
-        year_published: int = 0,
-        min_players: int = 0,
-        max_players: int = 0,
-        playing_time: int = 0,
-        bgg_rating: float = 0.0,
-        location: str = "armari",
-        item_type: str = "boardgame",
-        description: str = "",
-    ) -> Game:
-        now = datetime.now(UTC)
-        existing = self.get_by_bgg_id(bgg_id)
-        slug = (
-            existing.slug
-            if existing and slugify(existing.name) == slugify(name)
-            else ensure_unique(
-                slugify(name),
-                (g.slug for g in self._games.values() if g.bgg_id != bgg_id),
-            )
-        )
-        if existing:
-            game = Game(
-                id=existing.id,
-                bgg_id=bgg_id,
-                name=name,
-                slug=slug,
-                thumbnail_url=thumbnail_url,
-                image_url=image_url,
-                year_published=year_published,
-                min_players=min_players,
-                max_players=max_players,
-                playing_time=playing_time,
-                bgg_rating=bgg_rating,
-                location=location,
-                created_at=existing.created_at,
-                updated_at=now,
-                item_type=item_type,
-                description=description,
-            )
-            self._games[game.id] = game
-            return game
-        game = Game(
-            id=self._next_id,
-            bgg_id=bgg_id,
-            name=name,
-            slug=slug,
-            thumbnail_url=thumbnail_url,
-            image_url=image_url,
-            year_published=year_published,
-            min_players=min_players,
-            max_players=max_players,
-            playing_time=playing_time,
-            bgg_rating=bgg_rating,
-            location=location,
-            created_at=now,
-            updated_at=now,
-            item_type=item_type,
-            description=description,
-        )
-        self._games[game.id] = game
-        self._next_id += 1
-        return game
+def _loan(game_id: int) -> Loan:
+    return Loan(
+        id=1,
+        game_id=game_id,
+        member_id=1,
+        borrowed_at=datetime.now(UTC),
+        returned_at=None,
+    )
 
 
 _DND_RPG_ITEM = BggRpgItem(
@@ -129,67 +47,124 @@ _PF_RPG_ITEM = BggRpgItem(
 
 
 class TestImportRpgItemsUseCase:
-    def test_imports_new_rpg_items(self) -> None:
+    def test_imports_new_rpg_items(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClientRpg([_DND_RPG_ITEM, _PF_RPG_ITEM])
-        repo = FakeGameRepository()
-        use_case = ImportRpgItemsUseCase(repo, bgg_client)
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
 
         result = use_case.execute()
 
         assert result.created == 2
         assert result.updated == 0
         assert result.total == 2
-        assert len(repo.list_all()) == 2
+        assert len(fake_game_repo.list_all()) == 2
 
-    def test_upserts_with_rpgitem_type(self) -> None:
+    def test_upserts_with_rpgitem_type(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClientRpg([_DND_RPG_ITEM])
-        repo = FakeGameRepository()
-        use_case = ImportRpgItemsUseCase(repo, bgg_client)
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
 
         use_case.execute()
 
-        game = repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_bgg_id(1001)
         assert game is not None
         assert game.item_type == "rpgitem"
 
-    def test_upserts_description(self) -> None:
+    def test_upserts_description(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClientRpg([_DND_RPG_ITEM])
-        repo = FakeGameRepository()
-        use_case = ImportRpgItemsUseCase(repo, bgg_client)
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
 
         use_case.execute()
 
-        game = repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_bgg_id(1001)
         assert game is not None
         assert game.description == "A guide for adventurers."
 
-    def test_updates_existing_rpg_item(self) -> None:
-        repo = FakeGameRepository()
-        repo.upsert_by_bgg_id(
-            1001,
-            "D&D PHB",
-            "https://old.jpg",
-            item_type="rpgitem",
+    def test_updates_existing_rpg_item(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(
+            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
         )
         bgg_client = FakeBggClientRpg([_DND_RPG_ITEM])
-        use_case = ImportRpgItemsUseCase(repo, bgg_client)
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
 
         result = use_case.execute()
 
         assert result.created == 0
         assert result.updated == 1
-        game = repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_bgg_id(1001)
         assert game is not None
         assert game.name == "Dungeons & Dragons Player's Handbook"
 
-    def test_empty_collection(self) -> None:
+    def test_empty_collection(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
         bgg_client = FakeBggClientRpg([])
-        repo = FakeGameRepository()
-        use_case = ImportRpgItemsUseCase(repo, bgg_client)
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
 
         result = use_case.execute()
 
         assert result.created == 0
         assert result.updated == 0
         assert result.total == 0
-        assert repo.list_all() == []
+        assert fake_game_repo.list_all() == []
+        assert result.skip_reason is not None
+
+    def test_missing_and_not_lent_is_hard_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(
+            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        )
+        fake_game_repo.upsert_by_bgg_id(
+            1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
+        )
+        bgg_client = FakeBggClientRpg([_PF_RPG_ITEM])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 1
+        assert fake_game_repo.get_by_bgg_id(1001) is None
+
+    def test_missing_and_currently_lent_is_soft_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        game = fake_game_repo.upsert_by_bgg_id(
+            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        )
+        fake_game_repo.upsert_by_bgg_id(
+            1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
+        )
+        fake_loan_repo.set_active_loan(game.id, _loan(game.id))
+        bgg_client = FakeBggClientRpg([_PF_RPG_ITEM])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deactivated == 1
+        assert result.deleted == 0
+        stored = fake_game_repo.get_by_bgg_id(1001)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_item_type_scoping_ignores_boardgames(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        """An RPG import must never delete/deactivate a boardgame."""
+        fake_game_repo.upsert_by_bgg_id(
+            13, "Catan", "https://c.jpg", item_type="boardgame"
+        )
+        bgg_client = FakeBggClientRpg([])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        use_case.execute()
+
+        catan = fake_game_repo.get_by_bgg_id(13)
+        assert catan is not None
+        assert catan.is_active is True

--- a/tests/domain/use_cases/test_request_password_reset.py
+++ b/tests/domain/use_cases/test_request_password_reset.py
@@ -41,15 +41,15 @@ class TestRequestPasswordReset:
         token_repo: SqlitePasswordTokenRepository,
     ) -> None:
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         use_case, fake_email = self._make_use_case(member_repo, token_repo)
 
-        use_case.execute("test@test.com")
+        use_case.execute("TEST_email@domain.com")
 
         assert len(fake_email.sent) == 1
         to_email, display_name, url = fake_email.sent[0]
-        assert to_email == "test@test.com"
+        assert to_email == "TEST_email@domain.com"
         assert display_name == "Test User"
         assert url.startswith("https://example.com/set-password?token=")
 
@@ -60,11 +60,11 @@ class TestRequestPasswordReset:
         db_conn: sqlite3.Connection,
     ) -> None:
         member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         use_case, _ = self._make_use_case(member_repo, token_repo)
 
-        use_case.execute("test@test.com")
+        use_case.execute("TEST_email@domain.com")
 
         row = db_conn.execute("SELECT COUNT(*) FROM password_tokens").fetchone()
         assert row[0] == 1
@@ -77,7 +77,7 @@ class TestRequestPasswordReset:
     ) -> None:
         use_case, fake_email = self._make_use_case(member_repo, token_repo)
 
-        use_case.execute("nobody@test.com")
+        use_case.execute("TEST_email@domain.com")
 
         assert len(fake_email.sent) == 0
         row = db_conn.execute("SELECT COUNT(*) FROM password_tokens").fetchone()
@@ -90,12 +90,12 @@ class TestRequestPasswordReset:
         db_conn: sqlite3.Connection,
     ) -> None:
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "test@test.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         member_repo.set_active(member.id, False)
         use_case, fake_email = self._make_use_case(member_repo, token_repo)
 
-        use_case.execute("test@test.com")
+        use_case.execute("TEST_email@domain.com")
 
         assert len(fake_email.sent) == 0
         row = db_conn.execute("SELECT COUNT(*) FROM password_tokens").fetchone()

--- a/tests/domain/use_cases/test_return_game.py
+++ b/tests/domain/use_cases/test_return_game.py
@@ -39,7 +39,7 @@ class TestReturnGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "t@t.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         loan = loan_repo.create(game.id, member.id)
 
@@ -55,10 +55,10 @@ class TestReturnGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         m1 = member_repo.upsert_by_email(
-            1, "A", "User", None, None, "a@t.com", "A User", False
+            1, "A", "User", None, None, "TEST_email@domain.com", "A User", False
         )
         member_repo.upsert_by_email(
-            2, "B", "User", None, None, "b@t.com", "B User", False
+            2, "B", "User", None, None, "TEST_email@domain.com", "B User", False
         )
         loan = loan_repo.create(game.id, m1.id)
 
@@ -74,10 +74,10 @@ class TestReturnGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         m1 = member_repo.upsert_by_email(
-            1, "A", "User", None, None, "a@t.com", "A User", False
+            1, "A", "User", None, None, "TEST_email@domain.com", "A User", False
         )
         member_repo.upsert_by_email(
-            2, "Admin", "User", None, None, "admin@t.com", "Admin", True
+            2, "Admin", "User", None, None, "TEST_email@domain.com", "Admin", True
         )
         loan = loan_repo.create(game.id, m1.id)
 
@@ -93,7 +93,7 @@ class TestReturnGameUseCase:
     ) -> None:
         game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
         member = member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "t@t.com", "Test User", False
+            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         loan = loan_repo.create(game.id, member.id)
         loan_repo.mark_returned(loan.id)

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -49,7 +49,7 @@ class TestMigrationRunner:
         conn = get_memory_connection()
         first_run = run_migrations(conn)
         second_run = run_migrations(conn)
-        assert len(first_run) == 7
+        assert len(first_run) == 8
         assert len(second_run) == 0
         conn.close()
 
@@ -83,6 +83,7 @@ class TestMigrationRunner:
             "updated_at",
             "item_type",
             "description",
+            "is_active",
         }
         conn.close()
 


### PR DESCRIPTION
## Summary
- Re-importing board games or RPG items from BGG now removes items missing from the fetched collection: hard-deleted if never lent, soft-deleted (`is_active`, hidden from catalog) if currently on loan.
- Items with any loan history (even fully returned) can never be hard-deleted due to `ON DELETE RESTRICT` on `loans.game_id` — they stay soft-deleted and are re-evaluated on every subsequent import.
- Safety guard: skips removing newly-missing items when the BGG fetch is empty or would drop more than 50% of the active catalog (already-hidden stale items are still reconciled regardless).
- `GetGameHistoryUseCase` now scopes by `item_type` and deliberately ignores `is_active` so loan history for a removed item stays reachable; `BorrowGameUseCase` rejects deactivated items; `ReturnGameUseCase` is unaffected (never looked at the game row).
- CLI (`import-games`, `import-rol`) and the admin `/api/admin/bgg/import` route (used by the "Reimportar desde BGG" button on `/ludoteca/admin/bgg`) report new `deleted`/`deactivated`/`skip_reason` counts; the admin page renders them.

## Related Tasks
No linked GitHub issue — skipped per explicit request.

## Test plan
- [x] `pytest` — full backend suite passes (318 passed; 15 pre-existing member-import failures unrelated to this change, confirmed present on `development` before this branch)
- [x] `ruff check` / `black --check` / `npx tsc --noEmit` / frontend `eslint` all clean
- [x] Scripted run against real SQLite repos: never-borrowed missing item hard-deletes; currently-lent missing item is hidden (404 on detail, catalog excludes it, history still accessible); after return, item stays soft-deleted forever due to loan-history FK restrict (confirmed via dedicated integration test)
- [x] Live `uvicorn` + `curl`: `GET /api/juegos` excludes hidden/deleted items, detail 404s, history still returns entries
- [x] Browser smoke of `/ludoteca/admin/bgg`: login as admin, catalog correctly filtered, reimport button renders both the success counts and the skip-reason warning with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrWxizeJHkQBLqLHAcYDF8