### PR TITLE
fix(bgg): key catalog identity on BGG's collection entry id, not objectid

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ than 50% of the current active catalog, that run skips removing
 newly-missing items (still applying updates and cleaning up already-hidden
 ones) and reports a warning instead.
 
+Catalog rows are identified by BGG's per-copy collection entry id
+(`bgg_collection_id`), not by BGG's `bgg_id` (objectid). BGG can list
+several distinct owned items — different names, images, editions — under
+one shared objectid (e.g. themed spin-offs BGG treats as versions of a
+single base game rather than giving each its own id); keying on the
+collection entry instead of the objectid keeps those as separate catalog
+rows instead of collapsing them into one. Rows imported before this
+existed adopt their collection id automatically on the next import.
+
 ## Tests
 
 ```bash

--- a/backend/cli/main.py
+++ b/backend/cli/main.py
@@ -166,17 +166,21 @@ def enrich_games() -> None:
         for game in games:
             if game.bgg_id in details:
                 d = details[game.bgg_id]
-                game_repo.upsert_by_bgg_id(
-                    bgg_id=game.bgg_id,
-                    name=game.name,
-                    thumbnail_url=d.thumbnail_url or game.thumbnail_url,
-                    image_url=d.image_url or game.image_url or game.thumbnail_url,
-                    year_published=game.year_published,
+                # Player count, playing time, and rating are legitimately
+                # shared per BGG's thing API (one page per bgg_id). Image and
+                # thumbnail are NOT: BGG's collection can list several
+                # distinct owned items under one bgg_id (see
+                # BggGame.collection_id), each with its own picture, already
+                # captured at import time — only fall back to the shared
+                # thing-API image when this row doesn't have one yet.
+                game_repo.update_details(
+                    game.id,
+                    thumbnail_url=game.thumbnail_url or d.thumbnail_url,
+                    image_url=game.image_url or d.image_url or game.thumbnail_url,
                     min_players=d.min_players,
                     max_players=d.max_players,
                     playing_time=d.playing_time,
                     bgg_rating=d.bgg_rating,
-                    location=game.location,
                 )
                 updated += 1
 

--- a/backend/data/bgg_client.py
+++ b/backend/data/bgg_client.py
@@ -15,6 +15,14 @@ class BggGame:
     name: str
     thumbnail_url: str
     year_published: int
+    collection_id: int | None = None
+    # BGG's per-copy collection entry id ("collid") — unique per owned item,
+    # unlike bgg_id/objectid, which BGG can share across distinct products
+    # (e.g. reskinned variants). None when scraped from HTML (no collid
+    # available there); the importer falls back to bgg_id-keyed matching.
+    image_url: str = ""
+    # Full-size image captured from this entry's own collection XML <image>,
+    # distinct per copy even when several copies share one objectid.
 
 
 @dataclass(frozen=True)
@@ -37,6 +45,7 @@ class BggRpgItem:
     year_published: int
     bgg_rating: float
     description: str
+    collection_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -133,7 +142,13 @@ class BggClient:
         return games
 
     def _parse_html_collection(self, html: str) -> list[BggGame]:
-        """Parse games from the BGG collection HTML table."""
+        """Parse games from the BGG collection HTML table.
+
+        No per-copy collection entry id is available from this page, so
+        ``collection_id`` stays ``None`` — the importer degrades to
+        bgg_id-keyed matching for this fallback path, same as before
+        collection-id-based identity was introduced.
+        """
         games: list[BggGame] = []
 
         # Find all rows with game links: /boardgame/12345/game-name
@@ -248,23 +263,22 @@ class BggClient:
     def _parse_xml_collection(self, xml_text: str) -> list[BggGame]:
         root = ET.fromstring(xml_text)
 
+        def _text(item: ET.Element, tag: str) -> str:
+            el = item.find(tag)
+            return el.text if el is not None and el.text else ""
+
         return [
             BggGame(
                 bgg_id=int(item.get("objectid", "0")),
-                name=(
-                    item.find("name").text  # type: ignore[union-attr]
-                    if item.find("name") is not None and item.find("name").text  # type: ignore[union-attr]
-                    else "Unknown"
+                collection_id=(
+                    int(item.get("collid")) if item.get("collid") is not None else None
                 ),
-                thumbnail_url=(
-                    item.find("thumbnail").text  # type: ignore[union-attr]
-                    if item.find("thumbnail") is not None and item.find("thumbnail").text  # type: ignore[union-attr]
-                    else ""
-                ),
+                name=_text(item, "name") or "Unknown",
+                thumbnail_url=_text(item, "thumbnail"),
+                image_url=_text(item, "image"),
                 year_published=(
-                    int(item.find("yearpublished").text)  # type: ignore[arg-type, union-attr]
-                    if item.find("yearpublished") is not None
-                    and item.find("yearpublished").text  # type: ignore[union-attr]
+                    int(_text(item, "yearpublished"))
+                    if _text(item, "yearpublished")
                     else 0
                 ),
             )
@@ -283,14 +297,25 @@ class BggClient:
         return [
             BggRpgItem(
                 bgg_id=item.bgg_id,
+                collection_id=item.collection_id,
                 name=item.name,
+                # Prefer this entry's own image/thumbnail (per copy, from the
+                # collection XML) over the shared thing-API details, which
+                # BGG can pool across several distinct owned items sharing
+                # one bgg_id (see BggGame.collection_id).
                 thumbnail_url=(
-                    details[item.bgg_id].thumbnail_url
-                    if item.bgg_id in details
-                    else item.thumbnail_url
+                    item.thumbnail_url
+                    or (
+                        details[item.bgg_id].thumbnail_url
+                        if item.bgg_id in details
+                        else ""
+                    )
                 ),
                 image_url=(
-                    details[item.bgg_id].image_url if item.bgg_id in details else ""
+                    item.image_url
+                    or (
+                        details[item.bgg_id].image_url if item.bgg_id in details else ""
+                    )
                 ),
                 year_published=(
                     details[item.bgg_id].year_published

--- a/backend/data/repositories/sqlite_game_repository.py
+++ b/backend/data/repositories/sqlite_game_repository.py
@@ -28,6 +28,11 @@ def _row_to_game(row: sqlite3.Row) -> Game:
         item_type=row["item_type"] if "item_type" in keys else "boardgame",
         description=row["description"] if "description" in keys else "",
         is_active=bool(row["is_active"]) if "is_active" in keys else True,
+        bgg_collection_id=(
+            row["bgg_collection_id"]
+            if "bgg_collection_id" in keys and row["bgg_collection_id"] is not None
+            else None
+        ),
     )
 
 
@@ -53,6 +58,12 @@ class SqliteGameRepository:
         ).fetchone()
         return _row_to_game(row) if row else None
 
+    def get_by_collection_id(self, bgg_collection_id: int) -> Game | None:
+        row = self._conn.execute(
+            "SELECT * FROM games WHERE bgg_collection_id = ?", (bgg_collection_id,)
+        ).fetchone()
+        return _row_to_game(row) if row else None
+
     def list_all(self) -> list[Game]:
         rows = self._conn.execute("SELECT * FROM games ORDER BY name").fetchall()
         return [_row_to_game(row) for row in rows]
@@ -70,48 +81,53 @@ class SqliteGameRepository:
         ).fetchall()
         return [_row_to_game(row) for row in rows]
 
-    def deactivate_by_bgg_ids(self, bgg_ids: Collection[int]) -> int:
-        if not bgg_ids:
+    def deactivate_by_collection_ids(self, collection_ids: Collection[int]) -> int:
+        if not collection_ids:
             return 0
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        placeholders = ",".join("?" for _ in bgg_ids)
+        placeholders = ",".join("?" for _ in collection_ids)
         cursor = self._conn.execute(
             f"UPDATE games SET is_active = 0, updated_at = ? "
-            f"WHERE bgg_id IN ({placeholders}) AND is_active = 1",
-            (now, *bgg_ids),
+            f"WHERE bgg_collection_id IN ({placeholders}) AND is_active = 1",
+            (now, *collection_ids),
         )
         self._conn.commit()
         return cursor.rowcount
 
-    def delete_by_bgg_ids(
-        self, bgg_ids: Collection[int]
+    def delete_by_collection_ids(
+        self, collection_ids: Collection[int]
     ) -> tuple[frozenset[int], frozenset[int]]:
         deleted: set[int] = set()
         blocked: set[int] = set()
-        for bgg_id in bgg_ids:
+        for collection_id in collection_ids:
             try:
                 cursor = self._conn.execute(
-                    "DELETE FROM games WHERE bgg_id = ?", (bgg_id,)
+                    "DELETE FROM games WHERE bgg_collection_id = ?", (collection_id,)
                 )
                 self._conn.commit()
                 if cursor.rowcount:
-                    deleted.add(bgg_id)
+                    deleted.add(collection_id)
             except sqlite3.IntegrityError:
-                blocked.add(bgg_id)
+                blocked.add(collection_id)
         return frozenset(deleted), frozenset(blocked)
 
     def get_last_updated_at(self) -> datetime | None:
         row = self._conn.execute("SELECT MAX(updated_at) AS last FROM games").fetchone()
         return datetime.fromisoformat(row["last"]) if row and row["last"] else None
 
-    def _slug_for_upsert(self, bgg_id: int, name: str) -> str:
-        existing = self.get_by_bgg_id(bgg_id)
-        if existing is not None and slugify(existing.name) == slugify(name):
-            return existing.slug
+    def _slug_for_upsert(
+        self, existing_id: int | None, existing_name: str | None, name: str
+    ) -> str:
+        if existing_id is not None and slugify(existing_name or "") == slugify(name):
+            row = self._conn.execute(
+                "SELECT slug FROM games WHERE id = ?", (existing_id,)
+            ).fetchone()
+            return row["slug"]
         base = slugify(name)
+        excluded_id = existing_id if existing_id is not None else -1
         taken_rows = self._conn.execute(
-            "SELECT slug FROM games WHERE slug != '' AND bgg_id != ?",
-            (bgg_id,),
+            "SELECT slug FROM games WHERE slug != '' AND id != ?",
+            (excluded_id,),
         ).fetchall()
         return ensure_unique(base, (row["slug"] for row in taken_rows))
 
@@ -130,52 +146,167 @@ class SqliteGameRepository:
         item_type: str = "boardgame",
         description: str = "",
     ) -> Game:
+        """Legacy path for the JSON-seed import, which has no collection_id."""
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        slug = self._slug_for_upsert(bgg_id, name)
+        existing = self.get_by_bgg_id(bgg_id)
+        slug = self._slug_for_upsert(
+            existing.id if existing else None,
+            existing.name if existing else None,
+            name,
+        )
+        values = (
+            name,
+            slug,
+            thumbnail_url,
+            image_url,
+            year_published,
+            min_players,
+            max_players,
+            playing_time,
+            bgg_rating,
+            location,
+            item_type,
+            description,
+            now,
+        )
+        if existing is not None:
+            self._conn.execute(
+                """
+                UPDATE games SET
+                    name = ?, slug = ?, thumbnail_url = ?, image_url = ?,
+                    year_published = ?, min_players = ?, max_players = ?,
+                    playing_time = ?, bgg_rating = ?, location = ?,
+                    item_type = ?, description = ?, is_active = 1, updated_at = ?
+                WHERE id = ?
+                """,
+                (*values, existing.id),
+            )
+        else:
+            self._conn.execute(
+                """
+                INSERT INTO games (
+                    bgg_id, name, slug, thumbnail_url, image_url, year_published,
+                    min_players, max_players, playing_time, bgg_rating, location,
+                    item_type, description, is_active, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                """,
+                (bgg_id, *values, now),
+            )
+        self._conn.commit()
+        game = self.get_by_bgg_id(bgg_id)
+        assert game is not None
+        return game
+
+    def upsert_by_collection_id(
+        self,
+        bgg_collection_id: int,
+        bgg_id: int,
+        name: str,
+        thumbnail_url: str,
+        image_url: str = "",
+        year_published: int = 0,
+        min_players: int = 0,
+        max_players: int = 0,
+        playing_time: int = 0,
+        bgg_rating: float = 0.0,
+        location: str = "armari",
+        item_type: str = "boardgame",
+        description: str = "",
+    ) -> tuple[Game, bool]:
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        existing = self.get_by_collection_id(bgg_collection_id)
+        if existing is None:
+            legacy_row = self._conn.execute(
+                "SELECT * FROM games WHERE bgg_collection_id IS NULL AND bgg_id = ? "
+                "LIMIT 1",
+                (bgg_id,),
+            ).fetchone()
+            existing = _row_to_game(legacy_row) if legacy_row else None
+
+        slug = self._slug_for_upsert(
+            existing.id if existing else None,
+            existing.name if existing else None,
+            name,
+        )
+        values = (
+            bgg_id,
+            bgg_collection_id,
+            name,
+            slug,
+            thumbnail_url,
+            image_url,
+            year_published,
+            min_players,
+            max_players,
+            playing_time,
+            bgg_rating,
+            location,
+            item_type,
+            description,
+            now,
+        )
+        if existing is not None:
+            self._conn.execute(
+                """
+                UPDATE games SET
+                    bgg_id = ?, bgg_collection_id = ?, name = ?, slug = ?,
+                    thumbnail_url = ?, image_url = ?, year_published = ?,
+                    min_players = ?, max_players = ?, playing_time = ?,
+                    bgg_rating = ?, location = ?, item_type = ?, description = ?,
+                    is_active = 1, updated_at = ?
+                WHERE id = ?
+                """,
+                (*values, existing.id),
+            )
+        else:
+            self._conn.execute(
+                """
+                INSERT INTO games (
+                    bgg_id, bgg_collection_id, name, slug, thumbnail_url, image_url,
+                    year_published, min_players, max_players, playing_time,
+                    bgg_rating, location, item_type, description, is_active,
+                    created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                """,
+                (*values, now),
+            )
+        self._conn.commit()
+        game = self.get_by_collection_id(bgg_collection_id)
+        assert game is not None
+        return game, existing is None
+
+    def update_details(
+        self,
+        game_id: int,
+        thumbnail_url: str,
+        image_url: str,
+        min_players: int,
+        max_players: int,
+        playing_time: int,
+        bgg_rating: float,
+    ) -> Game:
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         self._conn.execute(
             """
-            INSERT INTO games (
-                bgg_id, name, slug, thumbnail_url, image_url, year_published,
-                min_players, max_players, playing_time, bgg_rating, location,
-                item_type, description, is_active, created_at, updated_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-            ON CONFLICT(bgg_id) DO UPDATE SET
-                name = excluded.name,
-                slug = excluded.slug,
-                thumbnail_url = excluded.thumbnail_url,
-                image_url = excluded.image_url,
-                year_published = excluded.year_published,
-                min_players = excluded.min_players,
-                max_players = excluded.max_players,
-                playing_time = excluded.playing_time,
-                bgg_rating = excluded.bgg_rating,
-                location = excluded.location,
-                item_type = excluded.item_type,
-                description = excluded.description,
-                is_active = 1,
-                updated_at = ?
+            UPDATE games SET
+                thumbnail_url = ?, image_url = ?, min_players = ?,
+                max_players = ?, playing_time = ?, bgg_rating = ?, updated_at = ?
+            WHERE id = ?
             """,
             (
-                bgg_id,
-                name,
-                slug,
                 thumbnail_url,
                 image_url,
-                year_published,
                 min_players,
                 max_players,
                 playing_time,
                 bgg_rating,
-                location,
-                item_type,
-                description,
                 now,
-                now,
-                now,
+                game_id,
             ),
         )
         self._conn.commit()
-        game = self.get_by_bgg_id(bgg_id)
+        game = self.get_by_id(game_id)
         assert game is not None
         return game

--- a/backend/domain/entities/game.py
+++ b/backend/domain/entities/game.py
@@ -23,3 +23,4 @@ class Game:
     item_type: str = field(default="boardgame")
     description: str = field(default="")
     is_active: bool = field(default=True)
+    bgg_collection_id: int | None = field(default=None)

--- a/backend/domain/repositories/game_repository.py
+++ b/backend/domain/repositories/game_repository.py
@@ -14,6 +14,12 @@ class GameRepository(Protocol):
 
     def get_by_bgg_id(self, bgg_id: int) -> Game | None: ...
 
+    # bgg_id (BGG's objectid) is NOT unique: BGG's collection can list several
+    # distinct owned items under one objectid. Returns an arbitrary match —
+    # only meant for the JSON-seed import path, which has no collection_id.
+
+    def get_by_collection_id(self, bgg_collection_id: int) -> Game | None: ...
+
     def list_all(self) -> list[Game]: ...
 
     def list_by_type(self, item_type: str) -> list[Game]: ...  # active items only
@@ -23,10 +29,10 @@ class GameRepository(Protocol):
     # active and inactive (soft-deleted) items — used by BGG reconciliation,
     # which must see previously soft-deleted rows too
 
-    def deactivate_by_bgg_ids(self, bgg_ids: Collection[int]) -> int: ...
+    def deactivate_by_collection_ids(self, collection_ids: Collection[int]) -> int: ...
 
-    def delete_by_bgg_ids(
-        self, bgg_ids: Collection[int]
+    def delete_by_collection_ids(
+        self, collection_ids: Collection[int]
     ) -> tuple[frozenset[int], frozenset[int]]: ...  # (deleted, blocked_by_history)
 
     def get_last_updated_at(self) -> datetime | None: ...
@@ -46,3 +52,42 @@ class GameRepository(Protocol):
         item_type: str = "boardgame",
         description: str = "",
     ) -> Game: ...
+
+    # legacy path: JSON-seed import, which has no collection_id concept
+
+    def upsert_by_collection_id(
+        self,
+        bgg_collection_id: int,
+        bgg_id: int,
+        name: str,
+        thumbnail_url: str,
+        image_url: str = "",
+        year_published: int = 0,
+        min_players: int = 0,
+        max_players: int = 0,
+        playing_time: int = 0,
+        bgg_rating: float = 0.0,
+        location: str = "armari",
+        item_type: str = "boardgame",
+        description: str = "",
+    ) -> tuple[Game, bool]: ...  # (game, was_created)
+
+    # Match rule: (1) an existing row with this bgg_collection_id, (2) else a
+    # legacy row (bgg_collection_id IS NULL) matching bgg_id, which adopts
+    # this collection_id, (3) else a newly created row.
+
+    def update_details(
+        self,
+        game_id: int,
+        thumbnail_url: str,
+        image_url: str,
+        min_players: int,
+        max_players: int,
+        playing_time: int,
+        bgg_rating: float,
+    ) -> Game: ...
+
+    # Updates by primary key, not bgg_id — enrich_games fetches shared
+    # attributes from BGG's thing API keyed by bgg_id/objectid, which can be
+    # shared by several distinct rows, so callers must resolve the target
+    # row themselves rather than relying on bgg_id-keyed matching here.

--- a/backend/domain/use_cases/bgg_reconciliation.py
+++ b/backend/domain/use_cases/bgg_reconciliation.py
@@ -7,36 +7,45 @@ DEACTIVATION_GUARD_RATIO = 0.5
 
 @dataclass(frozen=True)
 class ReconciliationOutcome:
-    missing_bgg_ids: frozenset[int]
+    missing_ids: frozenset[int]
     skip_reason: str | None
 
 
 def compute_reconciliation(
-    existing_active_bgg_ids: frozenset[int],
-    fetched_bgg_ids: frozenset[int],
+    existing_active_ids: frozenset[int],
+    fetched_ids: frozenset[int],
     item_type: str,
 ) -> ReconciliationOutcome:
-    if not fetched_bgg_ids:
+    """Diff by BGG collection entry id (bgg_collection_id), not bgg_id/objectid.
+
+    ``existing_active_ids`` should only include rows that already carry a
+    collection_id — legacy rows (imported before collection-id identity
+    existed) are excluded until an import run adopts one for them. This
+    means the first run after adopting collection-id identity naturally
+    treats "nothing is missing yet" rather than wrongly flagging every
+    not-yet-adopted row as gone.
+    """
+    if not fetched_ids:
         return ReconciliationOutcome(
-            missing_bgg_ids=frozenset(),
+            missing_ids=frozenset(),
             skip_reason=(
                 f"BGG fetch for '{item_type}' returned no items; "
                 "skipping removal of newly-missing items"
             ),
         )
 
-    missing = existing_active_bgg_ids - fetched_bgg_ids
-    if existing_active_bgg_ids and (
-        len(missing) / len(existing_active_bgg_ids) > DEACTIVATION_GUARD_RATIO
+    missing = existing_active_ids - fetched_ids
+    if existing_active_ids and (
+        len(missing) / len(existing_active_ids) > DEACTIVATION_GUARD_RATIO
     ):
         return ReconciliationOutcome(
-            missing_bgg_ids=frozenset(),
+            missing_ids=frozenset(),
             skip_reason=(
-                f"{len(missing)} of {len(existing_active_bgg_ids)} active "
+                f"{len(missing)} of {len(existing_active_ids)} active "
                 f"'{item_type}' items are missing from the BGG fetch "
                 f"(> {DEACTIVATION_GUARD_RATIO:.0%}); skipping removal of "
                 "newly-missing items"
             ),
         )
 
-    return ReconciliationOutcome(missing_bgg_ids=missing, skip_reason=None)
+    return ReconciliationOutcome(missing_ids=missing, skip_reason=None)

--- a/backend/domain/use_cases/import_games.py
+++ b/backend/domain/use_cases/import_games.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from backend.data.bgg_client import BggClient
+from backend.data.bgg_client import BggClient, BggGame
 from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
 from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
@@ -20,6 +20,18 @@ class ImportResult:
     skip_reason: str | None = None
 
 
+def _resolve_collection_id(bgg_game: BggGame) -> int:
+    """BGG's per-copy collection id, or a synthetic negative one keyed by
+    bgg_id when unavailable (HTML-scrape fallback, which can't tell distinct
+    owned items sharing one bgg_id apart) — matching the pre-collection-id
+    behavior for that degraded path."""
+    return (
+        bgg_game.collection_id
+        if bgg_game.collection_id is not None
+        else -bgg_game.bgg_id
+    )
+
+
 class ImportGamesUseCase:
     def __init__(
         self,
@@ -33,52 +45,59 @@ class ImportGamesUseCase:
 
     def execute(self) -> ImportResult:
         all_local_items = self._game_repo.list_by_type_including_inactive(ITEM_TYPE)
-        active_bgg_ids = frozenset(g.bgg_id for g in all_local_items if g.is_active)
+        active_ids = frozenset(
+            g.bgg_collection_id
+            for g in all_local_items
+            if g.is_active and g.bgg_collection_id is not None
+        )
 
         bgg_games = self._bgg_client.fetch_owned_games()
-        fetched_bgg_ids = frozenset(g.bgg_id for g in bgg_games)
+        fetched_ids = frozenset(_resolve_collection_id(g) for g in bgg_games)
 
         created = 0
         updated = 0
         for bgg_game in bgg_games:
-            existing = self._game_repo.get_by_bgg_id(bgg_game.bgg_id)
-            self._game_repo.upsert_by_bgg_id(
+            collection_id = _resolve_collection_id(bgg_game)
+            _, was_created = self._game_repo.upsert_by_collection_id(
+                bgg_collection_id=collection_id,
                 bgg_id=bgg_game.bgg_id,
                 name=bgg_game.name,
                 thumbnail_url=bgg_game.thumbnail_url,
-                image_url="",
+                image_url=bgg_game.image_url,
                 year_published=bgg_game.year_published,
             )
-            if existing is None:
+            if was_created:
                 created += 1
             else:
                 updated += 1
 
-        outcome = compute_reconciliation(active_bgg_ids, fetched_bgg_ids, ITEM_TYPE)
+        outcome = compute_reconciliation(active_ids, fetched_ids, ITEM_TYPE)
 
         # Previously soft-deleted items are re-evaluated every run, independent
         # of the guard above — they're already hidden, so there's no new risk.
         stale_inactive_ids = frozenset(
-            g.bgg_id
+            g.bgg_collection_id
             for g in all_local_items
-            if not g.is_active and g.bgg_id not in fetched_bgg_ids
+            if not g.is_active
+            and g.bgg_collection_id is not None
+            and g.bgg_collection_id not in fetched_ids
         )
-        removal_candidates = outcome.missing_bgg_ids | stale_inactive_ids
+        removal_candidates = outcome.missing_ids | stale_inactive_ids
 
         lent_ids = frozenset(
-            bgg_id
-            for bgg_id in removal_candidates
-            if (game := self._game_repo.get_by_bgg_id(bgg_id)) is not None
+            collection_id
+            for collection_id in removal_candidates
+            if (game := self._game_repo.get_by_collection_id(collection_id)) is not None
             and self._loan_repo.get_active_by_game_id(game.id) is not None
         )
         unlent_ids = removal_candidates - lent_ids
 
-        newly_deactivated = self._game_repo.deactivate_by_bgg_ids(lent_ids)
-        deleted_ids, blocked_ids = self._game_repo.delete_by_bgg_ids(unlent_ids)
+        newly_deactivated = self._game_repo.deactivate_by_collection_ids(lent_ids)
+        deleted_ids, blocked_ids = self._game_repo.delete_by_collection_ids(unlent_ids)
         if blocked_ids:
             # Has loan history (FK RESTRICT) but isn't lent right now — keep it
             # hidden since it can't be physically removed.
-            self._game_repo.deactivate_by_bgg_ids(blocked_ids)
+            self._game_repo.deactivate_by_collection_ids(blocked_ids)
 
         return ImportResult(
             created=created,

--- a/backend/domain/use_cases/import_rpg_items.py
+++ b/backend/domain/use_cases/import_rpg_items.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from backend.data.bgg_client import BggClient
+from backend.data.bgg_client import BggClient, BggRpgItem
 from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
 from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
@@ -20,6 +20,11 @@ class ImportRpgResult:
     skip_reason: str | None = None
 
 
+def _resolve_collection_id(item: BggRpgItem) -> int:
+    """See import_games._resolve_collection_id — same fallback rationale."""
+    return item.collection_id if item.collection_id is not None else -item.bgg_id
+
+
 class ImportRpgItemsUseCase:
     def __init__(
         self,
@@ -33,16 +38,21 @@ class ImportRpgItemsUseCase:
 
     def execute(self) -> ImportRpgResult:
         all_local_items = self._game_repo.list_by_type_including_inactive(ITEM_TYPE)
-        active_bgg_ids = frozenset(g.bgg_id for g in all_local_items if g.is_active)
+        active_ids = frozenset(
+            g.bgg_collection_id
+            for g in all_local_items
+            if g.is_active and g.bgg_collection_id is not None
+        )
 
         rpg_items = self._bgg_client.fetch_owned_rpg_items()
-        fetched_bgg_ids = frozenset(item.bgg_id for item in rpg_items)
+        fetched_ids = frozenset(_resolve_collection_id(item) for item in rpg_items)
 
         created = 0
         updated = 0
         for item in rpg_items:
-            existing = self._game_repo.get_by_bgg_id(item.bgg_id)
-            self._game_repo.upsert_by_bgg_id(
+            collection_id = _resolve_collection_id(item)
+            _, was_created = self._game_repo.upsert_by_collection_id(
+                bgg_collection_id=collection_id,
                 bgg_id=item.bgg_id,
                 name=item.name,
                 thumbnail_url=item.thumbnail_url,
@@ -52,36 +62,38 @@ class ImportRpgItemsUseCase:
                 description=item.description,
                 item_type=ITEM_TYPE,
             )
-            if existing is None:
+            if was_created:
                 created += 1
             else:
                 updated += 1
 
-        outcome = compute_reconciliation(active_bgg_ids, fetched_bgg_ids, ITEM_TYPE)
+        outcome = compute_reconciliation(active_ids, fetched_ids, ITEM_TYPE)
 
         # Previously soft-deleted items are re-evaluated every run, independent
         # of the guard above — they're already hidden, so there's no new risk.
         stale_inactive_ids = frozenset(
-            g.bgg_id
+            g.bgg_collection_id
             for g in all_local_items
-            if not g.is_active and g.bgg_id not in fetched_bgg_ids
+            if not g.is_active
+            and g.bgg_collection_id is not None
+            and g.bgg_collection_id not in fetched_ids
         )
-        removal_candidates = outcome.missing_bgg_ids | stale_inactive_ids
+        removal_candidates = outcome.missing_ids | stale_inactive_ids
 
         lent_ids = frozenset(
-            bgg_id
-            for bgg_id in removal_candidates
-            if (game := self._game_repo.get_by_bgg_id(bgg_id)) is not None
+            collection_id
+            for collection_id in removal_candidates
+            if (game := self._game_repo.get_by_collection_id(collection_id)) is not None
             and self._loan_repo.get_active_by_game_id(game.id) is not None
         )
         unlent_ids = removal_candidates - lent_ids
 
-        newly_deactivated = self._game_repo.deactivate_by_bgg_ids(lent_ids)
-        deleted_ids, blocked_ids = self._game_repo.delete_by_bgg_ids(unlent_ids)
+        newly_deactivated = self._game_repo.deactivate_by_collection_ids(lent_ids)
+        deleted_ids, blocked_ids = self._game_repo.delete_by_collection_ids(unlent_ids)
         if blocked_ids:
             # Has loan history (FK RESTRICT) but isn't lent right now — keep it
             # hidden since it can't be physically removed.
-            self._game_repo.deactivate_by_bgg_ids(blocked_ids)
+            self._game_repo.deactivate_by_collection_ids(blocked_ids)
 
         return ImportRpgResult(
             created=created,

--- a/backend/migrations/009_add_game_bgg_collection_id.sql
+++ b/backend/migrations/009_add_game_bgg_collection_id.sql
@@ -1,0 +1,65 @@
+-- BGG's collection API can list several distinct owned items (different
+-- names/images) under the same objectid (games.bgg_id) — e.g. reskinned
+-- variants BGG treats as versions of one base game. games.bgg_id was
+-- previously UNIQUE, which silently collapsed those into a single row.
+--
+-- games.bgg_collection_id stores BGG's per-copy collection entry id
+-- ("collid"), which is unique per owned item/copy. It becomes the identity
+-- used for import upserts; bgg_id (objectid) stays as a non-unique
+-- reference field (still used for the "view on BGG" link and for fetching
+-- shared details like rating/playtime).
+--
+-- SQLite has no ALTER TABLE ... DROP CONSTRAINT, so dropping the UNIQUE on
+-- bgg_id requires a full table rebuild. loans.game_id references games(id)
+-- ON DELETE RESTRICT, so foreign key enforcement must be off for the
+-- rebuild (not permitted mid-transaction) and restored after.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN TRANSACTION;
+
+CREATE TABLE games_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bgg_id INTEGER NOT NULL,
+    bgg_collection_id INTEGER,
+    name TEXT NOT NULL,
+    thumbnail_url TEXT NOT NULL,
+    year_published INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    min_players INTEGER NOT NULL DEFAULT 0,
+    max_players INTEGER NOT NULL DEFAULT 0,
+    playing_time INTEGER NOT NULL DEFAULT 0,
+    bgg_rating REAL NOT NULL DEFAULT 0.0,
+    location TEXT NOT NULL DEFAULT 'armari',
+    image_url TEXT NOT NULL DEFAULT '',
+    slug TEXT NOT NULL DEFAULT '',
+    item_type TEXT NOT NULL DEFAULT 'boardgame'
+        CHECK (item_type IN ('boardgame', 'rpgitem')),
+    description TEXT NOT NULL DEFAULT '',
+    is_active INTEGER NOT NULL DEFAULT 1
+);
+
+INSERT INTO games_new (
+    id, bgg_id, bgg_collection_id, name, thumbnail_url, year_published,
+    created_at, updated_at, min_players, max_players, playing_time,
+    bgg_rating, location, image_url, slug, item_type, description, is_active
+)
+SELECT
+    id, bgg_id, NULL, name, thumbnail_url, year_published,
+    created_at, updated_at, min_players, max_players, playing_time,
+    bgg_rating, location, image_url, slug, item_type, description, is_active
+FROM games;
+
+DROP TABLE games;
+
+ALTER TABLE games_new RENAME TO games;
+
+CREATE UNIQUE INDEX idx_games_slug ON games(slug) WHERE slug != '';
+CREATE INDEX idx_games_item_type ON games (item_type);
+CREATE UNIQUE INDEX idx_games_collection_id ON games(bgg_collection_id)
+    WHERE bgg_collection_id IS NOT NULL;
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/tests/data/repositories/test_sqlite_game_repository.py
+++ b/tests/data/repositories/test_sqlite_game_repository.py
@@ -146,57 +146,62 @@ class TestSqliteGameRepository:
     def test_list_by_type_excludes_inactive(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        game_repo.deactivate_by_bgg_ids([13])
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_collection_ids([101])
         assert game_repo.list_by_type("boardgame") == []
 
     def test_list_by_type_including_inactive_includes_it(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        game_repo.deactivate_by_bgg_ids([13])
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_collection_ids([101])
         games = game_repo.list_by_type_including_inactive("boardgame")
         assert [g.bgg_id for g in games] == [13]
         assert games[0].is_active is False
 
-    def test_deactivate_by_bgg_ids_marks_inactive_and_returns_count(
+    def test_deactivate_by_collection_ids_marks_inactive_and_returns_count(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        count = game_repo.deactivate_by_bgg_ids([13, 14])
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://c.jpg", 1995)
+        game_repo.upsert_by_collection_id(102, 14, "Azul", "https://a.jpg", 2017)
+        count = game_repo.deactivate_by_collection_ids([101, 102])
         assert count == 2
-        assert game_repo.get_by_bgg_id(13).is_active is False
-        assert game_repo.get_by_bgg_id(14).is_active is False
+        assert game_repo.get_by_collection_id(101).is_active is False
+        assert game_repo.get_by_collection_id(102).is_active is False
 
-    def test_deactivate_by_bgg_ids_no_ops_on_empty_input(
+    def test_deactivate_by_collection_ids_no_ops_on_empty_input(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        assert game_repo.deactivate_by_bgg_ids([]) == 0
+        assert game_repo.deactivate_by_collection_ids([]) == 0
 
-    def test_delete_by_bgg_ids_removes_never_borrowed_game(
+    def test_delete_by_collection_ids_removes_never_borrowed_game(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        deleted, blocked = game_repo.delete_by_bgg_ids([13])
-        assert deleted == frozenset({13})
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://c.jpg", 1995)
+        deleted, blocked = game_repo.delete_by_collection_ids([101])
+        assert deleted == frozenset({101})
         assert blocked == frozenset()
-        assert game_repo.get_by_bgg_id(13) is None
+        assert game_repo.get_by_collection_id(101) is None
 
     def test_upsert_reactivates_previously_inactive_row(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        game_repo.deactivate_by_bgg_ids([13])
-        reactivated = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://c.jpg", 1995)
+        game_repo.deactivate_by_collection_ids([101])
+        reactivated, _ = game_repo.upsert_by_collection_id(
+            101, 13, "Catan", "https://c.jpg", 1995
+        )
         assert reactivated.is_active is True
 
     def test_point_lookups_return_inactive_rows(
         self, game_repo: SqliteGameRepository
     ) -> None:
-        game = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        game_repo.deactivate_by_bgg_ids([13])
+        game, _ = game_repo.upsert_by_collection_id(
+            101, 13, "Catan", "https://c.jpg", 1995
+        )
+        game_repo.deactivate_by_collection_ids([101])
         assert game_repo.get_by_bgg_id(13) is not None
+        assert game_repo.get_by_collection_id(101) is not None
         assert game_repo.get_by_slug(game.slug) is not None
 
     def test_delete_blocked_by_returned_loan_history(
@@ -208,15 +213,129 @@ class TestSqliteGameRepository:
         """A game with past (returned) loan history can never be hard-deleted,
         because SQLite's FK constraint on loans.game_id doesn't distinguish
         active from historical loans."""
-        game = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        game, _ = game_repo.upsert_by_collection_id(
+            101, 13, "Catan", "https://c.jpg", 1995
+        )
         member = member_repo.upsert_by_email(
             1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         loan = loan_repo.create(game.id, member.id)
         loan_repo.mark_returned(loan.id)
 
-        deleted, blocked = game_repo.delete_by_bgg_ids([13])
+        deleted, blocked = game_repo.delete_by_collection_ids([101])
 
         assert deleted == frozenset()
-        assert blocked == frozenset({13})
-        assert game_repo.get_by_bgg_id(13) is not None
+        assert blocked == frozenset({101})
+        assert game_repo.get_by_collection_id(101) is not None
+
+    def test_upsert_by_collection_id_creates_new_row(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game, was_created = game_repo.upsert_by_collection_id(
+            101, 13, "Catan", "https://c.jpg", 1995
+        )
+        assert was_created is True
+        assert game.bgg_id == 13
+        assert game.bgg_collection_id == 101
+        assert game.name == "Catan"
+
+    def test_upsert_by_collection_id_updates_existing_row(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        game_repo.upsert_by_collection_id(101, 13, "Catan", "https://old.jpg", 1995)
+        updated, was_created = game_repo.upsert_by_collection_id(
+            101, 13, "Catan: 25th Anniversary", "https://new.jpg", 1995
+        )
+        assert was_created is False
+        assert updated.name == "Catan: 25th Anniversary"
+        assert updated.thumbnail_url == "https://new.jpg"
+
+    def test_upsert_by_collection_id_adopts_legacy_bgg_id_row(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        """A row imported before collection-id identity existed (via
+        upsert_by_bgg_id) must adopt its collection_id, not spawn a
+        duplicate row."""
+        legacy = game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        assert legacy.bgg_collection_id is None
+
+        adopted, was_created = game_repo.upsert_by_collection_id(
+            101, 13, "Catan", "https://c.jpg", 1995
+        )
+
+        assert was_created is False
+        assert adopted.id == legacy.id
+        assert adopted.bgg_collection_id == 101
+        assert len(game_repo.list_all()) == 1
+
+    def test_upsert_by_collection_id_distinct_items_sharing_bgg_id(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        """BGG can list several distinct owned items under one bgg_id
+        (objectid) — they must land in separate rows, each keyed by its own
+        collection_id."""
+        mitos, _ = game_repo.upsert_by_collection_id(
+            146444331,
+            268620,
+            "Similo: Mitos",
+            "https://mitos_t.jpg",
+            year_published=2020,
+            image_url="https://mitos.jpg",
+        )
+        historia, _ = game_repo.upsert_by_collection_id(
+            146444335,
+            268620,
+            "Similo: Historia",
+            "https://historia_t.jpg",
+            year_published=2020,
+            image_url="https://historia.jpg",
+        )
+
+        assert mitos.id != historia.id
+        assert mitos.bgg_id == historia.bgg_id == 268620
+        assert mitos.slug == "similo-mitos"
+        assert historia.slug == "similo-historia"
+        assert mitos.image_url == "https://mitos.jpg"
+        assert historia.image_url == "https://historia.jpg"
+        all_games = game_repo.list_all()
+        assert len(all_games) == 2
+
+    def test_update_details_updates_by_id_not_bgg_id(
+        self, game_repo: SqliteGameRepository
+    ) -> None:
+        """update_details must target one specific row by id — used by
+        enrich_games, which fetches shared attributes by bgg_id/objectid
+        that can be shared by several distinct rows."""
+        mitos, _ = game_repo.upsert_by_collection_id(
+            146444331,
+            268620,
+            "Similo: Mitos",
+            "thumb1.jpg",
+            year_published=2020,
+            image_url="img1.jpg",
+        )
+        historia, _ = game_repo.upsert_by_collection_id(
+            146444335,
+            268620,
+            "Similo: Historia",
+            "thumb2.jpg",
+            year_published=2020,
+            image_url="img2.jpg",
+        )
+
+        updated = game_repo.update_details(
+            mitos.id,
+            thumbnail_url="new_thumb.jpg",
+            image_url="new_img.jpg",
+            min_players=2,
+            max_players=4,
+            playing_time=15,
+            bgg_rating=7.5,
+        )
+
+        assert updated.image_url == "new_img.jpg"
+        assert updated.min_players == 2
+        unaffected = game_repo.get_by_id(historia.id)
+        assert unaffected is not None
+        assert unaffected.image_url == "img2.jpg"
+        assert unaffected.min_players == 0

--- a/tests/domain/use_cases/conftest.py
+++ b/tests/domain/use_cases/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from datetime import UTC, datetime
 
 import pytest
@@ -12,15 +13,16 @@ from backend.domain.slug import ensure_unique, slugify
 class FakeGameRepository:
     """Shared fake for import-reconciliation tests.
 
-    ``blocked_bgg_ids`` is a test-only escape hatch: populate it directly to
-    simulate a game that has loan history and is therefore FK-blocked from
-    hard deletion, without reimplementing real SQLite FK semantics here.
+    ``blocked_collection_ids`` is a test-only escape hatch: populate it
+    directly to simulate a game that has loan history and is therefore
+    FK-blocked from hard deletion, without reimplementing real SQLite FK
+    semantics here.
     """
 
     def __init__(self) -> None:
         self._games: dict[int, Game] = {}
         self._next_id = 1
-        self.blocked_bgg_ids: set[int] = set()
+        self.blocked_collection_ids: set[int] = set()
 
     def get_by_id(self, game_id: int) -> Game | None:
         return self._games.get(game_id)
@@ -30,6 +32,16 @@ class FakeGameRepository:
 
     def get_by_bgg_id(self, bgg_id: int) -> Game | None:
         return next((g for g in self._games.values() if g.bgg_id == bgg_id), None)
+
+    def get_by_collection_id(self, bgg_collection_id: int) -> Game | None:
+        return next(
+            (
+                g
+                for g in self._games.values()
+                if g.bgg_collection_id == bgg_collection_id
+            ),
+            None,
+        )
 
     def list_all(self) -> list[Game]:
         return sorted(self._games.values(), key=lambda g: g.name)
@@ -50,29 +62,41 @@ class FakeGameRepository:
             key=lambda g: g.name,
         )
 
-    def deactivate_by_bgg_ids(self, bgg_ids: object) -> int:
+    def deactivate_by_collection_ids(self, collection_ids: object) -> int:
         count = 0
-        for bgg_id in bgg_ids:
-            game = self.get_by_bgg_id(bgg_id)
+        for collection_id in collection_ids:
+            game = self.get_by_collection_id(collection_id)
             if game is not None and game.is_active:
-                self._games[game.id] = _replace_is_active(game, is_active=False)
+                self._games[game.id] = dataclasses.replace(game, is_active=False)
                 count += 1
         return count
 
-    def delete_by_bgg_ids(
-        self, bgg_ids: object
+    def delete_by_collection_ids(
+        self, collection_ids: object
     ) -> tuple[frozenset[int], frozenset[int]]:
         deleted: set[int] = set()
         blocked: set[int] = set()
-        for bgg_id in bgg_ids:
-            if bgg_id in self.blocked_bgg_ids:
-                blocked.add(bgg_id)
+        for collection_id in collection_ids:
+            if collection_id in self.blocked_collection_ids:
+                blocked.add(collection_id)
                 continue
-            game = self.get_by_bgg_id(bgg_id)
+            game = self.get_by_collection_id(collection_id)
             if game is not None:
                 del self._games[game.id]
-                deleted.add(bgg_id)
+                deleted.add(collection_id)
         return frozenset(deleted), frozenset(blocked)
+
+    def _slug_for(self, existing: Game | None, name: str) -> str:
+        if existing is not None and slugify(existing.name) == slugify(name):
+            return existing.slug
+        return ensure_unique(
+            slugify(name),
+            (
+                g.slug
+                for g in self._games.values()
+                if existing is None or g.id != existing.id
+            ),
+        )
 
     def upsert_by_bgg_id(
         self,
@@ -89,16 +113,10 @@ class FakeGameRepository:
         item_type: str = "boardgame",
         description: str = "",
     ) -> Game:
+        """Legacy path: no collection_id concept."""
         now = datetime.now(UTC)
         existing = self.get_by_bgg_id(bgg_id)
-        slug = (
-            existing.slug
-            if existing and slugify(existing.name) == slugify(name)
-            else ensure_unique(
-                slugify(name),
-                (g.slug for g in self._games.values() if g.bgg_id != bgg_id),
-            )
-        )
+        slug = self._slug_for(existing, name)
         game = Game(
             id=existing.id if existing else self._next_id,
             bgg_id=bgg_id,
@@ -117,33 +135,91 @@ class FakeGameRepository:
             item_type=item_type,
             description=description,
             is_active=True,
+            bgg_collection_id=existing.bgg_collection_id if existing else None,
         )
         self._games[game.id] = game
         if existing is None:
             self._next_id += 1
         return game
 
+    def upsert_by_collection_id(
+        self,
+        bgg_collection_id: int,
+        bgg_id: int,
+        name: str,
+        thumbnail_url: str,
+        image_url: str = "",
+        year_published: int = 0,
+        min_players: int = 0,
+        max_players: int = 0,
+        playing_time: int = 0,
+        bgg_rating: float = 0.0,
+        location: str = "armari",
+        item_type: str = "boardgame",
+        description: str = "",
+    ) -> tuple[Game, bool]:
+        now = datetime.now(UTC)
+        existing = self.get_by_collection_id(bgg_collection_id)
+        if existing is None:
+            existing = next(
+                (
+                    g
+                    for g in self._games.values()
+                    if g.bgg_collection_id is None and g.bgg_id == bgg_id
+                ),
+                None,
+            )
+        was_created = existing is None
 
-def _replace_is_active(game: Game, *, is_active: bool) -> Game:
-    return Game(
-        id=game.id,
-        bgg_id=game.bgg_id,
-        name=game.name,
-        slug=game.slug,
-        thumbnail_url=game.thumbnail_url,
-        image_url=game.image_url,
-        year_published=game.year_published,
-        min_players=game.min_players,
-        max_players=game.max_players,
-        playing_time=game.playing_time,
-        bgg_rating=game.bgg_rating,
-        location=game.location,
-        created_at=game.created_at,
-        updated_at=game.updated_at,
-        item_type=game.item_type,
-        description=game.description,
-        is_active=is_active,
-    )
+        slug = self._slug_for(existing, name)
+        game = Game(
+            id=existing.id if existing else self._next_id,
+            bgg_id=bgg_id,
+            bgg_collection_id=bgg_collection_id,
+            name=name,
+            slug=slug,
+            thumbnail_url=thumbnail_url,
+            image_url=image_url,
+            year_published=year_published,
+            min_players=min_players,
+            max_players=max_players,
+            playing_time=playing_time,
+            bgg_rating=bgg_rating,
+            location=location,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+            item_type=item_type,
+            description=description,
+            is_active=True,
+        )
+        self._games[game.id] = game
+        if was_created:
+            self._next_id += 1
+        return game, was_created
+
+    def update_details(
+        self,
+        game_id: int,
+        thumbnail_url: str,
+        image_url: str,
+        min_players: int,
+        max_players: int,
+        playing_time: int,
+        bgg_rating: float,
+    ) -> Game:
+        game = self._games[game_id]
+        updated = dataclasses.replace(
+            game,
+            thumbnail_url=thumbnail_url,
+            image_url=image_url,
+            min_players=min_players,
+            max_players=max_players,
+            playing_time=playing_time,
+            bgg_rating=bgg_rating,
+            updated_at=datetime.now(UTC),
+        )
+        self._games[game_id] = updated
+        return updated
 
 
 class FakeLoanRepository:

--- a/tests/domain/use_cases/test_bgg_reconciliation.py
+++ b/tests/domain/use_cases/test_bgg_reconciliation.py
@@ -6,54 +6,54 @@ from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
 class TestComputeReconciliation:
     def test_no_missing_ids(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset({1, 2}),
-            fetched_bgg_ids=frozenset({1, 2}),
+            existing_active_ids=frozenset({1, 2}),
+            fetched_ids=frozenset({1, 2}),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.missing_ids == frozenset()
         assert outcome.skip_reason is None
 
     def test_missing_ids_under_guard(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
-            fetched_bgg_ids=frozenset({1, 2, 3}),
+            existing_active_ids=frozenset({1, 2, 3, 4}),
+            fetched_ids=frozenset({1, 2, 3}),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset({4})
+        assert outcome.missing_ids == frozenset({4})
         assert outcome.skip_reason is None
 
     def test_empty_fetch_skips(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset({1, 2}),
-            fetched_bgg_ids=frozenset(),
+            existing_active_ids=frozenset({1, 2}),
+            fetched_ids=frozenset(),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.missing_ids == frozenset()
         assert outcome.skip_reason is not None
 
     def test_over_50_percent_drop_skips(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
-            fetched_bgg_ids=frozenset({1}),
+            existing_active_ids=frozenset({1, 2, 3, 4}),
+            fetched_ids=frozenset({1}),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.missing_ids == frozenset()
         assert outcome.skip_reason is not None
 
     def test_exactly_50_percent_drop_does_not_skip(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset({1, 2, 3, 4}),
-            fetched_bgg_ids=frozenset({1, 2}),
+            existing_active_ids=frozenset({1, 2, 3, 4}),
+            fetched_ids=frozenset({1, 2}),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset({3, 4})
+        assert outcome.missing_ids == frozenset({3, 4})
         assert outcome.skip_reason is None
 
     def test_first_ever_import_does_not_skip_or_divide_by_zero(self) -> None:
         outcome = compute_reconciliation(
-            existing_active_bgg_ids=frozenset(),
-            fetched_bgg_ids=frozenset({1, 2}),
+            existing_active_ids=frozenset(),
+            fetched_ids=frozenset({1, 2}),
             item_type="boardgame",
         )
-        assert outcome.missing_bgg_ids == frozenset()
+        assert outcome.missing_ids == frozenset()
         assert outcome.skip_reason is None

--- a/tests/domain/use_cases/test_borrow_game.py
+++ b/tests/domain/use_cases/test_borrow_game.py
@@ -59,8 +59,10 @@ class TestBorrowGameUseCase:
         loan_repo: SqliteLoanRepository,
         member_repo: SqliteMemberRepository,
     ) -> None:
-        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
-        game_repo.deactivate_by_bgg_ids([1])
+        game, _ = game_repo.upsert_by_collection_id(
+            101, 1, "Catan", "https://c.jpg", 1995
+        )
+        game_repo.deactivate_by_collection_ids([101])
         member = member_repo.upsert_by_email(
             1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
@@ -74,13 +76,15 @@ class TestBorrowGameUseCase:
         loan_repo: SqliteLoanRepository,
         member_repo: SqliteMemberRepository,
     ) -> None:
-        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        game, _ = game_repo.upsert_by_collection_id(
+            101, 1, "Catan", "https://c.jpg", 1995
+        )
         member = member_repo.upsert_by_email(
             1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", False
         )
         borrow_use_case = BorrowGameUseCase(game_repo, loan_repo)
         loan = borrow_use_case.execute(game.id, member.id)
-        game_repo.deactivate_by_bgg_ids([game.bgg_id])
+        game_repo.deactivate_by_collection_ids([101])
 
         return_use_case = ReturnGameUseCase(loan_repo)
         returned = return_use_case.execute(loan.id, member)

--- a/tests/domain/use_cases/test_import_games.py
+++ b/tests/domain/use_cases/test_import_games.py
@@ -32,8 +32,8 @@ class TestImportGamesUseCase:
     ) -> None:
         bgg_client = FakeBggClient(
             [
-                BggGame(13, "Catan", "https://c.jpg", 1995),
-                BggGame(230802, "Azul", "https://a.jpg", 2017),
+                BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013),
+                BggGame(230802, "Azul", "https://a.jpg", 2017, collection_id=1230802),
             ]
         )
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
@@ -46,26 +46,36 @@ class TestImportGamesUseCase:
     def test_updates_existing_games(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://old.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(
+            1013, 13, "Catan", "https://old.jpg", 1995
+        )
         bgg_client = FakeBggClient(
-            [BggGame(13, "Catan: 25th Anniversary", "https://new.jpg", 1995)]
+            [
+                BggGame(
+                    13,
+                    "Catan: 25th Anniversary",
+                    "https://new.jpg",
+                    1995,
+                    collection_id=1013,
+                )
+            ]
         )
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
         assert result.created == 0
         assert result.updated == 1
-        game = fake_game_repo.get_by_bgg_id(13)
+        game = fake_game_repo.get_by_collection_id(1013)
         assert game is not None
         assert game.name == "Catan: 25th Anniversary"
 
     def test_mixed_create_and_update(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
         bgg_client = FakeBggClient(
             [
-                BggGame(13, "Catan", "https://c.jpg", 1995),
-                BggGame(230802, "Azul", "https://a.jpg", 2017),
+                BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013),
+                BggGame(230802, "Azul", "https://a.jpg", 2017, collection_id=1230802),
             ]
         )
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
@@ -90,131 +100,226 @@ class TestImportGamesUseCase:
     def test_missing_and_not_lent_is_hard_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
+        bgg_client = FakeBggClient(
+            [BggGame(14, "Azul", "https://a.jpg", 2017, collection_id=1014)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deleted == 1
         assert result.deactivated == 0
-        assert fake_game_repo.get_by_bgg_id(13) is None
+        assert fake_game_repo.get_by_collection_id(1013) is None
 
     def test_missing_and_currently_lent_is_soft_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        game = fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
+        game, _ = fake_game_repo.upsert_by_collection_id(
+            1013, 13, "Catan", "https://c.jpg", 1995
+        )
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
         fake_loan_repo.set_active_loan(game.id, _loan(game.id))
-        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+        bgg_client = FakeBggClient(
+            [BggGame(14, "Azul", "https://a.jpg", 2017, collection_id=1014)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deactivated == 1
         assert result.deleted == 0
-        stored = fake_game_repo.get_by_bgg_id(13)
+        stored = fake_game_repo.get_by_collection_id(1013)
         assert stored is not None
         assert stored.is_active is False
 
     def test_present_items_are_untouched(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deleted == 0
         assert result.deactivated == 0
-        assert fake_game_repo.get_by_bgg_id(13) is not None
+        assert fake_game_repo.get_by_collection_id(1013) is not None
 
     def test_previously_soft_deleted_still_lent_stays_soft_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        game = fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        fake_game_repo.deactivate_by_bgg_ids([13])
+        game, _ = fake_game_repo.upsert_by_collection_id(
+            1013, 13, "Catan", "https://c.jpg", 1995
+        )
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_collection_ids([1013])
         fake_loan_repo.set_active_loan(game.id, _loan(game.id))
-        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+        bgg_client = FakeBggClient(
+            [BggGame(14, "Azul", "https://a.jpg", 2017, collection_id=1014)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deleted == 0
-        stored = fake_game_repo.get_by_bgg_id(13)
+        stored = fake_game_repo.get_by_collection_id(1013)
         assert stored is not None
         assert stored.is_active is False
 
     def test_previously_soft_deleted_no_longer_lent_is_hard_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        fake_game_repo.deactivate_by_bgg_ids([13])
-        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_collection_ids([1013])
+        bgg_client = FakeBggClient(
+            [BggGame(14, "Azul", "https://a.jpg", 2017, collection_id=1014)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deleted == 1
-        assert fake_game_repo.get_by_bgg_id(13) is None
+        assert fake_game_repo.get_by_collection_id(1013) is None
 
     def test_previously_soft_deleted_fk_blocked_stays_soft_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        fake_game_repo.deactivate_by_bgg_ids([13])
-        fake_game_repo.blocked_bgg_ids.add(13)
-        bgg_client = FakeBggClient([BggGame(14, "Azul", "https://a.jpg", 2017)])
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.deactivate_by_collection_ids([1013])
+        fake_game_repo.blocked_collection_ids.add(1013)
+        bgg_client = FakeBggClient(
+            [BggGame(14, "Azul", "https://a.jpg", 2017, collection_id=1014)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.deleted == 0
         assert result.deactivated == 1
-        stored = fake_game_repo.get_by_bgg_id(13)
+        stored = fake_game_repo.get_by_collection_id(1013)
         assert stored is not None
         assert stored.is_active is False
 
     def test_drastic_drop_skips_newly_missing_but_not_stale_inactive(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.upsert_by_bgg_id(14, "Azul", "https://a.jpg", 2017)
-        fake_game_repo.upsert_by_bgg_id(15, "Pandemic", "https://p.jpg", 2008)
-        fake_game_repo.upsert_by_bgg_id(16, "Ticket to Ride", "https://t.jpg", 2004)
-        fake_game_repo.deactivate_by_bgg_ids([16])
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.upsert_by_collection_id(1014, 14, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.upsert_by_collection_id(
+            1015, 15, "Pandemic", "https://p.jpg", 2008
+        )
+        fake_game_repo.upsert_by_collection_id(
+            1016, 16, "Ticket to Ride", "https://t.jpg", 2004
+        )
+        fake_game_repo.deactivate_by_collection_ids([1016])
         # only 1 of 3 active items remains -> > 50% missing, guard trips
-        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013)]
+        )
 
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         result = use_case.execute()
 
         assert result.skip_reason is not None
-        # newly-missing (14, 15) are neither deleted nor deactivated
-        assert fake_game_repo.get_by_bgg_id(14) is not None
-        assert fake_game_repo.get_by_bgg_id(14).is_active is True
-        assert fake_game_repo.get_by_bgg_id(15) is not None
-        assert fake_game_repo.get_by_bgg_id(15).is_active is True
-        # already-inactive stale item (16) is still reconciled regardless
-        assert fake_game_repo.get_by_bgg_id(16) is None
+        # newly-missing (1014, 1015) are neither deleted nor deactivated
+        game_1014 = fake_game_repo.get_by_collection_id(1014)
+        game_1015 = fake_game_repo.get_by_collection_id(1015)
+        assert game_1014 is not None
+        assert game_1014.is_active is True
+        assert game_1015 is not None
+        assert game_1015.is_active is True
+        # already-inactive stale item (1016) is still reconciled regardless
+        assert fake_game_repo.get_by_collection_id(1016) is None
         assert result.deleted == 1
 
     def test_reappearing_item_is_reactivated(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
-        fake_game_repo.deactivate_by_bgg_ids([13])
-        assert fake_game_repo.get_by_bgg_id(13).is_active is False
+        fake_game_repo.upsert_by_collection_id(1013, 13, "Catan", "https://c.jpg", 1995)
+        fake_game_repo.deactivate_by_collection_ids([1013])
+        deactivated = fake_game_repo.get_by_collection_id(1013)
+        assert deactivated is not None
+        assert deactivated.is_active is False
 
-        bgg_client = FakeBggClient([BggGame(13, "Catan", "https://c.jpg", 1995)])
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013)]
+        )
         use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         use_case.execute()
 
-        stored = fake_game_repo.get_by_bgg_id(13)
+        stored = fake_game_repo.get_by_collection_id(1013)
         assert stored is not None
         assert stored.is_active is True
+
+    def test_legacy_row_adopts_collection_id_on_first_run(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        """A row imported before collection-id identity existed (bgg_id-keyed
+        only) must adopt its collection_id on the next import — not be
+        wrongly treated as missing, and not spawn a duplicate row."""
+        legacy = fake_game_repo.upsert_by_bgg_id(13, "Catan", "https://c.jpg", 1995)
+        assert legacy.bgg_collection_id is None
+
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://c.jpg", 1995, collection_id=1013)]
+        )
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.created == 0
+        assert result.updated == 1
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.skip_reason is None
+        assert len(fake_game_repo.list_all()) == 1
+        adopted = fake_game_repo.get_by_collection_id(1013)
+        assert adopted is not None
+        assert adopted.id == legacy.id
+
+    def test_bgg_id_shared_by_distinct_items_creates_separate_rows(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        """BGG can list several distinct owned items under one bgg_id
+        (objectid) — they must become separate catalog rows, keyed by their
+        own distinct collection_id."""
+        bgg_client = FakeBggClient(
+            [
+                BggGame(
+                    268620,
+                    "Similo: Mitos",
+                    "https://mitos.jpg",
+                    2020,
+                    collection_id=146444331,
+                    image_url="mitos_full.jpg",
+                ),
+                BggGame(
+                    268620,
+                    "Similo: Historia",
+                    "https://historia.jpg",
+                    2020,
+                    collection_id=146444335,
+                    image_url="historia_full.jpg",
+                ),
+            ]
+        )
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.created == 2
+        all_games = fake_game_repo.list_all()
+        assert len(all_games) == 2
+        names = {g.name for g in all_games}
+        assert names == {"Similo: Mitos", "Similo: Historia"}
+        images = {g.name: g.image_url for g in all_games}
+        assert images == {
+            "Similo: Mitos": "mitos_full.jpg",
+            "Similo: Historia": "historia_full.jpg",
+        }
+        slugs = {g.slug for g in all_games}
+        assert slugs == {"similo-mitos", "similo-historia"}

--- a/tests/domain/use_cases/test_import_rpg_items.py
+++ b/tests/domain/use_cases/test_import_rpg_items.py
@@ -34,6 +34,7 @@ _DND_RPG_ITEM = BggRpgItem(
     year_published=2014,
     bgg_rating=8.5,
     description="A guide for adventurers.",
+    collection_id=2001,
 )
 _PF_RPG_ITEM = BggRpgItem(
     bgg_id=1002,
@@ -43,6 +44,7 @@ _PF_RPG_ITEM = BggRpgItem(
     year_published=2019,
     bgg_rating=9.1,
     description="The complete Pathfinder rules.",
+    collection_id=2002,
 )
 
 
@@ -68,7 +70,7 @@ class TestImportRpgItemsUseCase:
 
         use_case.execute()
 
-        game = fake_game_repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_collection_id(2001)
         assert game is not None
         assert game.item_type == "rpgitem"
 
@@ -80,15 +82,15 @@ class TestImportRpgItemsUseCase:
 
         use_case.execute()
 
-        game = fake_game_repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_collection_id(2001)
         assert game is not None
         assert game.description == "A guide for adventurers."
 
     def test_updates_existing_rpg_item(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(
-            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        fake_game_repo.upsert_by_collection_id(
+            2001, 1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
         )
         bgg_client = FakeBggClientRpg([_DND_RPG_ITEM])
         use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
@@ -97,7 +99,7 @@ class TestImportRpgItemsUseCase:
 
         assert result.created == 0
         assert result.updated == 1
-        game = fake_game_repo.get_by_bgg_id(1001)
+        game = fake_game_repo.get_by_collection_id(2001)
         assert game is not None
         assert game.name == "Dungeons & Dragons Player's Handbook"
 
@@ -118,11 +120,11 @@ class TestImportRpgItemsUseCase:
     def test_missing_and_not_lent_is_hard_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        fake_game_repo.upsert_by_bgg_id(
-            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        fake_game_repo.upsert_by_collection_id(
+            2001, 1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
         )
-        fake_game_repo.upsert_by_bgg_id(
-            1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
+        fake_game_repo.upsert_by_collection_id(
+            2002, 1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
         )
         bgg_client = FakeBggClientRpg([_PF_RPG_ITEM])
 
@@ -130,16 +132,16 @@ class TestImportRpgItemsUseCase:
         result = use_case.execute()
 
         assert result.deleted == 1
-        assert fake_game_repo.get_by_bgg_id(1001) is None
+        assert fake_game_repo.get_by_collection_id(2001) is None
 
     def test_missing_and_currently_lent_is_soft_deleted(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
-        game = fake_game_repo.upsert_by_bgg_id(
-            1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        game, _ = fake_game_repo.upsert_by_collection_id(
+            2001, 1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
         )
-        fake_game_repo.upsert_by_bgg_id(
-            1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
+        fake_game_repo.upsert_by_collection_id(
+            2002, 1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
         )
         fake_loan_repo.set_active_loan(game.id, _loan(game.id))
         bgg_client = FakeBggClientRpg([_PF_RPG_ITEM])
@@ -149,7 +151,7 @@ class TestImportRpgItemsUseCase:
 
         assert result.deactivated == 1
         assert result.deleted == 0
-        stored = fake_game_repo.get_by_bgg_id(1001)
+        stored = fake_game_repo.get_by_collection_id(2001)
         assert stored is not None
         assert stored.is_active is False
 
@@ -157,14 +159,47 @@ class TestImportRpgItemsUseCase:
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
     ) -> None:
         """An RPG import must never delete/deactivate a boardgame."""
-        fake_game_repo.upsert_by_bgg_id(
-            13, "Catan", "https://c.jpg", item_type="boardgame"
+        fake_game_repo.upsert_by_collection_id(
+            1013, 13, "Catan", "https://c.jpg", item_type="boardgame"
         )
         bgg_client = FakeBggClientRpg([])
 
         use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
         use_case.execute()
 
-        catan = fake_game_repo.get_by_bgg_id(13)
+        catan = fake_game_repo.get_by_collection_id(1013)
         assert catan is not None
         assert catan.is_active is True
+
+    def test_bgg_id_shared_by_distinct_items_creates_separate_rows(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        bgg_client = FakeBggClientRpg(
+            [
+                BggRpgItem(
+                    bgg_id=5000,
+                    name="Variant A",
+                    thumbnail_url="a_t.jpg",
+                    image_url="a.jpg",
+                    year_published=2020,
+                    bgg_rating=7.0,
+                    description="",
+                    collection_id=9001,
+                ),
+                BggRpgItem(
+                    bgg_id=5000,
+                    name="Variant B",
+                    thumbnail_url="b_t.jpg",
+                    image_url="b.jpg",
+                    year_published=2020,
+                    bgg_rating=7.0,
+                    description="",
+                    collection_id=9002,
+                ),
+            ]
+        )
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.created == 2
+        assert len(fake_game_repo.list_all()) == 2

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -49,7 +49,7 @@ class TestMigrationRunner:
         conn = get_memory_connection()
         first_run = run_migrations(conn)
         second_run = run_migrations(conn)
-        assert len(first_run) == 8
+        assert len(first_run) == 9
         assert len(second_run) == 0
         conn.close()
 
@@ -84,7 +84,82 @@ class TestMigrationRunner:
             "item_type",
             "description",
             "is_active",
+            "bgg_collection_id",
         }
+        conn.close()
+
+    def test_bgg_id_is_no_longer_unique(self) -> None:
+        """Migration 009 drops UNIQUE(bgg_id): BGG can list several distinct
+        owned items under one bgg_id/objectid."""
+        conn = get_memory_connection()
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO games (bgg_id, name, thumbnail_url, year_published) "
+            "VALUES (268620, 'Similo: Mitos', 't1.jpg', 2020)"
+        )
+        conn.execute(
+            "INSERT INTO games (bgg_id, name, thumbnail_url, year_published) "
+            "VALUES (268620, 'Similo: Historia', 't2.jpg', 2020)"
+        )
+        conn.commit()
+        count = conn.execute(
+            "SELECT COUNT(*) FROM games WHERE bgg_id = 268620"
+        ).fetchone()[0]
+        assert count == 2
+        conn.close()
+
+    def test_bgg_collection_id_is_unique_when_set(self) -> None:
+        import sqlite3
+
+        conn = get_memory_connection()
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO games "
+            "(bgg_id, bgg_collection_id, name, thumbnail_url, year_published) "
+            "VALUES (1, 100, 'Catan', 't.jpg', 1995)"
+        )
+        conn.commit()
+        try:
+            conn.execute(
+                "INSERT INTO games "
+                "(bgg_id, bgg_collection_id, name, thumbnail_url, year_published) "
+                "VALUES (2, 100, 'Other', 't.jpg', 2000)"
+            )
+            conn.commit()
+            raise AssertionError("duplicate bgg_collection_id should be rejected")
+        except sqlite3.IntegrityError:
+            pass
+        conn.close()
+
+    def test_loans_fk_preserved_after_migration_009_rebuild(self) -> None:
+        """The games table rebuild (dropping UNIQUE(bgg_id)) must not lose
+        loans.game_id's ON DELETE RESTRICT foreign key."""
+        import sqlite3
+
+        conn = get_memory_connection()
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO games (bgg_id, name, thumbnail_url, year_published) "
+            "VALUES (1, 'Catan', 't.jpg', 1995)"
+        )
+        conn.execute(
+            "INSERT INTO members (email, display_name, first_name, last_name) "
+            "VALUES ('a@b.com', 'A', 'A', 'B')"
+        )
+        conn.commit()
+        game_id = conn.execute("SELECT id FROM games").fetchone()[0]
+        member_id = conn.execute("SELECT id FROM members").fetchone()[0]
+        conn.execute(
+            "INSERT INTO loans (game_id, member_id) VALUES (?, ?)",
+            (game_id, member_id),
+        )
+        conn.commit()
+        try:
+            conn.execute("DELETE FROM games WHERE id = ?", (game_id,))
+            conn.commit()
+            raise AssertionError("FK should have blocked this delete")
+        except sqlite3.IntegrityError:
+            pass
         conn.close()
 
     def test_games_item_type_index_created(self) -> None:


### PR DESCRIPTION
## Summary
- BGG's collection API can list several distinct owned items under one shared `bgg_id`/objectid (e.g. themed spin-offs BGG treats as versions of a single base game) — discovered via a real 4-way "Similo" family (Espeluznante, Fábulas, Historia, Mitos) all sharing objectid 268620 in the club's actual BGG collection. Since `games.bgg_id` was `UNIQUE` and the import identity, those collapsed into one catalog row, silently discarding the other 3.
- `games.bgg_collection_id` now stores BGG's per-copy collection entry id (`collid`), which is unique per owned item, and becomes the import identity. `bgg_id` stays as a non-unique reference field (BGG links, shared detail lookups via the `thing` API).
- Rows imported before this existed adopt their collection id automatically on the next import — no special backfill migration needed. The reconciliation diff only considers rows that already carry a `bgg_collection_id`, so the transitional run correctly treats "nothing is missing yet" instead of wrongly flagging every not-yet-adopted row as gone.
- `enrich_games` no longer overwrites a row's own captured image with the shared `thing`-API image (which pools across colliding `bgg_id`s) — it only falls back to the shared image when a row doesn't have one of its own yet.
- SQLite has no `ALTER TABLE ... DROP CONSTRAINT`, so dropping `UNIQUE(bgg_id)` required a full table rebuild (migration 009) with `PRAGMA foreign_keys=OFF` around it, since `loans.game_id` references `games(id) ON DELETE RESTRICT`.

## Related Tasks
No linked GitHub issue — skipped per explicit request (same as the prior BGG re-import PR).

## Test plan
- [x] `pytest` — full backend suite passes (280 passed; 15 pre-existing member-import failures confirmed unrelated and present on `development` before this branch)
- [x] `ruff check` clean; `black --check` clean on all files this PR touches
- [x] Migration rebuild verified: FK preserved (`PRAGMA foreign_key_check` empty, `DELETE` on a referenced game still blocked), `bgg_id` no longer unique, `bgg_collection_id` uniqueness enforced when set
- [x] Real-data dry-run: pulled a copy of production's `games` table (356 rows, no PII — members/loans excluded) with the actual live Similo collision, ran migration 009 + a real `ImportGamesUseCase` execution against it locally — legacy rows adopted their collection id (`updated=236`), exactly the 3 missing Similo variants were created (`created=3`), zero FK violations, second run fully idempotent (`created=0`)
- [x] Synthetic unit/integration coverage for: legacy-row adoption, distinct items sharing one `bgg_id` landing in separate rows with distinct slugs/images, `update_details` targeting by row id (not `bgg_id`) so shared-`thing`-API updates don't clobber sibling rows' images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrWxizeJHkQBLqLHAcYDF8