### PR TITLE
fix(bgg): resolve catalog images to BGG's medium-size preset

### DIFF
--- a/backend/data/bgg_client.py
+++ b/backend/data/bgg_client.py
@@ -57,9 +57,13 @@ _BROWSER_HEADERS = {
 }
 
 
+_IMAGE_ID_PATTERN = re.compile(r"pic(\d+)\.")
+
+
 class BggClient:
     XML_API_URL = "https://boardgamegeek.com/xmlapi2/collection"
     THING_API_URL = "https://boardgamegeek.com/xmlapi2/thing"
+    IMAGES_API_URL = "https://api.geekdo.com/api/images"
     WEB_URL = "https://boardgamegeek.com/collection/user"
     MAX_RETRIES = 5
     INITIAL_BACKOFF = 5.0
@@ -175,6 +179,34 @@ class BggClient:
 
         return games
 
+    def _resolve_display_image_url(self, image_url: str) -> str:
+        """Resolve a BGG image URL to the "medium" (fit-in 500x500) variant.
+
+        BGG's own <image>/<thumbnail> XML fields only offer the full-resolution
+        original or a tiny 200x150 crop — nothing sized for a catalog card. The
+        geekdo images API exposes a "medium" preset that's much closer to what
+        we display, so we look it up by image id and fall back to the original
+        URL if that lookup fails for any reason.
+        """
+        match = _IMAGE_ID_PATTERN.search(image_url)
+        if not match:
+            return image_url
+
+        try:
+            response = httpx.get(
+                f"{self.IMAGES_API_URL}/{match.group(1)}", timeout=15.0
+            )
+        except httpx.HTTPError:
+            return image_url
+
+        if response.status_code != 200:
+            return image_url
+
+        try:
+            return response.json()["images"]["medium"]["url"] or image_url
+        except (KeyError, TypeError, ValueError):
+            return image_url
+
     def fetch_details(
         self, bgg_ids: list[int], batch_size: int = 20
     ) -> dict[int, BggGameDetails]:
@@ -205,6 +237,8 @@ class BggClient:
                 image_url = (
                     image_el.text if image_el is not None and image_el.text else ""
                 )
+                if image_url:
+                    image_url = self._resolve_display_image_url(image_url)
                 thumb_el = item.find("thumbnail")
                 thumbnail_url = (
                     thumb_el.text if thumb_el is not None and thumb_el.text else ""

--- a/tests/data/test_bgg_client.py
+++ b/tests/data/test_bgg_client.py
@@ -2,6 +2,136 @@ from __future__ import annotations
 
 from backend.data.bgg_client import BggClient
 
+THING_XML = """<?xml version="1.0" encoding="utf-8"?>
+<items>
+    <item type="boardgame" id="13">
+        <thumbnail>https://cf.geekdo-images.com/catan_t.png</thumbnail>
+        <image>https://cf.geekdo-images.com/abc__original/img/sig/0x0/filters:format(jpeg)/pic3479879.jpg</image>
+        <minplayers value="3"/>
+        <maxplayers value="4"/>
+        <playingtime value="90"/>
+        <statistics page="1">
+            <ratings>
+                <average value="7.20"/>
+            </ratings>
+        </statistics>
+    </item>
+</items>"""
+
+IMAGES_API_RESPONSE = {
+    "images": {
+        "medium": {
+            "url": "https://cf.geekdo-images.com/abc__medium/img/sig2/fit-in/500x500/filters:no_upscale():strip_icc()/pic3479879.jpg",
+        }
+    }
+}
+
+
+class _FakeResponse:
+    def __init__(
+        self, status_code: int = 200, text: str = "", json_body: object = None
+    ) -> None:
+        self.status_code = status_code
+        self.text = text
+        self._json_body = json_body
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> object:
+        return self._json_body
+
+
+class TestBggClientResolveDisplayImageUrl:
+    def test_resolves_to_medium_variant(self, monkeypatch: object) -> None:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda *_a, **_kw: _FakeResponse(json_body=IMAGES_API_RESPONSE),
+        )
+        client = BggClient("test")
+        result = client._resolve_display_image_url(
+            "https://cf.geekdo-images.com/abc__original/img/sig/0x0/"
+            "filters:format(jpeg)/pic3479879.jpg"
+        )
+        assert result == IMAGES_API_RESPONSE["images"]["medium"]["url"]
+
+    def test_falls_back_to_original_when_id_missing(self) -> None:
+        client = BggClient("test")
+        url = "https://cf.geekdo-images.com/no-id-here.jpg"
+        assert client._resolve_display_image_url(url) == url
+
+    def test_falls_back_to_original_on_non_200(self, monkeypatch: object) -> None:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx, "get", lambda *_a, **_kw: _FakeResponse(status_code=404)
+        )
+        client = BggClient("test")
+        url = "https://cf.geekdo-images.com/x/pic3479879.jpg"
+        assert client._resolve_display_image_url(url) == url
+
+    def test_falls_back_to_original_on_malformed_json(
+        self, monkeypatch: object
+    ) -> None:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda *_a, **_kw: _FakeResponse(json_body={"unexpected": "shape"}),
+        )
+        client = BggClient("test")
+        url = "https://cf.geekdo-images.com/x/pic3479879.jpg"
+        assert client._resolve_display_image_url(url) == url
+
+    def test_falls_back_to_original_on_network_error(self, monkeypatch: object) -> None:
+        import httpx
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise httpx.HTTPError("boom")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+        client = BggClient("test")
+        url = "https://cf.geekdo-images.com/x/pic3479879.jpg"
+        assert client._resolve_display_image_url(url) == url
+
+
+class TestBggClientFetchDetails:
+    def test_resolves_image_url_to_medium_variant(self, monkeypatch: object) -> None:
+        import httpx
+
+        responses = iter(
+            [
+                _FakeResponse(text=THING_XML),
+                _FakeResponse(json_body=IMAGES_API_RESPONSE),
+            ]
+        )
+        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: next(responses))
+        client = BggClient("test")
+        details = client.fetch_details([13])
+        assert details[13].image_url == IMAGES_API_RESPONSE["images"]["medium"]["url"]
+        assert details[13].thumbnail_url == "https://cf.geekdo-images.com/catan_t.png"
+        assert details[13].min_players == 3
+        assert details[13].max_players == 4
+        assert details[13].playing_time == 90
+        assert details[13].bgg_rating == 7.2
+
+    def test_skips_resolution_when_image_missing(self, monkeypatch: object) -> None:
+        import httpx
+
+        xml = """<?xml version="1.0"?>
+        <items>
+            <item type="boardgame" id="1"></item>
+        </items>"""
+        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: _FakeResponse(text=xml))
+        client = BggClient("test")
+        details = client.fetch_details([1])
+        assert details[1].image_url == ""
+
+
 SAMPLE_XML = """<?xml version="1.0" encoding="utf-8"?>
 <items totalitems="3" termsofuse="https://boardgamegeek.com/xmlapi/termsofuse" pubdate="Mon, 31 Mar 2026 00:00:00 +0000">
     <item objecttype="thing" objectid="13" subtype="boardgame" collid="1001">


### PR DESCRIPTION
## Summary
- The board-game catalog at `/ludoteca/juegos-de-mesa` currently renders images from BGG's `<thumbnail>` field (a 200x150 crop, blurry when upscaled to the 252px card) because `image_url` was never populated for board games during enrichment, and the raw BGG `<image>` field is the full-resolution original (measured 3383x4500px / ~1.7MB for one game) — too heavy to use directly.
- BGG's signed CDN URLs can't be resized by editing query params (confirmed: changing `fit-in/200x150` to another size on a signed URL returns 400), but `api.geekdo.com/api/images/{id}` exposes a "medium" preset (fit-in 500x500, no upscale) that closely matches the display size, including at 2x/retina.
- `BggClient.fetch_details` now resolves the BGG `<image>` URL through that medium preset, falling back to the raw original URL if the lookup fails for any reason (network error, non-200, unexpected JSON shape).
- No frontend change needed — `GameCard` already prefers `image_url` over `thumbnail_url`.

## Related Tasks
No GitHub issue for this change (explicitly waived).

## Test plan
- [x] `pytest tests/data/test_bgg_client.py` — 12 tests covering the new resolver (medium-variant resolution, and fallback on missing id / non-200 / malformed JSON / network error) and its integration into `fetch_details`
- [x] `pytest` (full suite) — 273 passed, 1 pre-existing unrelated failure (missing `content-mirror` fixture, not present in a fresh worktree), 1 skipped
- [x] `ruff check` / `black --check` on changed files
- [ ] Live verification requires running `refugio enrich-games` on the server (needs `BGG_BEARER_TOKEN`), which is an ops step outside this diff — not runnable from this environment (BGG's XML thing API returned 401 here even from a browser session, likely IP/auth gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DExEjJkGRNuQ37MbsK9x9c