### PR TITLE
feat(profile): add member information page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,21 @@
 Website for the **Refugio del Sátiro** RPG association.
 
 Current scope: the game-lending feature (mounted at `/ludoteca`). Members can
-browse the catalog, borrow games, and return them. The catalog is imported
-from [BoardGameGeek](https://boardgamegeek.com/collection/user/RefugioDelSatiro?subtype=boardgame&own=1&ff=1).
-The catalog is publicly browsable read-only (no account needed; borrowing
-requires logging in). Legacy `/prestamos` URLs redirect permanently to
-`/ludoteca`.
+browse the catalog, borrow and return games, and review their own profile. The
+catalog is imported from
+[BoardGameGeek](https://boardgamegeek.com/collection/user/RefugioDelSatiro?subtype=boardgame&own=1&ff=1).
+The catalog is publicly browsable read-only (no account needed; borrowing and
+reviewing a member's own profile require logging in). Legacy `/prestamos` URLs
+redirect permanently to `/ludoteca`.
 
 A public membership-validation page lives at `/ludoteca/validacion`: anyone
 can enter a member number and see whether that person is a current member
 (name, ES/NO ES socio·a verdict, last paid fee). The legacy
 `/Validacion-Membresia` URL (printed on QR codes) 301-redirects there. The
 page also accepts `?id=<n>` for direct lookups.
+
+Authenticated members can review their read-only membership information at
+`/ludoteca/profile`, with links to their loans and password-change flow.
 
 Everything else under `/` is mirrored from the club's Google Sites site by a
 small scraper (see `scraper/`) and served as static files by Caddy.

--- a/backend/api/routes/auth_routes.py
+++ b/backend/api/routes/auth_routes.py
@@ -47,9 +47,16 @@ class ChangePasswordRequest(BaseModel):
 
 class MemberResponse(BaseModel):
     id: int
-    display_name: str
+    member_number: int | None
+    first_name: str
+    last_name: str
+    nickname: str | None
+    phone: str | None
     email: str
+    display_name: str
     is_admin: bool
+    is_active: bool
+    last_payment: str | None
 
 
 class OkResponse(BaseModel):
@@ -59,9 +66,16 @@ class OkResponse(BaseModel):
 def _member_to_response(member: Member) -> MemberResponse:
     return MemberResponse(
         id=member.id,
-        display_name=member.display_name,
+        member_number=member.member_number,
+        first_name=member.first_name,
+        last_name=member.last_name,
+        nickname=member.nickname,
+        phone=member.phone,
         email=member.email,
+        display_name=member.display_name,
         is_admin=member.is_admin,
+        is_active=member.is_active,
+        last_payment=member.last_payment,
     )
 
 

--- a/e2e/tests/site-shell.spec.ts
+++ b/e2e/tests/site-shell.spec.ts
@@ -20,10 +20,15 @@ const ADMIN_STATE = resolve(FIXTURES_DIR, "admin.json");
 
 const HOME = "/ludoteca/";
 const LOGIN_PATH = "/ludoteca/login";
+const PROFILE_PATH = "/ludoteca/profile";
 const LUDOTECA_LABEL = "Ludoteca";
+const MEMBER_DISPLAY_NAME = "E2E Member";
+const MEMBER_EMAIL = process.env.TEST_MEMBER_EMAIL ?? "TEST_email@domain.com";
 
-const isMobileProject = (projectName: string) => projectName === "chromium-mobile";
-const isDesktopProject = (projectName: string) => projectName === "chromium-desktop";
+const isMobileProject = (projectName: string) =>
+  projectName === "chromium-mobile";
+const isDesktopProject = (projectName: string) =>
+  projectName === "chromium-desktop";
 
 async function openLudotecaSubmenuOnMobile(page: Page) {
   await page.getByRole("button", { name: "Abrir menú" }).click();
@@ -45,12 +50,30 @@ async function revealLudotecaSubmenuOnDesktop(page: Page) {
     .hover();
 }
 
+async function openUserSubmenu(page: Page, projectName: string) {
+  if (isMobileProject(projectName)) {
+    await page.getByRole("button", { name: "Abrir menú" }).click();
+    await page
+      .getByRole("button", { name: MEMBER_DISPLAY_NAME, exact: true })
+      .filter({ visible: true })
+      .click();
+    return;
+  }
+
+  await page
+    .getByRole("button", { name: MEMBER_DISPLAY_NAME, exact: true })
+    .filter({ visible: true })
+    .hover();
+}
+
 test.describe("site-shell @ guest", () => {
   test.use({ storageState: GUEST_STATE });
 
   test("nav-logo-1: logo visible on home", async ({ page }) => {
     await page.goto(HOME);
-    const logo = page.getByRole("link", { name: /Refugio del Sátiro/i }).first();
+    const logo = page
+      .getByRole("link", { name: /Refugio del Sátiro/i })
+      .first();
     await expect(logo).toBeVisible();
     // The shield img is decorative (alt=""); the accessible name comes from
     // the link's aria-label plus the visible logo text.
@@ -67,9 +90,23 @@ test.describe("site-shell @ guest", () => {
       await page.getByRole("button", { name: "Abrir menú" }).click();
     }
 
-    const loginLink = page.getByRole("link", { name: "Iniciar sesión" }).first();
+    const loginLink = page
+      .getByRole("link", { name: "Iniciar sesión" })
+      .first();
     await expect(loginLink).toBeVisible();
     await expect(loginLink).toHaveAttribute("href", LOGIN_PATH);
+  });
+
+  test("profile-guest-1: direct profile navigation redirects to login", async ({
+    page,
+  }) => {
+    await page.goto(PROFILE_PATH);
+
+    await expect(page).toHaveURL(new RegExp(`${LOGIN_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Mi perfil" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByText(MEMBER_EMAIL)).toHaveCount(0);
   });
 });
 
@@ -95,9 +132,45 @@ test.describe("site-shell @ member", () => {
     await expect(
       page.getByRole("button", { name: "Cerrar sesión" }).first(),
     ).toBeVisible();
+    await expect(page.locator("text=Administración")).toHaveCount(0);
+  });
+
+  test("profile-member-1: member opens the read-only profile from the user menu", async ({
+    page,
+  }, testInfo) => {
+    const meRequests: string[] = [];
+    page.on("request", (request) => {
+      if (new URL(request.url()).pathname.endsWith("/api/me")) {
+        meRequests.push(request.url());
+      }
+    });
+
+    await page.goto(HOME);
+    await openUserSubmenu(page, testInfo.project.name);
+
+    const profileLink = page
+      .getByRole("link", { name: "Mi perfil", exact: true })
+      .filter({ visible: true });
+    await expect(profileLink).toHaveAttribute("href", PROFILE_PATH);
+    await profileLink.click();
+
+    await expect(page).toHaveURL(new RegExp(`${PROFILE_PATH}$`));
     await expect(
-      page.locator("text=Administración"),
-    ).toHaveCount(0);
+      page.getByRole("heading", { name: "Mi perfil" }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: MEMBER_EMAIL })).toBeVisible();
+    await expect(page.getByText("Estado de membresía")).toBeVisible();
+    await expect(page.getByText("Activo").first()).toBeVisible();
+    const profileActions = page.getByRole("navigation", {
+      name: "Acciones del perfil",
+    });
+    await expect(
+      profileActions.getByRole("link", { name: "Mis préstamos" }),
+    ).toBeVisible();
+    await expect(
+      profileActions.getByRole("link", { name: "Cambiar contraseña" }),
+    ).toBeVisible();
+    expect(meRequests).toHaveLength(1);
   });
 
   test("auth-1: Cerrar sesión clears prestamos_session sentinel", async ({
@@ -119,10 +192,7 @@ test.describe("site-shell @ member", () => {
 
     // "Cerrar sesión" is in the header actions slot — always visible on desktop,
     // no need to hover the Ludoteca submenu first.
-    await page
-      .getByRole("button", { name: "Cerrar sesión" })
-      .first()
-      .click();
+    await page.getByRole("button", { name: "Cerrar sesión" }).first().click();
 
     await expect
       .poll(async () =>
@@ -194,7 +264,9 @@ test.describe("site-shell @ static page (guest)", () => {
     } else {
       await page.getByRole("link", { name: "Socios" }).first().hover();
     }
-    const link = page.getByRole("link", { name: new RegExp(`^${LUDOTECA_LABEL}`) }).first();
+    const link = page
+      .getByRole("link", { name: new RegExp(`^${LUDOTECA_LABEL}`) })
+      .first();
     await expect(link).toBeVisible();
     // Scraped from the Socios submenu on the Google Site; the Caddyfile
     // 301-redirects /socios/ludoteca → /ludoteca at the network layer.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { AdminBggPage } from "./pages/AdminBggPage";
 import { RpgCatalogPage } from "./pages/RpgCatalogPage";
 import { RpgDetailPage } from "./pages/RpgDetailPage";
 import { ValidacionPage } from "./pages/ValidacionPage";
+import { ProfilePage } from "./pages/ProfilePage";
 
 export default function App() {
   return (
@@ -24,7 +25,10 @@ export default function App() {
         <CatalogModeProvider>
           <SiteNavProvider>
             <Routes>
-              <Route path="/" element={<Navigate to="/juegos-de-mesa" replace />} />
+              <Route
+                path="/"
+                element={<Navigate to="/juegos-de-mesa" replace />}
+              />
               <Route
                 path="/juegos-de-mesa"
                 element={
@@ -62,6 +66,14 @@ export default function App() {
                 element={
                   <PageLayout>
                     <MyLoansPage />
+                  </PageLayout>
+                }
+              />
+              <Route
+                path="/profile"
+                element={
+                  <PageLayout>
+                    <ProfilePage />
                   </PageLayout>
                 }
               />

--- a/frontend/src/components/SiteHeader/SiteHeader.test.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.test.tsx
@@ -63,9 +63,16 @@ function setMember() {
     ...mockAuthState,
     member: {
       id: 1,
+      member_number: 101,
+      first_name: "Test",
+      last_name: "User",
+      nickname: "Tester",
+      phone: "600 00 00 01",
       email: "user@test.com",
       display_name: "Test User",
       is_admin: false,
+      is_active: true,
+      last_payment: "24/01/2026",
     },
   };
 }
@@ -75,9 +82,16 @@ function setAdmin() {
     ...mockAuthState,
     member: {
       id: 2,
+      member_number: 102,
+      first_name: "Admin",
+      last_name: "User",
+      nickname: null,
+      phone: "600 00 00 02",
       email: "admin@test.com",
       display_name: "Admin User",
       is_admin: true,
+      is_active: true,
+      last_payment: "24/01/2026",
     },
   };
 }
@@ -168,10 +182,11 @@ describe("SiteHeader", () => {
       ).toEqual(0);
     });
 
-    it("does not show Mis préstamos, Cambiar contraseña, Cerrar sesión, or Administración for guest", () => {
+    it("does not show authenticated user-menu entries for guest", () => {
       setGuest();
       renderHeader();
 
+      expect(screen.queryByText("Mi perfil")).toBeNull();
       expect(screen.queryByText("Mis préstamos")).toBeNull();
       expect(screen.queryByText("Cambiar contraseña")).toBeNull();
       expect(screen.queryByText("Cerrar sesión")).toBeNull();
@@ -235,7 +250,7 @@ describe("SiteHeader", () => {
       expect(trigger!.querySelectorAll("svg").length).toEqual(1);
     });
 
-    it("renders exactly Mis préstamos, Cambiar contraseña and Cerrar sesión as menuitems for member", () => {
+    it("renders the exact member menu ordering", () => {
       setMember();
       renderHeader();
 
@@ -244,7 +259,24 @@ describe("SiteHeader", () => {
       const menuitems = screen
         .getAllByRole("menuitem")
         .map((el) => el.textContent?.trim());
-      expect(menuitems).toEqual(["Mis préstamos", "Cambiar contraseña", "Cerrar sesión"]);
+      expect(menuitems).toEqual([
+        "Mi perfil",
+        "Mis préstamos",
+        "Cambiar contraseña",
+        "Cerrar sesión",
+      ]);
+    });
+
+    it("links Mi perfil to /profile", () => {
+      setMember();
+      renderHeader();
+
+      const profileLinks = screen
+        .getAllByRole("menuitem")
+        .filter((el) => el.textContent?.trim() === "Mi perfil")
+        .map((el) => el.querySelector("a"));
+      expect(profileLinks).toEqual([expect.any(HTMLAnchorElement)]);
+      expect(profileLinks[0]).toHaveAttribute("href", "/profile");
     });
 
     it("links Mis préstamos to /my-loans", () => {
@@ -308,7 +340,7 @@ describe("SiteHeader", () => {
       expect(screen.getByText("Datos BGG").tagName).toEqual("A");
     });
 
-    it("orders the desktop menu Mis préstamos, Administración, Cerrar sesión", () => {
+    it("renders the exact admin top-level menu ordering", () => {
       setAdmin();
       const { container } = renderHeader();
 
@@ -319,11 +351,23 @@ describe("SiteHeader", () => {
         li.querySelector(":scope > a, :scope > button")?.textContent?.trim()
       );
       expect(topLevelLabels).toEqual([
+        "Mi perfil",
         "Mis préstamos",
         "Cambiar contraseña",
         "Administración",
         "Cerrar sesión",
       ]);
+    });
+
+    it("links Mi perfil to /profile for admin", () => {
+      setAdmin();
+      renderHeader();
+
+      const profileLink = screen
+        .getAllByRole("menuitem")
+        .find((el) => el.textContent?.trim() === "Mi perfil")
+        ?.querySelector("a");
+      expect(profileLink).toHaveAttribute("href", "/profile");
     });
 
     it("does not show nested admin items for guest", () => {
@@ -454,7 +498,32 @@ describe("SiteHeader", () => {
       expect(userTrigger!.getAttribute("aria-expanded")).toEqual("false");
       fireEvent.click(userTrigger!);
       expect(userTrigger!.getAttribute("aria-expanded")).toEqual("true");
+      expect(within(drawer).getByText("Mi perfil")).toHaveAttribute(
+        "href",
+        "/profile"
+      );
       expect(within(drawer).getByText("Mis préstamos").tagName).toEqual("A");
+    });
+
+    it("clicking Mi perfil in the drawer closes it", () => {
+      setMember();
+      const { container } = renderHeader();
+
+      const hamburger = screen.getByRole("button", { name: "Abrir menú" });
+      fireEvent.click(hamburger);
+
+      const drawer = container.querySelector("#mobile-drawer") as HTMLElement;
+      const userTrigger = within(drawer)
+        .getAllByRole("button")
+        .find(
+          (el) =>
+            el.textContent?.includes("Test User") &&
+            el.getAttribute("aria-haspopup") === "menu"
+        );
+      fireEvent.click(userTrigger!);
+      fireEvent.click(within(drawer).getByRole("link", { name: "Mi perfil" }));
+
+      expect(hamburger.getAttribute("aria-expanded")).toEqual("false");
     });
 
     // draw-6: nested Administración expands inside drawer

--- a/frontend/src/components/SiteHeader/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.tsx
@@ -105,6 +105,11 @@ function UserSubmenu({
       role="menu"
     >
       <li className={styles.submenuItem} role="menuitem">
+        <Link to="/profile" onClick={onItemClick}>
+          Mi perfil
+        </Link>
+      </li>
+      <li className={styles.submenuItem} role="menuitem">
         <Link to="/my-loans" onClick={onItemClick}>
           Mis préstamos
         </Link>

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -51,16 +51,30 @@ const game: GameWithStatus = {
 
 const member: CurrentMember = {
   id: 42,
+  member_number: 42,
+  first_name: "Alice",
+  last_name: "Smith",
+  nickname: "Ali",
+  phone: "600 111 222",
   display_name: "Alice Smith",
   email: "alice@example.com",
   is_admin: false,
+  is_active: true,
+  last_payment: "1/03/2026",
 };
 
 const admin: CurrentMember = {
   id: 99,
+  member_number: 99,
+  first_name: "Admin",
+  last_name: "User",
+  nickname: null,
+  phone: null,
   display_name: "Admin User",
   email: "admin@example.com",
   is_admin: true,
+  is_active: true,
+  last_payment: null,
 };
 
 const historyEntry: LoanHistoryEntry = {
@@ -116,13 +130,20 @@ describe("GameDetailPage borrow CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: BORROW_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: BORROW_CTA }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
   });
 
   it("shows the non-actionable 'Prestado' status instead of the CTA for a lent game", () => {
     setHook({
-      game: { ...game, status: "lent", borrower_display_name: null, loan_id: null },
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: null,
+        loan_id: null,
+      },
     });
     setMember(null);
 
@@ -190,7 +211,9 @@ describe("GameDetailPage anonymous mode (/ludoteca unauthenticated)", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: HISTORY_HEADING })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: HISTORY_HEADING }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Bob Jones")).toBeInTheDocument();
   });
 });
@@ -198,7 +221,12 @@ describe("GameDetailPage anonymous mode (/ludoteca unauthenticated)", () => {
 describe("GameDetailPage borrower visibility", () => {
   it("hides borrower name and shows the no-name 'Prestado' badge when payload omits the name (anonymous)", () => {
     setHook({
-      game: { ...game, status: "lent", borrower_display_name: null, loan_id: null },
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: null,
+        loan_id: null,
+      },
     });
     setMember(null);
 
@@ -238,7 +266,9 @@ describe("GameDetailPage return CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: RETURN_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
   });
 
   it("shows the return CTA to an admin even when the loan is someone else's", () => {
@@ -254,7 +284,9 @@ describe("GameDetailPage return CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: RETURN_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -281,13 +313,20 @@ describe("GameDetailPage history section", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: HISTORY_HEADING })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: HISTORY_HEADING }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Bob Jones")).toBeInTheDocument();
   });
 
   it("renders history entries for a lent game", () => {
     setHook({
-      game: { ...game, status: "lent", borrower_display_name: null, loan_id: 7 },
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: null,
+        loan_id: 7,
+      },
       history: [historyEntry],
     });
     setMember(null);

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -1,0 +1,127 @@
+.profile-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 var(--space-md) var(--space-2xl);
+}
+
+.profile-loading {
+  padding: var(--space-2xl);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.profile-card {
+  overflow: hidden;
+}
+
+.profile-card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.profile-card-heading h2 {
+  margin: 0;
+  color: var(--color-text-heading);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+}
+
+.profile-status {
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+
+.profile-status--active {
+  color: var(--color-text-body);
+  background-color: var(--color-available);
+}
+
+.profile-status--inactive {
+  color: var(--color-text-body);
+  background-color: var(--color-lent);
+}
+
+.profile-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 var(--space-xl);
+  margin: 0;
+}
+
+.profile-fields > div {
+  min-width: 0;
+  padding: var(--space-lg) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.profile-fields dt {
+  margin-bottom: var(--space-xs);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+
+.profile-fields dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-body);
+}
+
+.profile-fields a {
+  color: var(--color-brand);
+}
+
+.profile-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+}
+
+.profile-links a {
+  display: inline-flex;
+  padding: var(--space-sm) var(--space-lg);
+  border: 1px solid var(--color-brand);
+  border-radius: var(--radius-sm);
+  color: var(--color-brand);
+  font-weight: var(--font-weight-bold);
+  text-decoration: none;
+}
+
+.profile-links a:hover {
+  color: var(--color-brand-contrast);
+  background-color: var(--color-brand);
+}
+
+.profile-fields a:focus-visible,
+.profile-links a:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .profile-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-card-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .profile-links {
+    flex-direction: column;
+  }
+
+  .profile-links a {
+    justify-content: center;
+  }
+}

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,145 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CurrentMember } from "../types/member";
+import { ProfilePage } from "./ProfilePage";
+
+const useAuthMock = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const MEMBER: CurrentMember = {
+  id: 901,
+  member_number: 27,
+  first_name: "Ana",
+  last_name: "García López",
+  nickname: "Anita",
+  phone: "600 123 456",
+  email: "ana@example.invalid",
+  display_name: "Anita",
+  is_admin: false,
+  is_active: true,
+  last_payment: "1/03/2026",
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/profile"]}>
+      <Routes>
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/login" element={<h1>Inicio de sesión</h1>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthMock.mockReturnValue({ member: MEMBER, loading: false });
+});
+
+describe("ProfilePage authentication states", () => {
+  it("shows Spanish loading copy while authentication is loading", () => {
+    useAuthMock.mockReturnValue({ member: null, loading: true });
+
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Mi perfil" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cargando perfil...")).toBeInTheDocument();
+  });
+
+  it("redirects a guest to login", () => {
+    useAuthMock.mockReturnValue({ member: null, loading: false });
+
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Inicio de sesión" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Mi perfil" })).toBeNull();
+  });
+});
+
+describe("ProfilePage member information", () => {
+  it("renders every requested label and exact non-null value", () => {
+    renderPage();
+
+    expect(screen.getByText("Número de socio")).toBeInTheDocument();
+    expect(screen.getByText("27")).toBeInTheDocument();
+    expect(screen.getByText("Nombre")).toBeInTheDocument();
+    expect(screen.getByText("Ana")).toBeInTheDocument();
+    expect(screen.getByText("Apellidos")).toBeInTheDocument();
+    expect(screen.getByText("García López")).toBeInTheDocument();
+    expect(screen.getByText("Apodo")).toBeInTheDocument();
+    expect(screen.getByText("Anita")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "ana@example.invalid" }),
+    ).toHaveAttribute("href", "mailto:ana@example.invalid");
+    expect(screen.getByText("Teléfono")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "600 123 456" })).toHaveAttribute(
+      "href",
+      "tel:600 123 456",
+    );
+    expect(screen.getByText("Estado de membresía")).toBeInTheDocument();
+    expect(screen.getAllByText("Activo")).toHaveLength(2);
+    expect(screen.getByText("Última cuota")).toBeInTheDocument();
+    expect(screen.getByText("1/03/2026")).toBeInTheDocument();
+  });
+
+  it("renders concrete fallbacks for every nullable value", () => {
+    useAuthMock.mockReturnValue({
+      member: {
+        ...MEMBER,
+        member_number: null,
+        nickname: null,
+        phone: null,
+        last_payment: null,
+      },
+      loading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getAllByText("No disponible")).toHaveLength(4);
+  });
+
+  it("renders inactive membership status in text", () => {
+    useAuthMock.mockReturnValue({
+      member: { ...MEMBER, is_active: false },
+      loading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getAllByText("Inactivo")).toHaveLength(2);
+    expect(screen.queryByText("Activo")).toBeNull();
+  });
+});
+
+describe("ProfilePage navigation and read-only boundary", () => {
+  it("links to loans and password change", () => {
+    renderPage();
+
+    expect(screen.getByRole("link", { name: "Mis préstamos" })).toHaveAttribute(
+      "href",
+      "/my-loans",
+    );
+    expect(
+      screen.getByRole("link", { name: "Cambiar contraseña" }),
+    ).toHaveAttribute("href", "/change-password");
+  });
+
+  it("does not render editing or saving controls", () => {
+    renderPage();
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.queryByText(/Editar|Guardar/i)).toBeNull();
+  });
+});

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,93 @@
+import { Link, Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { Card } from "../ui/Card";
+import { PageTitle } from "../ui/PageTitle";
+import "./ProfilePage.css";
+
+const UNAVAILABLE = "No disponible";
+
+export function ProfilePage() {
+  const { member, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="profile-page">
+        <PageTitle>Mi perfil</PageTitle>
+        <p className="profile-loading">Cargando perfil...</p>
+      </div>
+    );
+  }
+
+  if (member === null) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return (
+    <div className="profile-page">
+      <PageTitle>Mi perfil</PageTitle>
+
+      <Card
+        as="section"
+        className="profile-card"
+        aria-labelledby="profile-details-title"
+      >
+        <div className="profile-card-heading">
+          <h2 id="profile-details-title">Datos de membresía</h2>
+          <span
+            className={`profile-status profile-status--${member.is_active ? "active" : "inactive"}`}
+          >
+            {member.is_active ? "Activo" : "Inactivo"}
+          </span>
+        </div>
+
+        <dl className="profile-fields">
+          <div>
+            <dt>Número de socio</dt>
+            <dd>{member.member_number ?? UNAVAILABLE}</dd>
+          </div>
+          <div>
+            <dt>Nombre</dt>
+            <dd>{member.first_name}</dd>
+          </div>
+          <div>
+            <dt>Apellidos</dt>
+            <dd>{member.last_name}</dd>
+          </div>
+          <div>
+            <dt>Apodo</dt>
+            <dd>{member.nickname ?? UNAVAILABLE}</dd>
+          </div>
+          <div>
+            <dt>Email</dt>
+            <dd>
+              <a href={`mailto:${member.email}`}>{member.email}</a>
+            </dd>
+          </div>
+          <div>
+            <dt>Teléfono</dt>
+            <dd>
+              {member.phone ? (
+                <a href={`tel:${member.phone}`}>{member.phone}</a>
+              ) : (
+                UNAVAILABLE
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt>Estado de membresía</dt>
+            <dd>{member.is_active ? "Activo" : "Inactivo"}</dd>
+          </div>
+          <div>
+            <dt>Última cuota</dt>
+            <dd>{member.last_payment ?? UNAVAILABLE}</dd>
+          </div>
+        </dl>
+      </Card>
+
+      <nav className="profile-links" aria-label="Acciones del perfil">
+        <Link to="/my-loans">Mis préstamos</Link>
+        <Link to="/change-password">Cambiar contraseña</Link>
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/pages/RpgDetailPage.test.tsx
+++ b/frontend/src/pages/RpgDetailPage.test.tsx
@@ -47,16 +47,30 @@ const item: RpgItem = {
 
 const member: CurrentMember = {
   id: 42,
+  member_number: 42,
+  first_name: "Alice",
+  last_name: "Smith",
+  nickname: "Ali",
+  phone: "600 111 222",
   display_name: "Alice Smith",
   email: "alice@example.com",
   is_admin: false,
+  is_active: true,
+  last_payment: "1/03/2026",
 };
 
 const admin: CurrentMember = {
   id: 99,
+  member_number: 99,
+  first_name: "Admin",
+  last_name: "User",
+  nickname: null,
+  phone: null,
   display_name: "Admin User",
   email: "admin@example.com",
   is_admin: true,
+  is_active: true,
+  last_payment: null,
 };
 
 const historyEntry: LoanHistoryEntry = {
@@ -127,13 +141,20 @@ describe("RpgDetailPage borrow CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: BORROW_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: BORROW_CTA }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
   });
 
   it("shows the 'Prestado' status instead of the CTA for a lent item when logged out", () => {
     setHook({
-      item: { ...item, status: "lent", borrower_display_name: null, loan_id: null },
+      item: {
+        ...item,
+        status: "lent",
+        borrower_display_name: null,
+        loan_id: null,
+      },
     });
     setMember(null);
 
@@ -200,7 +221,9 @@ describe("RpgDetailPage anonymous mode", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: HISTORY_HEADING })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: HISTORY_HEADING }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Bob Jones")).toBeInTheDocument();
   });
 });
@@ -208,7 +231,12 @@ describe("RpgDetailPage anonymous mode", () => {
 describe("RpgDetailPage borrower visibility", () => {
   it("shows no-name 'Prestado' badge when payload omits the name", () => {
     setHook({
-      item: { ...item, status: "lent", borrower_display_name: null, loan_id: null },
+      item: {
+        ...item,
+        status: "lent",
+        borrower_display_name: null,
+        loan_id: null,
+      },
     });
     setMember(null);
 
@@ -248,7 +276,9 @@ describe("RpgDetailPage return CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: RETURN_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
   });
 
   it("shows the return CTA to an admin even when the loan is someone else's", () => {
@@ -264,7 +294,9 @@ describe("RpgDetailPage return CTA", () => {
 
     renderPage();
 
-    expect(screen.getByRole("button", { name: RETURN_CTA })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -319,7 +351,9 @@ describe("RpgDetailPage history section", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: HISTORY_HEADING })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: HISTORY_HEADING }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Bob Jones")).toBeInTheDocument();
   });
 
@@ -342,12 +376,13 @@ describe("RpgDetailPage content", () => {
 
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "Dungeons & Dragons" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Dungeons & Dragons" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("1974")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Ver en RPGGeek" })).toHaveAttribute(
-      "href",
-      "https://rpggeek.com/rpgitem/200",
-    );
+    expect(
+      screen.getByRole("link", { name: "Ver en RPGGeek" }),
+    ).toHaveAttribute("href", "https://rpggeek.com/rpgitem/200");
   });
 
   it("renders the back link to the catalog", () => {

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,8 +1,15 @@
 export interface CurrentMember {
   readonly id: number;
-  readonly display_name: string;
+  readonly member_number: number | null;
+  readonly first_name: string;
+  readonly last_name: string;
+  readonly nickname: string | null;
+  readonly phone: string | null;
   readonly email: string;
+  readonly display_name: string;
   readonly is_admin: boolean;
+  readonly is_active: boolean;
+  readonly last_payment: string | null;
 }
 
 export const genderLabels = ["socio", "socia", "socio/a"] as const;

--- a/openspec/specs/lending-member-profile/spec.md
+++ b/openspec/specs/lending-member-profile/spec.md
@@ -1,0 +1,65 @@
+# lending-member-profile Specification
+
+## Purpose
+
+Define the authenticated, read-only self-profile and its API security boundary for lending-app members.
+
+## Requirements
+
+### Requirement: Authenticated self-profile
+
+The system SHALL provide a read-only profile at `/ludoteca/profile` for the member identified by the signed session. The profile SHALL NOT accept a member ID, expose another member's record, or provide editing controls.
+
+#### Scenario: Authenticated member opens their profile
+
+- **WHEN** an authenticated member opens `/ludoteca/profile`
+- **THEN** the system SHALL display the profile associated with that member's session
+- **AND** SHALL NOT provide edit or save controls
+
+#### Scenario: Guest opens the profile route
+
+- **WHEN** a visitor without a valid session opens `/ludoteca/profile`
+- **THEN** the frontend SHALL redirect the visitor to `/ludoteca/login`
+- **AND** `GET /api/me` without a valid session SHALL return HTTP 401
+
+### Requirement: Member profile information
+
+The profile SHALL display the member's membership number, first name, last name, nickname, email, phone, active status, and last payment using the current-member data already held by the authentication context.
+
+#### Scenario: Complete membership information
+
+- **WHEN** the current member has values for every profile field
+- **THEN** the profile SHALL display each value and render active status as `Activo` or `Inactivo`
+- **AND** SHALL NOT make a second request for the current member
+
+#### Scenario: Nullable membership information
+
+- **WHEN** membership number, nickname, phone, or last payment is null
+- **THEN** the profile SHALL show an explicit unavailable fallback for each null value
+- **AND** the API SHALL serialize each nullable field as JSON `null`
+
+### Requirement: Profile navigation
+
+The authenticated member menu SHALL expose the profile, and the profile SHALL link to the existing loans and password-change flows.
+
+#### Scenario: Member navigates from the authenticated menu
+
+- **WHEN** an authenticated member opens the user menu and selects `Mi perfil`
+- **THEN** the system SHALL navigate to `/ludoteca/profile`
+- **AND** the profile SHALL include links labelled `Mis préstamos` and `Cambiar contraseña`
+
+### Requirement: Current-member API allow-list
+
+`GET /api/me` SHALL derive the current member exclusively from the signed session and SHALL return exactly `id`, `member_number`, `first_name`, `last_name`, `nickname`, `phone`, `email`, `display_name`, `is_admin`, `is_active`, and `last_payment`.
+
+#### Scenario: Authenticated API response
+
+- **WHEN** an authenticated member requests `GET /api/me`
+- **THEN** the response SHALL contain exactly the allow-listed fields for the session member
+- **AND** SHALL retain `is_admin` for authorization-aware navigation
+
+#### Scenario: Sensitive and internal fields remain private
+
+- **WHEN** `GET /api/me` serializes the session member
+- **THEN** the response SHALL NOT contain `password_hash`, `created_at`, `updated_at`, or `gender`
+- **AND** no profile endpoint SHALL accept an arbitrary member ID

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -43,7 +43,8 @@ class TestLogin:
         )
 
         response = client.post(
-            "/api/login", json={"email": "TEST_email@domain.com", "password": "mypassword"}
+            "/api/login",
+            json={"email": "TEST_email@domain.com", "password": "mypassword"},
         )
         assert response.status_code == 200
         assert response.json() == {"ok": True}
@@ -80,7 +81,8 @@ class TestLogin:
         )
 
         response = client.post(
-            "/api/login", json={"email": "TEST_email@domain.com", "password": "anything"}
+            "/api/login",
+            json={"email": "TEST_email@domain.com", "password": "anything"},
         )
         assert response.status_code == 401
 
@@ -97,37 +99,99 @@ class TestGetMe:
     def test_get_me_authenticated(self) -> None:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
-        member_repo.upsert_by_email(
-            1, "Test", "User", None, None, "TEST_email@domain.com", "Test User", True
+        member = member_repo.upsert_by_email(
+            42,
+            "Ada",
+            "Lovelace",
+            "Enchantress of Numbers",
+            "+34 600 123 456",
+            "ada@example.invalid",
+            "Ada Lovelace",
+            True,
+            last_payment="2026-06-30",
+            gender="female",
         )
-        member_repo.set_password_hash(
-            member_repo.get_by_email("TEST_email@domain.com").id,  # type: ignore[union-attr]
-            hash_password("mypassword"),
-        )
+        member_repo.set_password_hash(member.id, hash_password("mypassword"))
 
         # Create JWT directly for the /me request
         from backend.api.auth import create_jwt
         from backend.api.dependencies import _settings
 
-        member = member_repo.get_by_email("TEST_email@domain.com")
-        assert member is not None
         token = create_jwt(member.id, _settings.jwt_secret)
 
         response = client.get("/api/me", headers={"Cookie": f"session_token={token}"})
+
         assert response.status_code == 200
-        data = response.json()
-        assert data["display_name"] == "Test User"
-        assert data["email"] == "TEST_email@domain.com"
-        assert data["is_admin"] is True
+        assert response.json() == {
+            "id": member.id,
+            "member_number": 42,
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "nickname": "Enchantress of Numbers",
+            "phone": "+34 600 123 456",
+            "email": "ada@example.invalid",
+            "display_name": "Ada Lovelace",
+            "is_admin": True,
+            "is_active": True,
+            "last_payment": "2026-06-30",
+        }
+        assert {
+            "password_hash",
+            "created_at",
+            "updated_at",
+            "gender",
+        }.isdisjoint(response.json())
+
+    def test_get_me_preserves_nullable_profile_fields(self) -> None:
+        client, conn = _setup_test_client()
+        member_repo = SqliteMemberRepository(conn)
+        member = member_repo.upsert_by_email(
+            None,
+            "Grace",
+            "Hopper",
+            None,
+            None,
+            "grace@example.invalid",
+            "Grace Hopper",
+            False,
+            last_payment=None,
+        )
+
+        from backend.api.auth import create_jwt
+        from backend.api.dependencies import _settings
+
+        token = create_jwt(member.id, _settings.jwt_secret)
+
+        response = client.get("/api/me", headers={"Cookie": f"session_token={token}"})
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": member.id,
+            "member_number": None,
+            "first_name": "Grace",
+            "last_name": "Hopper",
+            "nickname": None,
+            "phone": None,
+            "email": "grace@example.invalid",
+            "display_name": "Grace Hopper",
+            "is_admin": False,
+            "is_active": True,
+            "last_payment": None,
+        }
 
     def test_get_me_unauthenticated(self) -> None:
         client, _ = _setup_test_client()
+
         response = client.get("/api/me")
+
         assert response.status_code == 401
+        assert response.json() == {"detail": "Es necesario iniciar sesión."}
 
 
 class TestChangePassword:
-    def _login_cookie(self, member_repo: SqliteMemberRepository, member_id: int) -> dict[str, str]:
+    def _login_cookie(
+        self, member_repo: SqliteMemberRepository, member_id: int
+    ) -> dict[str, str]:
         from backend.api.auth import create_jwt
         from backend.api.dependencies import _settings
 


### PR DESCRIPTION
## Summary

- Expand `/api/me` with an explicit allow-list of the current member's permitted profile fields while keeping sensitive/internal fields out.
- Add a responsive, read-only `/ludoteca/profile` page backed by the existing AuthContext state, with null fallbacks and links to loans and password change.
- Add one shared `Mi perfil` submenu entry for authenticated desktop and mobile navigation.
- Document the route, contract, guest behavior, and security boundary in the living OpenSpec and README.
- Cover member discovery and guest redirect flows in desktop and mobile Playwright tests.

## Test plan

- `pytest -q tests/api/test_auth_routes.py` (14 passed)
- Profile/header Vitest selection (77 passed)
- Full frontend suite (185 passed)
- `ruff check backend tests`
- Scoped mypy for the changed auth route
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Desktop Playwright profile cases (2 passed)
- Mobile Playwright profile cases (2 passed)

The full backend suite reaches 318 passing tests. Its 16 failures are existing duplicate member-email fixtures plus the ignored mirror index; no profile tests fail.

## Related Tasks

- Closes #104
