### PR TITLE
feat(admin): include RPG items in BGG sync

### DIFF
--- a/backend/api/routes/bgg.py
+++ b/backend/api/routes/bgg.py
@@ -12,6 +12,7 @@ from backend.api.dependencies import CurrentMember, GameRepo, LoanRepo, _setting
 from backend.data.bgg_client import BggClient
 from backend.domain.entities.member import Member
 from backend.domain.use_cases.import_games import ImportGamesUseCase
+from backend.domain.use_cases.import_rpg_items import ImportRpgItemsUseCase
 
 router = APIRouter(prefix="/api/admin/bgg", tags=["admin", "bgg"])
 
@@ -32,13 +33,23 @@ class BggStatusResponse(BaseModel):
     last_imported_at: datetime | None
 
 
-class BggImportResponse(BaseModel):
+class BggImportStats(BaseModel):
     created: int
     updated: int
     total: int
     deleted: int
     deactivated: int
     skip_reason: str | None
+
+
+class BggCatalogOutcome(BaseModel):
+    result: BggImportStats | None
+    error: str | None
+
+
+class BggImportResponse(BaseModel):
+    boardgames: BggCatalogOutcome
+    rpg_items: BggCatalogOutcome
     last_imported_at: datetime | None
 
 
@@ -54,14 +65,49 @@ def import_games(
     bgg_client = BggClient(
         username="RefugioDelSatiro", bearer_token=_settings.bgg_bearer_token
     )
-    use_case = ImportGamesUseCase(game_repo, bgg_client, loan_repo)
-    result = use_case.execute()
+    boardgames_use_case = ImportGamesUseCase(game_repo, bgg_client, loan_repo)
+    rpg_items_use_case = ImportRpgItemsUseCase(game_repo, bgg_client, loan_repo)
+
+    try:
+        boardgames_result = boardgames_use_case.execute()
+        boardgames = BggCatalogOutcome(
+            result=BggImportStats(
+                created=boardgames_result.created,
+                updated=boardgames_result.updated,
+                total=boardgames_result.total,
+                deleted=boardgames_result.deleted,
+                deactivated=boardgames_result.deactivated,
+                skip_reason=boardgames_result.skip_reason,
+            ),
+            error=None,
+        )
+    except Exception:  # noqa: BLE001
+        boardgames = BggCatalogOutcome(
+            result=None,
+            error="No se han podido sincronizar los juegos de mesa.",
+        )
+
+    try:
+        rpg_items_result = rpg_items_use_case.execute()
+        rpg_items = BggCatalogOutcome(
+            result=BggImportStats(
+                created=rpg_items_result.created,
+                updated=rpg_items_result.updated,
+                total=rpg_items_result.total,
+                deleted=rpg_items_result.deleted,
+                deactivated=rpg_items_result.deactivated,
+                skip_reason=rpg_items_result.skip_reason,
+            ),
+            error=None,
+        )
+    except Exception:  # noqa: BLE001
+        rpg_items = BggCatalogOutcome(
+            result=None,
+            error="No se han podido sincronizar los juegos de rol.",
+        )
+
     return BggImportResponse(
-        created=result.created,
-        updated=result.updated,
-        total=result.total,
-        deleted=result.deleted,
-        deactivated=result.deactivated,
-        skip_reason=result.skip_reason,
+        boardgames=boardgames,
+        rpg_items=rpg_items,
         last_imported_at=game_repo.get_last_updated_at(),
     )

--- a/frontend/src/pages/AdminBggPage.css
+++ b/frontend/src/pages/AdminBggPage.css
@@ -1,58 +1,164 @@
 .admin-bgg-page {
   max-width: 960px;
   margin: 0 auto;
-  padding: 2rem 1.25rem;
+  padding: var(--space-xl) var(--space-md);
 }
 
 .admin-bgg-page header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-lg);
 }
 
 .admin-bgg-description {
-  color: var(--color-text-muted, #555);
-  font-size: 0.95rem;
+  max-width: 70ch;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   line-height: 1.5;
 }
 
 .admin-bgg-actions {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: var(--space-lg);
   flex-wrap: wrap;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-md);
 }
 
 .admin-bgg-status {
   display: grid;
   grid-template-columns: auto auto;
-  gap: 0.25rem 0.75rem;
+  gap: var(--space-xs) var(--space-md);
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-size-sm);
 }
 
 .admin-bgg-status dt {
-  color: #666;
+  color: var(--color-text-muted);
 }
 
 .admin-bgg-status dd {
   margin: 0;
-  font-family: "Source Code Pro", monospace;
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-medium);
+}
+
+.admin-bgg-error,
+.admin-bgg-catalog-error,
+.admin-bgg-warning {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+}
+
+.admin-bgg-error,
+.admin-bgg-catalog-error {
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-surface));
+  border: 1px solid var(--color-danger);
 }
 
 .admin-bgg-error {
-  padding: 0.75rem 1rem;
-  margin: 1rem 0;
-  background: #fff4f4;
-  border: 1px solid #be0000;
-  color: #be0000;
-  border-radius: 4px;
+  margin: var(--space-md) 0;
 }
 
-.admin-bgg-result {
-  padding: 0.75rem 1rem;
-  margin: 1rem 0;
-  background: #f4fff4;
-  border: 1px solid #2e7d32;
-  color: #2e7d32;
-  border-radius: 4px;
+.admin-bgg-results {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+}
+
+.admin-bgg-outcome {
+  min-width: 0;
+  padding: var(--space-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-top: var(--space-xs) solid var(--color-success);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.admin-bgg-outcome--failed {
+  border-top-color: var(--color-danger);
+}
+
+.admin-bgg-outcome-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.admin-bgg-outcome-heading h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.admin-bgg-outcome-status {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  text-align: right;
+}
+
+.admin-bgg-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.admin-bgg-stat {
+  padding: var(--space-sm);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-sm);
+}
+
+.admin-bgg-stat--total {
+  grid-column: 1 / -1;
+}
+
+.admin-bgg-stat dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.admin-bgg-stat dd {
+  margin: var(--space-xs) 0 0;
+  color: var(--color-text-heading);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.admin-bgg-catalog-error,
+.admin-bgg-warning {
+  margin: var(--space-md) 0 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.admin-bgg-warning {
+  color: var(--color-text-body);
+  background: color-mix(
+    in srgb,
+    var(--color-warning) 18%,
+    var(--color-surface)
+  );
+  border: 1px solid var(--color-warning);
+}
+
+@media (max-width: 680px) {
+  .admin-bgg-results {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-bgg-outcome-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .admin-bgg-outcome-status {
+    text-align: left;
+  }
 }

--- a/frontend/src/pages/AdminBggPage.test.tsx
+++ b/frontend/src/pages/AdminBggPage.test.tsx
@@ -1,0 +1,169 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminBggPage } from "./AdminBggPage";
+
+const useAuthMock = vi.fn();
+const apiFetchMock = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("../api/client", () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+const ADMIN = {
+  id: 1,
+  display_name: "Admin User",
+  email: "admin@example.invalid",
+  is_admin: true,
+};
+
+const COMBINED_SUCCESS = {
+  boardgames: {
+    result: {
+      created: 2,
+      updated: 3,
+      deleted: 4,
+      deactivated: 5,
+      total: 14,
+      skip_reason: null,
+    },
+    error: null,
+  },
+  rpg_items: {
+    result: {
+      created: 7,
+      updated: 8,
+      deleted: 9,
+      deactivated: 10,
+      total: 34,
+      skip_reason: null,
+    },
+    error: null,
+  },
+  last_imported_at: "2026-07-15T10:00:00Z",
+};
+
+const BOARDGAME_SKIP_WARNING =
+  "Se ha omitido la retirada de juegos de mesa por seguridad.";
+
+const PARTIAL_FAILURE = {
+  boardgames: {
+    result: {
+      created: 1,
+      updated: 2,
+      deleted: 0,
+      deactivated: 3,
+      total: 6,
+      skip_reason: BOARDGAME_SKIP_WARNING,
+    },
+    error: null,
+  },
+  rpg_items: {
+    result: null,
+    error: "No se han podido sincronizar los juegos de rol.",
+  },
+  last_imported_at: "2026-07-15T11:00:00Z",
+};
+
+const STAT_LABELS = {
+  created: "Nuevos",
+  updated: "Actualizados",
+  deleted: "Eliminados",
+  deactivated: "Ocultados",
+  total: "Total",
+} as const;
+
+function expectCatalogCounters(
+  catalogName: string,
+  counters: Readonly<Record<keyof typeof STAT_LABELS, number>>,
+): void {
+  const catalog = screen.getByRole("region", { name: catalogName });
+
+  Object.entries(STAT_LABELS).forEach(([key, label]) => {
+    const stat = within(catalog).getByText(label).closest(".admin-bgg-stat");
+    expect(stat).toHaveTextContent(
+      new RegExp(`${label}\\s*${counters[key as keyof typeof STAT_LABELS]}`),
+    );
+  });
+}
+
+async function startImport(): Promise<void> {
+  await waitFor(() => {
+    expect(apiFetchMock).toHaveBeenCalledWith("/admin/bgg/status");
+  });
+
+  const user = userEvent.setup();
+  await user.click(
+    screen.getByRole("button", { name: "Reimportar desde BGG" }),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthMock.mockReturnValue({ member: ADMIN, loading: false });
+  apiFetchMock.mockResolvedValueOnce({ last_imported_at: null });
+});
+
+describe("AdminBggPage catalog synchronization outcomes", () => {
+  it("renders separate concrete counters for successful board-game and RPG imports", async () => {
+    apiFetchMock.mockResolvedValueOnce(COMBINED_SUCCESS);
+    render(<AdminBggPage />);
+
+    await startImport();
+
+    await screen.findByRole("region", { name: "Juegos de mesa" });
+    expect(
+      screen.getByRole("heading", { name: "Juegos de mesa" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Juegos de rol" }),
+    ).toBeInTheDocument();
+    expectCatalogCounters("Juegos de mesa", {
+      created: 2,
+      updated: 3,
+      deleted: 4,
+      deactivated: 5,
+      total: 14,
+    });
+    expectCatalogCounters("Juegos de rol", {
+      created: 7,
+      updated: 8,
+      deleted: 9,
+      deactivated: 10,
+      total: 34,
+    });
+    expect(apiFetchMock).toHaveBeenNthCalledWith(2, "/admin/bgg/import", {
+      method: "POST",
+    });
+  });
+
+  it("keeps a board-game success and its warning visible beside an RPG failure", async () => {
+    apiFetchMock.mockResolvedValueOnce(PARTIAL_FAILURE);
+    render(<AdminBggPage />);
+
+    await startImport();
+
+    await screen.findByRole("region", { name: "Juegos de mesa" });
+    expectCatalogCounters("Juegos de mesa", {
+      created: 1,
+      updated: 2,
+      deleted: 0,
+      deactivated: 3,
+      total: 6,
+    });
+    expect(screen.getByText(BOARDGAME_SKIP_WARNING)).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("region", { name: "Juegos de rol" })).getByText(
+        "No se han podido sincronizar los juegos de rol.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No se ha podido reimportar desde BGG."),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/pages/AdminBggPage.tsx
+++ b/frontend/src/pages/AdminBggPage.tsx
@@ -8,14 +8,28 @@ type BggStatusResponse = {
   last_imported_at: string | null;
 };
 
-type BggImportResponse = {
+type CatalogImportResult = {
   created: number;
   updated: number;
   total: number;
   deleted: number;
   deactivated: number;
   skip_reason: string | null;
+};
+
+type CatalogImportOutcome =
+  | { result: CatalogImportResult; error: null }
+  | { result: null; error: string };
+
+type BggImportResponse = {
+  boardgames: CatalogImportOutcome;
+  rpg_items: CatalogImportOutcome;
   last_imported_at: string | null;
+};
+
+type CatalogOutcomeProps = {
+  title: string;
+  outcome: CatalogImportOutcome;
 };
 
 function formatDateTime(iso: string): string {
@@ -26,6 +40,64 @@ function formatDateTime(iso: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+function CatalogOutcome({ title, outcome }: CatalogOutcomeProps) {
+  const headingId = `admin-bgg-${title === "Juegos de mesa" ? "boardgames" : "rpg"}`;
+
+  return (
+    <section
+      className={`admin-bgg-outcome ${outcome.error ? "admin-bgg-outcome--failed" : ""}`}
+      aria-labelledby={headingId}
+    >
+      <div className="admin-bgg-outcome-heading">
+        <h2 id={headingId}>{title}</h2>
+        <span className="admin-bgg-outcome-status">
+          {outcome.error
+            ? "Sincronización fallida"
+            : "Sincronización completada"}
+        </span>
+      </div>
+
+      {outcome.result && (
+        <>
+          <dl className="admin-bgg-stats">
+            <div className="admin-bgg-stat">
+              <dt>Nuevos</dt>
+              <dd>{outcome.result.created}</dd>
+            </div>
+            <div className="admin-bgg-stat">
+              <dt>Actualizados</dt>
+              <dd>{outcome.result.updated}</dd>
+            </div>
+            <div className="admin-bgg-stat">
+              <dt>Eliminados</dt>
+              <dd>{outcome.result.deleted}</dd>
+            </div>
+            <div className="admin-bgg-stat">
+              <dt>Ocultados</dt>
+              <dd>{outcome.result.deactivated}</dd>
+            </div>
+            <div className="admin-bgg-stat admin-bgg-stat--total">
+              <dt>Total</dt>
+              <dd>{outcome.result.total}</dd>
+            </div>
+          </dl>
+          {outcome.result.skip_reason && (
+            <p className="admin-bgg-warning" role="alert">
+              {outcome.result.skip_reason}
+            </p>
+          )}
+        </>
+      )}
+
+      {outcome.error && (
+        <p className="admin-bgg-catalog-error" role="alert">
+          {outcome.error}
+        </p>
+      )}
+    </section>
+  );
 }
 
 export function AdminBggPage() {
@@ -40,7 +112,11 @@ export function AdminBggPage() {
       const res = await apiFetch<BggStatusResponse>("/admin/bgg/status");
       setLastImportedAt(res.last_imported_at);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "No se ha podido cargar el estado.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "No se ha podido cargar el estado.",
+      );
     }
   }, []);
 
@@ -60,7 +136,11 @@ export function AdminBggPage() {
       setResult(res);
       setLastImportedAt(res.last_imported_at);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "No se ha podido reimportar desde BGG.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "No se ha podido reimportar desde BGG.",
+      );
     } finally {
       setImporting(false);
     }
@@ -87,14 +167,18 @@ export function AdminBggPage() {
       <header>
         <h1>Datos BGG</h1>
         <p className="admin-bgg-description">
-          Reimporta la colección de juegos desde BoardGameGeek (BGG). Da de alta los
-          juegos nuevos y actualiza el nombre, la imagen y el año de publicación de
+          Sincroniza los juegos de mesa de BoardGameGeek y los juegos de rol de
+          RPGGeek. Se añadirán los títulos nuevos y se actualizarán los datos de
           los ya existentes.
         </p>
       </header>
 
       <section className="admin-bgg-actions">
-        <Button variant="primary" onClick={() => void handleImport()} disabled={importing}>
+        <Button
+          variant="primary"
+          onClick={() => void handleImport()}
+          disabled={importing}
+        >
           {importing ? "Importando…" : "Reimportar desde BGG"}
         </Button>
         <dl className="admin-bgg-status">
@@ -103,18 +187,20 @@ export function AdminBggPage() {
         </dl>
       </section>
 
-      {error && <div className="admin-bgg-error">{error}</div>}
-
-      {result && (
-        <p className="admin-bgg-result">
-          {result.created} nuevos, {result.updated} actualizados, {result.deleted}{" "}
-          eliminados, {result.deactivated} ocultados (prestados), {result.total} en
-          total.
-        </p>
+      {error && (
+        <div className="admin-bgg-error" role="alert">
+          {error}
+        </div>
       )}
 
-      {result?.skip_reason && (
-        <p className="admin-bgg-error">{result.skip_reason}</p>
+      {result && (
+        <div
+          className="admin-bgg-results"
+          aria-label="Resultado de la sincronización"
+        >
+          <CatalogOutcome title="Juegos de mesa" outcome={result.boardgames} />
+          <CatalogOutcome title="Juegos de rol" outcome={result.rpg_items} />
+        </div>
       )}
     </div>
   );

--- a/tests/api/test_bgg.py
+++ b/tests/api/test_bgg.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from backend.api.app import create_app
 from backend.api.auth import create_jwt
 from backend.api.dependencies import _settings, get_db_conn
-from backend.data.bgg_client import BggGame
+from backend.data.bgg_client import BggGame, BggRpgItem
 from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
 from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
 from backend.domain.entities.member import Member
@@ -96,17 +96,34 @@ class TestBggImport:
         assert response.status_code == 403
         conn.close()
 
-    def test_imports_owned_games_and_reports_counts(self) -> None:
+    def test_imports_owned_games_and_rpg_items_and_reports_counts(self) -> None:
         client, conn = _setup_client()
         member_repo = SqliteMemberRepository(conn)
+        game_repo = SqliteGameRepository(conn)
         member = _make_member(member_repo, is_admin=True)
 
-        with patch(
-            "backend.api.routes.bgg.BggClient.fetch_owned_games",
-            return_value=[
-                BggGame(13, "Catan", "https://c.jpg", 1995),
-                BggGame(230802, "Azul", "https://a.jpg", 2017),
-            ],
+        with (
+            patch(
+                "backend.api.routes.bgg.BggClient.fetch_owned_games",
+                return_value=[
+                    BggGame(13, "Catan", "https://c.jpg", 1995),
+                    BggGame(230802, "Azul", "https://a.jpg", 2017),
+                ],
+            ),
+            patch(
+                "backend.api.routes.bgg.BggClient.fetch_owned_rpg_items",
+                return_value=[
+                    BggRpgItem(
+                        bgg_id=1001,
+                        name="D&D Player's Handbook",
+                        thumbnail_url="https://dnd-thumb.jpg",
+                        image_url="https://dnd.jpg",
+                        year_published=2014,
+                        bgg_rating=8.2,
+                        description="Core rules",
+                    )
+                ],
+            ),
         ):
             response = client.post(
                 "/api/admin/bgg/import", headers=_auth_cookie(member)
@@ -114,11 +131,77 @@ class TestBggImport:
 
         assert response.status_code == 200
         body = response.json()
-        assert body["created"] == 2
-        assert body["updated"] == 0
-        assert body["total"] == 2
-        assert body["deleted"] == 0
-        assert body["deactivated"] == 0
-        assert body["skip_reason"] is None
+        assert set(body) == {"boardgames", "rpg_items", "last_imported_at"}
+        assert body["boardgames"] == {
+            "result": {
+                "created": 2,
+                "updated": 0,
+                "total": 2,
+                "deleted": 0,
+                "deactivated": 0,
+                "skip_reason": None,
+            },
+            "error": None,
+        }
+        assert body["rpg_items"] == {
+            "result": {
+                "created": 1,
+                "updated": 0,
+                "total": 1,
+                "deleted": 0,
+                "deactivated": 0,
+                "skip_reason": None,
+            },
+            "error": None,
+        }
         assert body["last_imported_at"] is not None
+        boardgame = game_repo.get_by_bgg_id(13)
+        rpg_item = game_repo.get_by_bgg_id(1001)
+        assert boardgame is not None
+        assert boardgame.item_type == "boardgame"
+        assert rpg_item is not None
+        assert rpg_item.item_type == "rpgitem"
+        conn.close()
+
+    def test_preserves_boardgame_result_when_rpg_import_fails(self) -> None:
+        client, conn = _setup_client()
+        member_repo = SqliteMemberRepository(conn)
+        game_repo = SqliteGameRepository(conn)
+        member = _make_member(member_repo, is_admin=True)
+
+        with (
+            patch(
+                "backend.api.routes.bgg.BggClient.fetch_owned_games",
+                return_value=[BggGame(13, "Catan", "https://c.jpg", 1995)],
+            ) as fetch_owned_games,
+            patch(
+                "backend.api.routes.bgg.BggClient.fetch_owned_rpg_items",
+                side_effect=RuntimeError("upstream secret details"),
+            ) as fetch_owned_rpg_items,
+        ):
+            response = client.post(
+                "/api/admin/bgg/import", headers=_auth_cookie(member)
+            )
+
+        assert response.status_code == 200
+        assert response.json()["boardgames"] == {
+            "result": {
+                "created": 1,
+                "updated": 0,
+                "total": 1,
+                "deleted": 0,
+                "deactivated": 0,
+                "skip_reason": None,
+            },
+            "error": None,
+        }
+        assert response.json()["rpg_items"] == {
+            "result": None,
+            "error": "No se han podido sincronizar los juegos de rol.",
+        }
+        fetch_owned_games.assert_called_once_with()
+        fetch_owned_rpg_items.assert_called_once_with()
+        persisted_game = game_repo.get_by_bgg_id(13)
+        assert persisted_game is not None
+        assert persisted_game.item_type == "boardgame"
         conn.close()


### PR DESCRIPTION
## Summary

- Run the existing board-game and RPG-item imports from the same admin action while preserving their separate reconciliation safeguards.
- Return a structured outcome for each catalog, so one failed import does not hide the other catalog's successful result.
- Show separate board-game and RPG counts, safety warnings, and failures on the admin page.
- Keep both CLI import commands and domain use cases unchanged.

## Test plan

- `pytest -q tests/api/test_bgg.py tests/domain/use_cases/test_import_games.py tests/domain/use_cases/test_import_rpg_items.py` (26 passed)
- `ruff check backend/api/routes/bgg.py tests/api/test_bgg.py`
- `black --check backend/api/routes/bgg.py tests/api/test_bgg.py`
- `npm test -- --run src/pages/AdminBggPage.test.tsx` (2 passed)
- `npm run typecheck`
- `npm run lint -- src/pages/AdminBggPage.tsx src/pages/AdminBggPage.test.tsx`
- `npm run build`

`mypy backend/api/routes/bgg.py` still reports four pre-existing errors from `backend/data/bgg_client.py`; it reports no errors in the changed route.

## Related Tasks

- Closes #102
