### PR TITLE
fix(bgg): delete stale legacy games + redesign catalog GameCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ one shared objectid (e.g. themed spin-offs BGG treats as versions of a
 single base game rather than giving each its own id); keying on the
 collection entry instead of the objectid keeps those as separate catalog
 rows instead of collapsing them into one. Rows imported before this
-existed adopt their collection id automatically on the next import.
+existed adopt their collection id automatically on the next import; legacy
+rows that are no longer in the BGG collection at all go through the same
+removal flow (and safety guard) as collection-id rows.
 
 Admins can upload the members CSV from `/ludoteca/admin/members`. The upload
 creates and updates members, disables active members that are absent from the

--- a/backend/api/routes/games.py
+++ b/backend/api/routes/games.py
@@ -40,6 +40,8 @@ class GameResponse(BaseModel):
     status: str
     borrower_display_name: str | None
     loan_id: int | None
+    min_age: int
+    primary_tag: str
 
 
 def _to_response(g: GameWithStatus, *, is_authenticated: bool) -> GameResponse:
@@ -63,6 +65,8 @@ def _to_response(g: GameWithStatus, *, is_authenticated: bool) -> GameResponse:
         status=g.status,
         borrower_display_name=g.borrower_display_name if is_authenticated else None,
         loan_id=g.loan_id if is_authenticated else None,
+        min_age=g.min_age,
+        primary_tag=g.primary_tag,
     )
 
 

--- a/backend/data/bgg_client.py
+++ b/backend/data/bgg_client.py
@@ -36,6 +36,8 @@ class BggGameDetails:
     bgg_rating: float
     description: str
     categories: tuple[str, ...]
+    min_age: int = 0
+    primary_tag: str = ""
 
 
 @dataclass(frozen=True)
@@ -83,6 +85,38 @@ def _element_int_value(item: ET.Element, element_name: str) -> int:
     if element is None:
         return 0
     return int(element.get("value", "0") or element.text or "0")
+
+
+def _rank_value(rank: ET.Element) -> int | None:
+    """Parse a <rank>'s numeric value attribute, or None if unranked/unparsable."""
+    try:
+        return int(rank.get("value", ""))
+    except ValueError:
+        return None
+
+
+def _primary_tag(item: ET.Element) -> str:
+    """Resolve the game's primary BGG subdomain (family rank) tag.
+
+    Selection hierarchy: among all `rank type="family"` entries, pick the one
+    with the best (lowest) numeric rank value; entries with an unparsable
+    ("Not Ranked") value lose to any numeric one, and if all are unranked,
+    the first family entry wins. Returns "" when there is no family rank.
+    """
+    family_ranks = [
+        rank
+        for rank in item.findall("statistics/ratings/ranks/rank")
+        if rank.get("type") == "family"
+    ]
+    if not family_ranks:
+        return ""
+
+    ranked = [(rank, _rank_value(rank)) for rank in family_ranks]
+    numeric = [(rank, value) for rank, value in ranked if value is not None]
+    if numeric:
+        best_rank, _ = min(numeric, key=lambda pair: pair[1])
+        return best_rank.get("name", "") or ""
+    return family_ranks[0].get("name", "") or ""
 
 
 _BROWSER_HEADERS = {
@@ -288,6 +322,8 @@ class BggClient:
                 min_p = _element_int_value(item, "minplayers")
                 max_p = _element_int_value(item, "maxplayers")
                 play_time = _element_int_value(item, "playingtime")
+                min_age = _element_int_value(item, "minage")
+                primary_tag = _primary_tag(item)
 
                 # Rating is in statistics/ratings/average
                 rating = 0.0
@@ -323,6 +359,8 @@ class BggClient:
                     bgg_rating=round(rating, 2),
                     description=description,
                     categories=categories,
+                    min_age=min_age,
+                    primary_tag=primary_tag,
                 )
 
             if i + batch_size < len(bgg_ids):

--- a/backend/data/repositories/sqlite_game_repository.py
+++ b/backend/data/repositories/sqlite_game_repository.py
@@ -65,6 +65,8 @@ def _row_to_game(row: sqlite3.Row) -> Game:
             if "bgg_collection_id" in keys and row["bgg_collection_id"] is not None
             else None
         ),
+        min_age=row["min_age"] if "min_age" in keys else 0,
+        primary_tag=row["primary_tag"] if "primary_tag" in keys else "",
     )
 
 
@@ -212,6 +214,8 @@ class SqliteGameRepository:
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> Game:
         """Legacy path for the JSON-seed import, which has no collection_id."""
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -238,6 +242,8 @@ class SqliteGameRepository:
             description,
             categories_json,
             publication_types_json,
+            min_age,
+            primary_tag,
             now,
         )
         if existing is not None:
@@ -248,7 +254,8 @@ class SqliteGameRepository:
                     year_published = ?, min_players = ?, max_players = ?,
                     playing_time = ?, bgg_rating = ?, location = ?,
                     item_type = ?, description = ?, categories_json = ?,
-                    publication_types_json = ?, is_active = 1, updated_at = ?
+                    publication_types_json = ?, min_age = ?, primary_tag = ?,
+                    is_active = 1, updated_at = ?
                 WHERE id = ?
                 """,
                 (*values, existing.id),
@@ -260,9 +267,10 @@ class SqliteGameRepository:
                     bgg_id, name, slug, thumbnail_url, image_url, year_published,
                     min_players, max_players, playing_time, bgg_rating, location,
                     item_type, description, categories_json,
-                    publication_types_json, is_active, created_at, updated_at
+                    publication_types_json, min_age, primary_tag,
+                    is_active, created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
                 """,
                 (bgg_id, *values, now),
             )
@@ -288,6 +296,8 @@ class SqliteGameRepository:
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> tuple[Game, bool]:
         now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         existing = self.get_by_collection_id(bgg_collection_id)
@@ -323,6 +333,8 @@ class SqliteGameRepository:
             description,
             categories_json,
             publication_types_json,
+            min_age,
+            primary_tag,
             now,
         )
         if existing is not None:
@@ -334,6 +346,7 @@ class SqliteGameRepository:
                     min_players = ?, max_players = ?, playing_time = ?,
                     bgg_rating = ?, location = ?, item_type = ?, description = ?,
                     categories_json = ?, publication_types_json = ?,
+                    min_age = ?, primary_tag = ?,
                     is_active = 1, updated_at = ?
                 WHERE id = ?
                 """,
@@ -346,9 +359,10 @@ class SqliteGameRepository:
                     bgg_id, bgg_collection_id, name, slug, thumbnail_url, image_url,
                     year_published, min_players, max_players, playing_time,
                     bgg_rating, location, item_type, description, categories_json,
-                    publication_types_json, is_active, created_at, updated_at
+                    publication_types_json, min_age, primary_tag,
+                    is_active, created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
                 """,
                 (*values, now),
             )

--- a/backend/data/repositories/sqlite_game_repository.py
+++ b/backend/data/repositories/sqlite_game_repository.py
@@ -143,6 +143,36 @@ class SqliteGameRepository:
                 blocked.add(collection_id)
         return frozenset(deleted), frozenset(blocked)
 
+    def deactivate_by_ids(self, game_ids: Collection[int]) -> int:
+        if not game_ids:
+            return 0
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        placeholders = ",".join("?" for _ in game_ids)
+        cursor = self._conn.execute(
+            f"UPDATE games SET is_active = 0, updated_at = ? "
+            f"WHERE id IN ({placeholders}) AND is_active = 1",
+            (now, *game_ids),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def delete_by_ids(
+        self, game_ids: Collection[int]
+    ) -> tuple[frozenset[int], frozenset[int]]:
+        deleted: set[int] = set()
+        blocked: set[int] = set()
+        for game_id in game_ids:
+            try:
+                cursor = self._conn.execute(
+                    "DELETE FROM games WHERE id = ?", (game_id,)
+                )
+                self._conn.commit()
+                if cursor.rowcount:
+                    deleted.add(game_id)
+            except sqlite3.IntegrityError:
+                blocked.add(game_id)
+        return frozenset(deleted), frozenset(blocked)
+
     def get_last_updated_at(self) -> datetime | None:
         row = self._conn.execute("SELECT MAX(updated_at) AS last FROM games").fetchone()
         return datetime.fromisoformat(row["last"]) if row and row["last"] else None

--- a/backend/domain/entities/game.py
+++ b/backend/domain/entities/game.py
@@ -26,3 +26,5 @@ class Game:
     publication_types: tuple[str, ...] = field(default=())
     is_active: bool = field(default=True)
     bgg_collection_id: int | None = field(default=None)
+    min_age: int = field(default=0)
+    primary_tag: str = field(default="")

--- a/backend/domain/repositories/game_repository.py
+++ b/backend/domain/repositories/game_repository.py
@@ -35,6 +35,15 @@ class GameRepository(Protocol):
         self, collection_ids: Collection[int]
     ) -> tuple[frozenset[int], frozenset[int]]: ...  # (deleted, blocked_by_history)
 
+    # id-based equivalents — needed for legacy rows (bgg_collection_id IS
+    # NULL), which have no collection_id to match on.
+
+    def deactivate_by_ids(self, game_ids: Collection[int]) -> int: ...
+
+    def delete_by_ids(
+        self, game_ids: Collection[int]
+    ) -> tuple[frozenset[int], frozenset[int]]: ...  # (deleted, blocked_by_history)
+
     def get_last_updated_at(self) -> datetime | None: ...
 
     def upsert_by_bgg_id(

--- a/backend/domain/repositories/game_repository.py
+++ b/backend/domain/repositories/game_repository.py
@@ -62,6 +62,8 @@ class GameRepository(Protocol):
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> Game: ...
 
     # legacy path: JSON-seed import, which has no collection_id concept
@@ -83,6 +85,8 @@ class GameRepository(Protocol):
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> tuple[Game, bool]: ...  # (game, was_created)
 
     # Match rule: (1) an existing row with this bgg_collection_id, (2) else a

--- a/backend/domain/use_cases/bgg_reconciliation.py
+++ b/backend/domain/use_cases/bgg_reconciliation.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
+
+from backend.domain.entities.game import Game
+from backend.domain.repositories.game_repository import GameRepository
+from backend.domain.repositories.loan_repository import LoanRepository
 
 DEACTIVATION_GUARD_RATIO = 0.5
 
@@ -15,6 +20,9 @@ def compute_reconciliation(
     existing_active_ids: frozenset[int],
     fetched_ids: frozenset[int],
     item_type: str,
+    *,
+    extra_active_count: int = 0,
+    extra_missing_count: int = 0,
 ) -> ReconciliationOutcome:
     """Diff by BGG collection entry id (bgg_collection_id), not bgg_id/objectid.
 
@@ -24,6 +32,12 @@ def compute_reconciliation(
     means the first run after adopting collection-id identity naturally
     treats "nothing is missing yet" rather than wrongly flagging every
     not-yet-adopted row as gone.
+
+    ``extra_active_count``/``extra_missing_count`` let callers fold legacy
+    (collection_id-less) rows into the same guard-ratio accounting as
+    collection-id rows, without mixing their identifiers into
+    ``existing_active_ids``/``fetched_ids`` (legacy rows are matched by
+    bgg_id, a different identifier space).
     """
     if not fetched_ids:
         return ReconciliationOutcome(
@@ -35,13 +49,13 @@ def compute_reconciliation(
         )
 
     missing = existing_active_ids - fetched_ids
-    if existing_active_ids and (
-        len(missing) / len(existing_active_ids) > DEACTIVATION_GUARD_RATIO
-    ):
+    total_active = len(existing_active_ids) + extra_active_count
+    total_missing = len(missing) + extra_missing_count
+    if total_active and (total_missing / total_active > DEACTIVATION_GUARD_RATIO):
         return ReconciliationOutcome(
             missing_ids=frozenset(),
             skip_reason=(
-                f"{len(missing)} of {len(existing_active_ids)} active "
+                f"{total_missing} of {total_active} active "
                 f"'{item_type}' items are missing from the BGG fetch "
                 f"(> {DEACTIVATION_GUARD_RATIO:.0%}); skipping removal of "
                 "newly-missing items"
@@ -49,3 +63,29 @@ def compute_reconciliation(
         )
 
     return ReconciliationOutcome(missing_ids=missing, skip_reason=None)
+
+
+def resolve_legacy_removals(
+    stale_legacy_games: Collection[Game],
+    game_repo: GameRepository,
+    loan_repo: LoanRepository,
+) -> tuple[int, int]:
+    """Deactivate or delete legacy rows (bgg_collection_id IS NULL) that are
+    no longer present in the BGG collection, matching the semantics applied
+    to collection-id rows: currently-lent games are deactivated rather than
+    deleted, and games with loan history that can't be hard-deleted (FK
+    RESTRICT) are deactivated instead. Returns (deactivated, deleted) counts.
+    """
+    lent_ids = frozenset(
+        game.id
+        for game in stale_legacy_games
+        if loan_repo.get_active_by_game_id(game.id) is not None
+    )
+    unlent_ids = frozenset(game.id for game in stale_legacy_games) - lent_ids
+
+    newly_deactivated = game_repo.deactivate_by_ids(lent_ids)
+    deleted_ids, blocked_ids = game_repo.delete_by_ids(unlent_ids)
+    if blocked_ids:
+        game_repo.deactivate_by_ids(blocked_ids)
+
+    return newly_deactivated + len(blocked_ids), len(deleted_ids)

--- a/backend/domain/use_cases/import_games.py
+++ b/backend/domain/use_cases/import_games.py
@@ -129,6 +129,16 @@ class ImportGamesUseCase:
                 publication_types=(
                     existing.publication_types if existing is not None else ()
                 ),
+                min_age=(
+                    details.min_age
+                    if details is not None
+                    else existing.min_age if existing is not None else 0
+                ),
+                primary_tag=(
+                    details.primary_tag
+                    if details is not None
+                    else existing.primary_tag if existing is not None else ""
+                ),
             )
             if was_created:
                 created += 1

--- a/backend/domain/use_cases/import_games.py
+++ b/backend/domain/use_cases/import_games.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 from backend.data.bgg_client import BggClient, BggGame
 from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
-from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
+from backend.domain.use_cases.bgg_reconciliation import (
+    compute_reconciliation,
+    resolve_legacy_removals,
+)
 
 ITEM_TYPE = "boardgame"
 
@@ -55,11 +58,16 @@ class ImportGamesUseCase:
             for game in all_local_items
             if game.bgg_collection_id is None
         }
+        legacy_active_count = sum(
+            1 for game in legacy_by_bgg_id.values() if game.is_active
+        )
 
         bgg_games = self._bgg_client.fetch_owned_games()
         fetched_ids = frozenset(_resolve_collection_id(g) for g in bgg_games)
         details_by_bgg_id = (
-            self._bgg_client.fetch_details(list(dict.fromkeys(g.bgg_id for g in bgg_games)))
+            self._bgg_client.fetch_details(
+                list(dict.fromkeys(g.bgg_id for g in bgg_games))
+            )
             if bgg_games
             else {}
         )
@@ -127,7 +135,27 @@ class ImportGamesUseCase:
             else:
                 updated += 1
 
-        outcome = compute_reconciliation(active_ids, fetched_ids, ITEM_TYPE)
+        # Any bgg_id remaining in legacy_by_bgg_id after the upsert loop was
+        # not adopted by any fetched game, i.e. it's no longer owned on BGG
+        # (the loop pops every bgg_id it encounters). Guarded against the
+        # rare case of a shared bgg_id already claimed by another row's
+        # collection_id by also checking fetched_bgg_ids directly.
+        fetched_bgg_ids = frozenset(g.bgg_id for g in bgg_games)
+        stale_legacy_games = [
+            game
+            for game in legacy_by_bgg_id.values()
+            if game.is_active and game.bgg_id not in fetched_bgg_ids
+        ]
+
+        outcome = compute_reconciliation(
+            active_ids,
+            fetched_ids,
+            ITEM_TYPE,
+            extra_active_count=legacy_active_count,
+            extra_missing_count=len(stale_legacy_games),
+        )
+        if outcome.skip_reason is not None:
+            stale_legacy_games = []
 
         # Previously soft-deleted items are re-evaluated every run, independent
         # of the guard above — they're already hidden, so there's no new risk.
@@ -155,11 +183,15 @@ class ImportGamesUseCase:
             # hidden since it can't be physically removed.
             self._game_repo.deactivate_by_collection_ids(blocked_ids)
 
+        legacy_deactivated, legacy_deleted = resolve_legacy_removals(
+            stale_legacy_games, self._game_repo, self._loan_repo
+        )
+
         return ImportResult(
             created=created,
             updated=updated,
             total=len(bgg_games),
-            deactivated=newly_deactivated + len(blocked_ids),
-            deleted=len(deleted_ids),
+            deactivated=newly_deactivated + len(blocked_ids) + legacy_deactivated,
+            deleted=len(deleted_ids) + legacy_deleted,
             skip_reason=outcome.skip_reason,
         )

--- a/backend/domain/use_cases/import_rpg_items.py
+++ b/backend/domain/use_cases/import_rpg_items.py
@@ -5,7 +5,10 @@ from dataclasses import dataclass
 from backend.data.bgg_client import BggClient, BggRpgItem
 from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
-from backend.domain.use_cases.bgg_reconciliation import compute_reconciliation
+from backend.domain.use_cases.bgg_reconciliation import (
+    compute_reconciliation,
+    resolve_legacy_removals,
+)
 
 ITEM_TYPE = "rpgitem"
 
@@ -48,6 +51,9 @@ class ImportRpgItemsUseCase:
             for game in all_local_items
             if game.bgg_collection_id is None
         }
+        legacy_active_count = sum(
+            1 for game in legacy_by_bgg_id.values() if game.is_active
+        )
 
         rpg_items = self._bgg_client.fetch_owned_rpg_items()
         fetched_ids = frozenset(_resolve_collection_id(item) for item in rpg_items)
@@ -97,7 +103,27 @@ class ImportRpgItemsUseCase:
             else:
                 updated += 1
 
-        outcome = compute_reconciliation(active_ids, fetched_ids, ITEM_TYPE)
+        # Any bgg_id remaining in legacy_by_bgg_id after the upsert loop was
+        # not adopted by any fetched item, i.e. it's no longer owned on BGG
+        # (the loop pops every bgg_id it encounters). Guarded against the
+        # rare case of a shared bgg_id already claimed by another row's
+        # collection_id by also checking fetched_bgg_ids directly.
+        fetched_bgg_ids = frozenset(item.bgg_id for item in rpg_items)
+        stale_legacy_games = [
+            game
+            for game in legacy_by_bgg_id.values()
+            if game.is_active and game.bgg_id not in fetched_bgg_ids
+        ]
+
+        outcome = compute_reconciliation(
+            active_ids,
+            fetched_ids,
+            ITEM_TYPE,
+            extra_active_count=legacy_active_count,
+            extra_missing_count=len(stale_legacy_games),
+        )
+        if outcome.skip_reason is not None:
+            stale_legacy_games = []
 
         # Previously soft-deleted items are re-evaluated every run, independent
         # of the guard above — they're already hidden, so there's no new risk.
@@ -125,11 +151,15 @@ class ImportRpgItemsUseCase:
             # hidden since it can't be physically removed.
             self._game_repo.deactivate_by_collection_ids(blocked_ids)
 
+        legacy_deactivated, legacy_deleted = resolve_legacy_removals(
+            stale_legacy_games, self._game_repo, self._loan_repo
+        )
+
         return ImportRpgResult(
             created=created,
             updated=updated,
             total=len(rpg_items),
-            deactivated=newly_deactivated + len(blocked_ids),
-            deleted=len(deleted_ids),
+            deactivated=newly_deactivated + len(blocked_ids) + legacy_deactivated,
+            deleted=len(deleted_ids) + legacy_deleted,
             skip_reason=outcome.skip_reason,
         )

--- a/backend/domain/use_cases/list_games.py
+++ b/backend/domain/use_cases/list_games.py
@@ -30,6 +30,8 @@ class GameWithStatus:
     status: str  # "available" or "lent"
     borrower_display_name: str | None
     loan_id: int | None
+    min_age: int
+    primary_tag: str
 
 
 def build_game_with_status(
@@ -59,6 +61,8 @@ def build_game_with_status(
             status="available",
             borrower_display_name=None,
             loan_id=None,
+            min_age=game.min_age,
+            primary_tag=game.primary_tag,
         )
 
     member = member_repo.get_by_id(active_loan.member_id)
@@ -82,6 +86,8 @@ def build_game_with_status(
         status="lent",
         borrower_display_name=member.display_name if member else None,
         loan_id=active_loan.id,
+        min_age=game.min_age,
+        primary_tag=game.primary_tag,
     )
 
 

--- a/backend/migrations/011_add_game_min_age_and_primary_tag.sql
+++ b/backend/migrations/011_add_game_min_age_and_primary_tag.sql
@@ -1,0 +1,3 @@
+-- Add BGG-derived minimum age and primary subdomain tag for catalog cards.
+ALTER TABLE games ADD COLUMN min_age INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE games ADD COLUMN primary_tag TEXT NOT NULL DEFAULT '';

--- a/docs/description-translation-plan.md
+++ b/docs/description-translation-plan.md
@@ -1,0 +1,63 @@
+# Plan: translating BGG game descriptions to Spanish
+
+Status: **proposal only — not implemented**.
+
+## Problem
+
+Game descriptions come from the BGG thing API and are in English. The catalog
+UI is Spanish-only (see `README.md`: "Spanish only; no i18n runtime"), so the
+card excerpt and the detail page currently mix Spanish chrome with English
+body text.
+
+## Constraints
+
+- BGG does not provide localized descriptions through the XML API, so the text
+  must be translated on our side.
+- ~240 boardgames plus RPG items today; descriptions change rarely (BGG edits
+  are infrequent), so translation is effectively a one-off per description
+  version, not a hot path.
+- The site runs on a small VPS; translation should happen at import time, not
+  per request.
+
+## Recommended approach: translate at import, cache by content hash
+
+1. **Schema**: add `description_es TEXT NOT NULL DEFAULT ''` and
+   `description_es_source_hash TEXT NOT NULL DEFAULT ''` to `games` (one
+   migration). The hash is `sha256(description)` of the English source the
+   translation was made from.
+2. **Domain**: a `TranslationService` Protocol in the domain layer
+   (`translate(texts: Sequence[str]) -> list[str]`), implemented in the data
+   layer against an LLM API (Claude Haiku is the cheap/fast fit; one batched
+   request of ~10 descriptions per call keeps costs and rate limits trivial —
+   the whole catalog is well under €1 to translate once).
+3. **Import flow**: after `fetch_details`, for each game where
+   `sha256(description) != description_es_source_hash`, queue the description
+   for translation; write `description_es` + the new hash. Unchanged
+   descriptions are never re-translated (the cache is the row itself).
+4. **Failure mode**: if translation fails or no API key is configured, keep
+   `description_es` empty. API serves both fields; the frontend falls back to
+   the English `description` when `description_es` is empty — the site never
+   breaks because a translation is missing.
+5. **Backfill**: a one-off CLI command (`translate-descriptions`) reusing the
+   same service, so existing rows don't wait for a BGG edit to get translated.
+
+## Alternatives considered
+
+- **Frontend/browser translation (Google widget, browser auto-translate)** —
+  rejected: inconsistent quality, no control, translates the whole page and
+  fights the already-Spanish chrome.
+- **Free MT APIs (LibreTranslate, DeepL free)** — workable, but board-game
+  jargon ("worker placement", "deck-building", "push-your-luck") is where
+  generic MT is weakest; an LLM with a one-line prompt ("translate for a
+  board-game club catalog; keep game-design terms natural in Spanish") does
+  noticeably better for the same near-zero cost at this volume.
+- **Translate on read (API middleware with cache)** — rejected: adds a
+  runtime dependency on an external API for public pages; import-time keeps
+  the serving path fully local.
+
+## Why it is not implemented in this PR
+
+The approach is clear, but it introduces the project's first external LLM/API
+dependency (key management on the VPS, cost account, prompt/quality review of
+240 translations before publishing). That deserves its own reviewed change
+rather than riding along a sync fix + card redesign.

--- a/frontend/src/components/GameCard.css
+++ b/frontend/src/components/GameCard.css
@@ -51,66 +51,82 @@
   font-weight: var(--font-weight-bold);
 }
 
-/* ─── Overlay badges ──────────────────────────────────────────────── */
+/* ─── Status ribbon (style-guide §2.4) ───────────────────────────────
+ * Diagonal ribbon across the cover's bottom-right corner. Clipped by
+ * .game-card-cover's overflow:hidden. */
 
-.game-card-status {
+.game-card-ribbon {
   position: absolute;
-  top: var(--space-sm);
-  left: var(--space-sm);
-}
-
-/* DQ-1: BGG rating as a solid red square, cover lower-left, on a scrim */
-.game-card-rating-scrim {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  display: inline-flex;
-  padding: var(--space-xs);
-  background-color: var(--color-scrim);
-  border-top-right-radius: var(--radius-sm);
-}
-
-/* Figma "Rate" chip: red rounded pill, Oswald regular */
-.game-card-rating {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  background-color: var(--color-brand);
+  bottom: 14px;
+  right: -34px;
+  width: 140px;
+  transform: rotate(-45deg);
   color: var(--color-brand-contrast);
-  border-radius: var(--radius-full);
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-regular);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.05em;
+  text-align: center;
+  text-transform: uppercase;
+  padding: var(--space-xs) 0;
+}
+
+.game-card-ribbon-lent {
+  background-color: var(--color-ribbon-prestamo);
 }
 
 /* ─── Body ────────────────────────────────────────────────────────── */
 
 .game-card-body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
+  position: relative;
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  column-gap: var(--space-sm);
+  row-gap: var(--space-xs);
   padding: var(--space-md);
   flex: 1;
 }
 
+/* DQ-1: BGG rating as a solid red square, hanging over the cover boundary. */
+.game-card-rating {
+  grid-column: 1;
+  grid-row: 1;
+  align-self: start;
+  margin-top: calc(-1 * var(--space-lg));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  background-color: var(--color-brand);
+  color: var(--color-brand-contrast);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
 .game-card-name {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  margin: 0;
   font-size: var(--font-size-lg); /* Figma titles are prominent Open Sans Bold */
   font-weight: var(--font-weight-bold);
   color: var(--color-text-heading);
   line-height: var(--line-height-tight);
-}
-
-.game-card-year {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+  text-align: center;
 }
 
 .game-card-meta {
+  grid-column: 1;
+  grid-row: 2 / span 2;
   display: flex;
-  gap: var(--space-sm);
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
@@ -128,6 +144,65 @@
   flex-shrink: 0;
 }
 
+.game-card-description {
+  grid-column: 2;
+  grid-row: 2;
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-normal);
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.game-card-tag {
+  grid-column: 2;
+  grid-row: 3;
+  justify-self: end;
+  align-self: end;
+  padding: 2px var(--space-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-heading);
+  white-space: nowrap;
+}
+
+/* Pastel pill colours, one per BGG subdomain family (task DQ: 8 tags). */
+.game-card-tag--mint {
+  background-color: var(--pill-mint);
+}
+
+.game-card-tag--pearl {
+  background-color: var(--pill-pearl);
+}
+
+.game-card-tag--pink {
+  background-color: var(--pill-pink);
+}
+
+.game-card-tag--sky {
+  background-color: var(--pill-sky);
+}
+
+.game-card-tag--lavender {
+  background-color: var(--pill-lavender);
+}
+
+.game-card-tag--yellow {
+  background-color: var(--pill-yellow);
+}
+
+.game-card-tag--peach {
+  background-color: var(--pill-peach);
+}
+
+.game-card-tag--turquoise {
+  background-color: var(--pill-turquoise);
+}
+
 /* ─── List view (style-guide §5.7) ────────────────────────────────── */
 
 .game-card-list .game-card-link {
@@ -140,16 +215,43 @@
   width: 110px;
 }
 
-.game-card-list .game-card-rating-scrim {
-  padding: 2px;
+.game-card-list .game-card-ribbon {
+  bottom: 8px;
+  right: -30px;
+  width: 100px;
+  font-size: 0.625rem;
+}
+
+.game-card-list .game-card-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--space-sm) var(--space-md);
 }
 
 .game-card-list .game-card-rating {
+  margin-top: 0;
   width: 1.75rem;
   height: 1.75rem;
   font-size: var(--font-size-sm);
 }
 
-.game-card-list .game-card-body {
-  justify-content: center;
+.game-card-list .game-card-name {
+  text-align: left;
+}
+
+.game-card-list .game-card-description {
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.game-card-list .game-card-meta {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.game-card-list .game-card-tag {
+  justify-self: start;
+  align-self: start;
 }

--- a/frontend/src/components/GameCard.test.tsx
+++ b/frontend/src/components/GameCard.test.tsx
@@ -6,6 +6,12 @@ import { GameCard } from "./GameCard";
 import type { CatalogView } from "../types/catalog";
 import type { GameWithStatus } from "../types/game";
 
+const RATING_CLASS = "game-card-rating";
+const RIBBON_CLASS = "game-card-ribbon";
+const RIBBON_LENT_CLASS = "game-card-ribbon-lent";
+const DESCRIPTION_CLASS = "game-card-description";
+const TAG_CLASS = "game-card-tag";
+
 const baseGame: GameWithStatus = {
   id: 1,
   bgg_id: 100,
@@ -17,40 +23,69 @@ const baseGame: GameWithStatus = {
   min_players: 3,
   max_players: 4,
   playing_time: 90,
+  min_age: 10,
   bgg_rating: 7.2,
   location: "armario",
-  description: "",
+  description: "Trade and build across the island.",
   categories: [],
+  primary_tag: "familygames",
   status: "available",
   borrower_display_name: null,
   loan_id: null,
 };
 
+function buildGame(overrides: Partial<GameWithStatus> = {}): GameWithStatus {
+  return { ...baseGame, ...overrides };
+}
+
 function renderCard(
   overrides: Partial<GameWithStatus> = {},
   view: CatalogView = "grid",
+  fallbackCategory?: string,
 ) {
   return render(
     <MemoryRouter>
-      <GameCard game={{ ...baseGame, ...overrides }} view={view} />
+      <GameCard
+        game={buildGame(overrides)}
+        view={view}
+        fallbackCategory={fallbackCategory}
+      />
     </MemoryRouter>,
   );
 }
 
-describe("GameCard availability badge", () => {
-  it("renders 'Disponible' for an available game", () => {
-    renderCard({ status: "available" });
+describe("GameCard rating block (DQ-1)", () => {
+  it("shows the BGG rating as a red square, one decimal", () => {
+    const { container } = renderCard({ bgg_rating: 8.4 });
 
-    expect(screen.getByText("Disponible")).toBeInTheDocument();
+    const rating = screen.getByText("8.4");
+    expect(rating.className).toBe(RATING_CLASS);
+    expect(container.querySelector(`.${RATING_CLASS}`)).toBe(rating);
   });
 
-  it("renders the no-name 'Prestado' badge for a lent game", () => {
-    renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
+  it("omits the rating block when the game has no rating", () => {
+    const { container } = renderCard({ bgg_rating: 0 });
 
-    expect(screen.getByText("Prestado")).toBeInTheDocument();
+    expect(container.querySelector(`.${RATING_CLASS}`)).toBeNull();
+  });
+});
+
+describe("GameCard status ribbon", () => {
+  it("renders the 'EN PRÉSTAMO' ribbon for a lent game", () => {
+    const { container } = renderCard({ status: "lent" });
+
+    const ribbon = screen.getByText("EN PRÉSTAMO");
+    expect(ribbon.className).toBe(`${RIBBON_CLASS} ${RIBBON_LENT_CLASS}`);
+    expect(container.querySelector(`.${RIBBON_CLASS}`)).toBe(ribbon);
   });
 
-  it("never renders the borrower name, even when the payload includes it", () => {
+  it("renders no ribbon for an available game", () => {
+    const { container } = renderCard({ status: "available" });
+
+    expect(container.querySelector(`.${RIBBON_CLASS}`)).toBeNull();
+  });
+
+  it("never renders the borrower name", () => {
     renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
 
     expect(screen.queryByText(/Alice/)).toBeNull();
@@ -65,36 +100,91 @@ describe("GameCard availability badge", () => {
   });
 });
 
-describe("GameCard borrow controls", () => {
-  it("never renders borrow or return action buttons", () => {
-    renderCard({ status: "lent", borrower_display_name: "Alice", loan_id: 7 });
+describe("GameCard description excerpt", () => {
+  it("renders the description with the line-clamp class", () => {
+    const { container } = renderCard({ description: "A trading game." });
 
-    expect(screen.queryByRole("button")).toBeNull();
+    const description = container.querySelector(`.${DESCRIPTION_CLASS}`);
+    expect(description).toHaveTextContent("A trading game.");
   });
 
-  it("renders no borrow control for available games either", () => {
-    renderCard({ status: "available" });
+  it("renders nothing when the game has no description", () => {
+    const { container } = renderCard({ description: "" });
 
-    expect(screen.queryByRole("button")).toBeNull();
-    expect(screen.queryByText(/Solicitar préstamo/)).toBeNull();
+    expect(container.querySelector(`.${DESCRIPTION_CLASS}`)).toBeNull();
   });
 });
 
-describe("GameCard rating badge (DQ-1)", () => {
-  it("shows the BGG rating as a red square over the cover, on a scrim", () => {
-    const { container } = renderCard({ bgg_rating: 8.4 });
+describe("GameCard meta column", () => {
+  it("renders age, playing time, and player range", () => {
+    renderCard({ min_age: 8, playing_time: 30, min_players: 3, max_players: 8 });
 
-    const rating = screen.getByText("8.4");
-    expect(rating.className).toBe("game-card-rating");
-    expect(container.querySelector(".game-card-rating-scrim")).toContainElement(
-      rating,
-    );
+    expect(screen.getByText("8+")).toBeInTheDocument();
+    expect(screen.getByText("30min")).toBeInTheDocument();
+    expect(screen.getByText("3-8")).toBeInTheDocument();
   });
 
-  it("omits the rating badge when the game has no rating", () => {
-    const { container } = renderCard({ bgg_rating: 0 });
+  it("hides the age item when min_age is 0", () => {
+    renderCard({ min_age: 0 });
 
-    expect(container.querySelector(".game-card-rating")).toBeNull();
+    expect(screen.queryByText(/\+$/)).toBeNull();
+  });
+
+  it("hides the playing time item when it is 0", () => {
+    renderCard({ playing_time: 0 });
+
+    expect(screen.queryByText(/min$/)).toBeNull();
+  });
+
+  it("hides the player range when either bound is 0", () => {
+    renderCard({ min_players: 0, max_players: 0 });
+
+    expect(screen.queryByText(/^\d+-\d+$/)).toBeNull();
+  });
+});
+
+describe("GameCard tag pill", () => {
+  it("maps a known primary_tag to its Spanish label", () => {
+    const { container } = renderCard({ primary_tag: "strategygames" });
+
+    const tag = screen.getByText("Estrategia");
+    expect(tag.className).toBe(`${TAG_CLASS} game-card-tag--pearl`);
+    expect(container.querySelector(`.${TAG_CLASS}`)).toBe(tag);
+  });
+
+  it("maps every known primary_tag to its Spanish label", () => {
+    const expectations: ReadonlyArray<[string, string]> = [
+      ["familygames", "Familiar"],
+      ["strategygames", "Estrategia"],
+      ["partygames", "Fiesta"],
+      ["thematic", "Temático"],
+      ["abstracts", "Abstracto"],
+      ["childrensgames", "Infantil"],
+      ["wargames", "Bélico"],
+      ["cgs", "Cartas"],
+    ];
+
+    expectations.forEach(([primaryTag, label]) => {
+      const { unmount } = renderCard({ primary_tag: primaryTag });
+      expect(screen.getByText(label)).toBeInTheDocument();
+      unmount();
+    });
+  });
+
+  it("falls back to the game's most common own category when primary_tag is empty", () => {
+    renderCard(
+      { primary_tag: "", categories: ["Economic"] },
+      "grid",
+      "Economic",
+    );
+
+    expect(screen.getByText("Economic")).toBeInTheDocument();
+  });
+
+  it("renders no pill when primary_tag is empty and there is no fallback category", () => {
+    const { container } = renderCard({ primary_tag: "", categories: [] });
+
+    expect(container.querySelector(`.${TAG_CLASS}`)).toBeNull();
   });
 });
 

--- a/frontend/src/components/GameCard.tsx
+++ b/frontend/src/components/GameCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
-import { Badge } from "../ui/Badge";
-import { ClockIcon, PlayersIcon } from "./MetaIcons";
+import { AgeIcon, ClockIcon, PlayersIcon } from "./MetaIcons";
+import { resolveTagPill } from "../lib/gameTags";
 import type { GameWithStatus } from "../types/game";
 import type { CatalogView } from "../types/catalog";
 import "./GameCard.css";
@@ -8,10 +8,27 @@ import "./GameCard.css";
 interface GameCardProps {
   readonly game: GameWithStatus;
   readonly view?: CatalogView;
+  /**
+   * Fallback tag label to show when the game has no `primary_tag` — the
+   * game's own most-common BGG category, ranked across the loaded catalog.
+   * Computed by the caller (CatalogPage), not by this component.
+   */
+  readonly fallbackCategory?: string;
 }
 
-export function GameCard({ game, view = "grid" }: GameCardProps) {
+// Structured so a second ribbon variant (e.g. "reservado") is a one-liner.
+const RIBBON_LABELS: Partial<Record<GameWithStatus["status"], string>> = {
+  lent: "EN PRÉSTAMO",
+};
+
+const RIBBON_CLASSES: Partial<Record<GameWithStatus["status"], string>> = {
+  lent: "game-card-ribbon-lent",
+};
+
+export function GameCard({ game, view = "grid", fallbackCategory }: GameCardProps) {
   const statusLabel = game.status === "available" ? "Disponible" : "Prestado";
+  const ribbonLabel = RIBBON_LABELS[game.status];
+  const tagPill = resolveTagPill(game.primary_tag, fallbackCategory);
 
   return (
     <article className={`game-card game-card-${view}`}>
@@ -33,36 +50,49 @@ export function GameCard({ game, view = "grid" }: GameCardProps) {
               <span aria-hidden="true">{game.name.charAt(0)}</span>
             </div>
           )}
-          <Badge variant={game.status} className="game-card-status">
-            {statusLabel}
-          </Badge>
-          {game.bgg_rating > 0 && (
-            <span className="game-card-rating-scrim">
-              <span className="game-card-rating">
-                {game.bgg_rating.toFixed(1)}
-              </span>
+          {ribbonLabel && (
+            <span
+              className={`game-card-ribbon ${RIBBON_CLASSES[game.status]}`}
+            >
+              {ribbonLabel}
             </span>
           )}
         </div>
         <div className="game-card-body">
-          <div className="game-card-name">{game.name}</div>
-          {game.year_published > 0 && (
-            <div className="game-card-year">{game.year_published}</div>
+          {game.bgg_rating > 0 && (
+            <span className="game-card-rating">
+              {game.bgg_rating.toFixed(1)}
+            </span>
           )}
-          <div className="game-card-meta">
-            {game.min_players > 0 && game.max_players > 0 && (
-              <span className="game-card-meta-item">
-                <PlayersIcon className="game-card-meta-icon" />
-                {`${game.min_players}-${game.max_players} jugadores`}
-              </span>
+          <h3 className="game-card-name">{game.name}</h3>
+          {game.description && (
+            <p className="game-card-description">{game.description}</p>
+          )}
+          <ul className="game-card-meta">
+            {game.min_age > 0 && (
+              <li className="game-card-meta-item">
+                <AgeIcon className="game-card-meta-icon" />
+                {`${game.min_age}+`}
+              </li>
             )}
             {game.playing_time > 0 && (
-              <span className="game-card-meta-item">
+              <li className="game-card-meta-item">
                 <ClockIcon className="game-card-meta-icon" />
-                {`${game.playing_time} min`}
-              </span>
+                {`${game.playing_time}min`}
+              </li>
             )}
-          </div>
+            {game.min_players > 0 && game.max_players > 0 && (
+              <li className="game-card-meta-item">
+                <PlayersIcon className="game-card-meta-icon" />
+                {`${game.min_players}-${game.max_players}`}
+              </li>
+            )}
+          </ul>
+          {tagPill && (
+            <span className={`game-card-tag ${tagPill.colorClass}`}>
+              {tagPill.label}
+            </span>
+          )}
         </div>
       </Link>
     </article>

--- a/frontend/src/components/MetaIcons.tsx
+++ b/frontend/src/components/MetaIcons.tsx
@@ -24,6 +24,23 @@ export function PlayersIcon({ className }: MetaIconProps) {
   );
 }
 
+export function AgeIcon({ className }: MetaIconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx="12" cy="7" r="3.2" />
+      <path d="M5.5 20c0-3.6 2.9-6.5 6.5-6.5s6.5 2.9 6.5 6.5" />
+    </svg>
+  );
+}
+
 export function ClockIcon({ className }: MetaIconProps) {
   return (
     <svg

--- a/frontend/src/lib/gameTags.test.ts
+++ b/frontend/src/lib/gameTags.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCategoryFrequency,
+  mostCommonOwnCategory,
+  resolveTagPill,
+} from "./gameTags";
+
+describe("resolveTagPill", () => {
+  it("maps a known primary_tag to its Spanish label and pill colour", () => {
+    expect(resolveTagPill("thematic", undefined)).toEqual({
+      label: "Temático",
+      colorClass: "game-card-tag--sky",
+    });
+  });
+
+  it("falls back to the raw category with a neutral colour when primary_tag is unknown", () => {
+    expect(resolveTagPill("", "Economic")).toEqual({
+      label: "Economic",
+      colorClass: "game-card-tag--pearl",
+    });
+  });
+
+  it("returns undefined when there is neither a primary_tag nor a fallback category", () => {
+    expect(resolveTagPill("", undefined)).toBeUndefined();
+  });
+});
+
+describe("computeCategoryFrequency", () => {
+  it("counts occurrences of each category across all games", () => {
+    const games = [
+      { categories: ["Economic", "Negotiation"] },
+      { categories: ["Economic"] },
+      { categories: ["Fantasy"] },
+    ];
+
+    expect(computeCategoryFrequency(games)).toEqual({
+      Economic: 2,
+      Negotiation: 1,
+      Fantasy: 1,
+    });
+  });
+
+  it("returns an empty object for an empty game list", () => {
+    expect(computeCategoryFrequency([])).toEqual({});
+  });
+});
+
+describe("mostCommonOwnCategory", () => {
+  it("picks the game's own category with the highest catalog-wide frequency", () => {
+    const frequency = { Economic: 2, Negotiation: 1 };
+
+    expect(mostCommonOwnCategory(["Negotiation", "Economic"], frequency)).toBe(
+      "Economic",
+    );
+  });
+
+  it("returns undefined when the game has no categories", () => {
+    expect(mostCommonOwnCategory([], {})).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/gameTags.ts
+++ b/frontend/src/lib/gameTags.ts
@@ -1,0 +1,93 @@
+/*
+ * Pure helpers for the catalog card's category tag pill.
+ *
+ * `primary_tag` on a game is a raw BGG subdomain name. We map it to a
+ * Spanish label and a pastel colour token (see frontend/src/tokens.css
+ * `--pill-*`). When a game has no `primary_tag`, the catalog falls back to
+ * that game's own most-common BGG category, ranked by frequency across the
+ * whole loaded catalog.
+ */
+
+export const PRIMARY_TAG_KEYS = [
+  "familygames",
+  "strategygames",
+  "partygames",
+  "thematic",
+  "abstracts",
+  "childrensgames",
+  "wargames",
+  "cgs",
+] as const;
+
+export type PrimaryTagKey = (typeof PRIMARY_TAG_KEYS)[number];
+
+export interface TagPill {
+  readonly label: string;
+  /** BEM-style modifier class applied alongside `game-card-tag` (see GameCard.css). */
+  readonly colorClass: string;
+}
+
+const PRIMARY_TAG_PILLS: Record<PrimaryTagKey, TagPill> = {
+  familygames: { label: "Familiar", colorClass: "game-card-tag--mint" },
+  strategygames: { label: "Estrategia", colorClass: "game-card-tag--pearl" },
+  partygames: { label: "Fiesta", colorClass: "game-card-tag--pink" },
+  thematic: { label: "Temático", colorClass: "game-card-tag--sky" },
+  abstracts: { label: "Abstracto", colorClass: "game-card-tag--lavender" },
+  childrensgames: { label: "Infantil", colorClass: "game-card-tag--yellow" },
+  wargames: { label: "Bélico", colorClass: "game-card-tag--peach" },
+  cgs: { label: "Cartas", colorClass: "game-card-tag--turquoise" },
+};
+
+/** Neutral pastel used when we fall back to a raw, untranslated BGG category. */
+const FALLBACK_CATEGORY_COLOR_CLASS = "game-card-tag--pearl";
+
+function isPrimaryTagKey(value: string): value is PrimaryTagKey {
+  return (PRIMARY_TAG_KEYS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolves the pill to render for a game: the mapped `primary_tag` label
+ * when available, otherwise the (untranslated) fallback category, otherwise
+ * no pill at all.
+ */
+export function resolveTagPill(
+  primaryTag: string,
+  fallbackCategory: string | undefined,
+): TagPill | undefined {
+  if (isPrimaryTagKey(primaryTag)) {
+    return PRIMARY_TAG_PILLS[primaryTag];
+  }
+  if (fallbackCategory) {
+    return { label: fallbackCategory, colorClass: FALLBACK_CATEGORY_COLOR_CLASS };
+  }
+  return undefined;
+}
+
+/** Counts how many times each BGG category appears across a list of games. */
+export function computeCategoryFrequency(
+  games: readonly { readonly categories: readonly string[] }[],
+): Readonly<Record<string, number>> {
+  return games
+    .flatMap((game) => game.categories)
+    .reduce<Record<string, number>>(
+      (frequency, category) => ({
+        ...frequency,
+        [category]: (frequency[category] ?? 0) + 1,
+      }),
+      {},
+    );
+}
+
+/**
+ * Picks the game's own category that is most frequent across the whole
+ * catalog (per the given frequency map). Returns undefined when the game
+ * has no categories.
+ */
+export function mostCommonOwnCategory(
+  categories: readonly string[],
+  frequency: Readonly<Record<string, number>>,
+): string | undefined {
+  return categories.toSorted(
+    (a, b) => (frequency[b] ?? 0) - (frequency[a] ?? 0),
+  )[0];
+}

--- a/frontend/src/pages/CatalogPage.test.tsx
+++ b/frontend/src/pages/CatalogPage.test.tsx
@@ -23,10 +23,12 @@ const AVAILABLE_GAME: GameWithStatus = {
   min_players: 3,
   max_players: 4,
   playing_time: 90,
+  min_age: 10,
   bgg_rating: 7.2,
   location: "armari",
   description: "",
   categories: [],
+  primary_tag: "familygames",
   status: "available",
   borrower_display_name: null,
   loan_id: null,
@@ -266,5 +268,19 @@ describe("CatalogPage view toggle (DQ-2)", () => {
     unmount();
     const { container: remounted } = renderPage();
     expect(remounted.querySelector(".catalog-list")).not.toBeNull();
+  });
+});
+
+describe("CatalogPage tag pill fallback", () => {
+  it("shows the game's most common own category when primary_tag is empty", () => {
+    setGames([
+      { ...AVAILABLE_GAME, primary_tag: "", categories: ["Economic"] },
+      { ...LENT_GAME, primary_tag: "", categories: ["Economic", "Fantasy"] },
+    ]);
+
+    renderPage();
+
+    // "Economic" wins the frequency tie-break (appears on both games).
+    expect(screen.getAllByText("Economic")).toHaveLength(2);
   });
 });

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -7,6 +7,7 @@ import { GameCard } from "../components/GameCard";
 import { PoweredByBgg } from "../components/PoweredByBgg";
 import { SearchBar } from "../components/SearchBar";
 import { SearchFiltersBox } from "../components/SearchFiltersBox";
+import { computeCategoryFrequency, mostCommonOwnCategory } from "../lib/gameTags";
 import { Button } from "../ui/Button";
 import { PageTitle } from "../ui/PageTitle";
 import {
@@ -107,6 +108,13 @@ export function CatalogPage() {
     [games, query],
   );
 
+  // Fallback tag for cards without a `primary_tag`: the game's own most
+  // frequent BGG category, ranked across the whole loaded catalog.
+  const categoryFrequency = useMemo(
+    () => computeCategoryFrequency(games),
+    [games],
+  );
+
   if (loading) {
     return (
       <div className="catalog-page">
@@ -168,7 +176,16 @@ export function CatalogPage() {
       ) : (
         <div className={view === "grid" ? "catalog-grid" : "catalog-list"}>
           {filteredGames.map((game) => (
-            <GameCard key={game.id} game={game} view={view} />
+            <GameCard
+              key={game.id}
+              game={game}
+              view={view}
+              fallbackCategory={
+                game.primary_tag
+                  ? undefined
+                  : mostCommonOwnCategory(game.categories, categoryFrequency)
+              }
+            />
           ))}
         </div>
       )}

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -42,11 +42,13 @@ const game: GameWithStatus = {
   min_players: 3,
   max_players: 4,
   playing_time: 90,
+  min_age: 10,
   bgg_rating: 7.2,
   location: "armario",
   description:
     "Trade and build across the island.\n\nEvery route changes the table.",
   categories: ["Economic", "Negotiation"],
+  primary_tag: "familygames",
   status: "available",
   borrower_display_name: null,
   loan_id: null,

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -47,9 +47,13 @@
   --color-available: #dcfce7;
   --color-lent: #fef3c7;
 
+  /* Diagonal cover ribbons (style-guide §2.4) */
+  --color-ribbon-prestamo: #e95a7a; /* EN PRÉSTAMO */
+  --color-ribbon-reservado: var(--color-brand); /* RESERVADO — not used yet */
+
   /* ─── Category pill pastels ─────────────────────────────────────── */
   /* Pair each with dark family text for AA contrast. */
-  --pill-mint: #98fb98; /* Nature / Familiar / Estrategia */
+  --pill-mint: #98fb98; /* Nature / Familiar */
   --pill-pink: #ffb6c1; /* Party / Horror */
   --pill-sky: #87ceeb; /* Mystery / Investigación */
   --pill-turquoise: #bbffff; /* Aventura */

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -9,10 +9,12 @@ export interface Game {
   readonly min_players: number;
   readonly max_players: number;
   readonly playing_time: number;
+  readonly min_age: number;
   readonly bgg_rating: number;
   readonly location: string;
   readonly description: string;
   readonly categories: readonly string[];
+  readonly primary_tag: string;
 }
 
 export interface GameWithStatus extends Game {

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
@@ -4,22 +4,23 @@
 
 ### Requirement: Cover-first GameCard
 
-The system SHALL render each game in the catalog as a card where the game cover image is the dominant visual element, with availability and rating shown as overlay badges and the game title and core stats below.
+The system SHALL render each game in the catalog as a card where the game cover image is the dominant visual element, with a rating block, description excerpt, meta column (age/time/players), and a single tag pill below.
 
 #### Scenario: Card visual hierarchy
 - **WHEN** a `GameCard` renders for a game
 - **THEN** the cover image SHALL occupy the top portion of the card
-- **AND** an availability badge SHALL be overlaid on the cover (e.g. top-left)
-- **AND** a BGG rating badge SHALL be overlaid on the cover (e.g. top-right)
-- **AND** the game title, year, player range, and playing time SHALL render below the cover
+- **AND** a red square block with the BGG rating (one decimal) SHALL hang over the cover/body boundary on the left
+- **AND** the game title SHALL render as the card heading with the game description below it, clamped to five lines
+- **AND** a vertical meta column SHALL show minimum age ("8+"), playing time ("30min"), and player range ("3-8"), hiding any item whose value is missing
+- **AND** a single tag pill SHALL render bottom-right: the game's primary BGG subdomain mapped to a Spanish label (Familiar, Estrategia, Fiesta, Temático, …), falling back to the game's most common own category, or no pill when neither exists
 
 #### Scenario: Available game card
 - **WHEN** a game is currently available
-- **THEN** the availability badge SHALL display "Disponible" with the success state styling
+- **THEN** no status overlay SHALL render on the cover
 
 #### Scenario: Lent game card
 - **WHEN** a game is currently lent
-- **THEN** the availability badge SHALL display "Prestado" with the warning/lent state styling
+- **THEN** a diagonal ribbon reading "EN PRÉSTAMO" SHALL be overlaid on the cover's bottom-right corner
 
 ### Requirement: Catalog filters as side panel + chip row
 

--- a/openspec/specs/lending-catalog-redesign/spec.md
+++ b/openspec/specs/lending-catalog-redesign/spec.md
@@ -5,22 +5,23 @@ TBD - created by archiving change plan-lending-redesign. Update Purpose after ar
 ## Requirements
 ### Requirement: Cover-first GameCard
 
-The system SHALL render each game in the catalog as a card where the game cover image is the dominant visual element, with availability and rating shown as overlay badges and the game title and core stats below.
+The system SHALL render each game in the catalog as a card where the game cover image is the dominant visual element, with a rating block, description excerpt, meta column (age/time/players), and a single tag pill below.
 
 #### Scenario: Card visual hierarchy
 - **WHEN** a `GameCard` renders for a game
 - **THEN** the cover image SHALL occupy the top portion of the card
-- **AND** an availability badge SHALL be overlaid on the cover (e.g. top-left)
-- **AND** a BGG rating badge SHALL be overlaid on the cover (e.g. top-right)
-- **AND** the game title, year, player range, and playing time SHALL render below the cover
+- **AND** a red square block with the BGG rating (one decimal) SHALL hang over the cover/body boundary on the left
+- **AND** the game title SHALL render as the card heading with the game description below it, clamped to five lines
+- **AND** a vertical meta column SHALL show minimum age ("8+"), playing time ("30min"), and player range ("3-8"), hiding any item whose value is missing
+- **AND** a single tag pill SHALL render bottom-right: the game's primary BGG subdomain mapped to a Spanish label (Familiar, Estrategia, Fiesta, Temático, …), falling back to the game's most common own category, or no pill when neither exists
 
 #### Scenario: Available game card
 - **WHEN** a game is currently available
-- **THEN** the availability badge SHALL display "Disponible" with the success state styling
+- **THEN** no status overlay SHALL render on the cover
 
 #### Scenario: Lent game card
 - **WHEN** a game is currently lent
-- **THEN** the availability badge SHALL display "Prestado" with the warning/lent state styling
+- **THEN** a diagonal ribbon reading "EN PRÉSTAMO" SHALL be overlaid on the cover's bottom-right corner
 
 ### Requirement: Catalog filters in a tabbed search-and-filters box
 

--- a/tests/api/test_games.py
+++ b/tests/api/test_games.py
@@ -85,6 +85,8 @@ class TestListGames:
             year_published=1995,
             description="Trade and build across the island.",
             categories=("Economic", "Negotiation"),
+            min_age=10,
+            primary_tag="familygames",
         )
         game2 = game_repo.upsert_by_bgg_id(
             bgg_id=200,
@@ -111,10 +113,16 @@ class TestListGames:
         assert {
             "description": by_name["Catan"]["description"],
             "categories": by_name["Catan"]["categories"],
+            "min_age": by_name["Catan"]["min_age"],
+            "primary_tag": by_name["Catan"]["primary_tag"],
         } == {
             "description": "Trade and build across the island.",
             "categories": ["Economic", "Negotiation"],
+            "min_age": 10,
+            "primary_tag": "familygames",
         }
+        assert by_name["Pandemic"]["min_age"] == 0
+        assert by_name["Pandemic"]["primary_tag"] == ""
         assert by_name["Catan"]["borrower_display_name"] is None
         assert by_name["Catan"]["loan_id"] is None
 
@@ -198,6 +206,8 @@ class TestGetGame:
             year_published=1995,
             description="Trade and build across the island.",
             categories=("Economic", "Negotiation"),
+            min_age=10,
+            primary_tag="familygames",
         )
 
         response = client.get(f"/api/juegos/{game.slug}")
@@ -210,9 +220,13 @@ class TestGetGame:
         assert {
             "description": data["description"],
             "categories": data["categories"],
+            "min_age": data["min_age"],
+            "primary_tag": data["primary_tag"],
         } == {
             "description": "Trade and build across the island.",
             "categories": ["Economic", "Negotiation"],
+            "min_age": 10,
+            "primary_tag": "familygames",
         }
         assert data["status"] == "available"
         assert data["borrower_display_name"] is None

--- a/tests/data/test_bgg_client.py
+++ b/tests/data/test_bgg_client.py
@@ -20,6 +20,30 @@ IMAGE_THING_XML = """<?xml version="1.0" encoding="utf-8"?>
     </item>
 </items>"""
 
+
+def _thing_xml_with_ranks(ranks_xml: str, *, minage: str = "") -> str:
+    minage_tag = f'<minage value="{minage}"/>' if minage else ""
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<items>
+    <item type="boardgame" id="13">
+        <thumbnail>https://cf.geekdo-images.com/catan_t.png</thumbnail>
+        <image>https://cf.geekdo-images.com/catan.png</image>
+        {minage_tag}
+        <minplayers value="3"/>
+        <maxplayers value="4"/>
+        <playingtime value="90"/>
+        <statistics page="1">
+            <ratings>
+                <average value="7.20"/>
+                <ranks>
+                    {ranks_xml}
+                </ranks>
+            </ratings>
+        </statistics>
+    </item>
+</items>"""
+
+
 IMAGES_API_RESPONSE = {
     "images": {
         "medium": {
@@ -132,6 +156,67 @@ class TestBggClientFetchDetails:
         client = BggClient("test")
         details = client.fetch_details([1])
         assert details[1].image_url == ""
+
+
+class TestBggClientMinAgeAndPrimaryTag:
+    OVERALL_RANK = '<rank type="subtype" id="1" name="boardgame" friendlyname="Board Game Rank" value="150"/>'
+
+    def _details(self, xml: str, monkeypatch: object):  # type: ignore[no-untyped-def]
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *_a, **_kw: _FakeResponse(text=xml))
+        return BggClient("test").fetch_details([13])[13]
+
+    def test_parses_min_age(self, monkeypatch: object) -> None:
+        xml = _thing_xml_with_ranks(self.OVERALL_RANK, minage="7")
+        assert self._details(xml, monkeypatch).min_age == 7
+
+    def test_min_age_defaults_to_zero_when_absent(self, monkeypatch: object) -> None:
+        xml = _thing_xml_with_ranks(self.OVERALL_RANK)
+        assert self._details(xml, monkeypatch).min_age == 0
+
+    def test_single_family_rank_is_primary_tag(self, monkeypatch: object) -> None:
+        ranks = (
+            self.OVERALL_RANK + '<rank type="family" id="5499" name="familygames" '
+            'friendlyname="Family Game Rank" value="52"/>'
+        )
+        xml = _thing_xml_with_ranks(ranks)
+        assert self._details(xml, monkeypatch).primary_tag == "familygames"
+
+    def test_multiple_family_ranks_picks_best_numeric_value(
+        self, monkeypatch: object
+    ) -> None:
+        ranks = (
+            self.OVERALL_RANK
+            + '<rank type="family" id="5497" name="strategygames" value="200"/>'
+            + '<rank type="family" id="5499" name="familygames" value="52"/>'
+        )
+        xml = _thing_xml_with_ranks(ranks)
+        assert self._details(xml, monkeypatch).primary_tag == "familygames"
+
+    def test_unranked_family_entries_lose_to_numeric_ones(
+        self, monkeypatch: object
+    ) -> None:
+        ranks = (
+            self.OVERALL_RANK
+            + '<rank type="family" id="5497" name="partygames" value="Not Ranked"/>'
+            + '<rank type="family" id="5499" name="familygames" value="52"/>'
+        )
+        xml = _thing_xml_with_ranks(ranks)
+        assert self._details(xml, monkeypatch).primary_tag == "familygames"
+
+    def test_all_unranked_family_entries_takes_first(self, monkeypatch: object) -> None:
+        ranks = (
+            self.OVERALL_RANK
+            + '<rank type="family" id="5497" name="partygames" value="Not Ranked"/>'
+            + '<rank type="family" id="5499" name="familygames" value="Not Ranked"/>'
+        )
+        xml = _thing_xml_with_ranks(ranks)
+        assert self._details(xml, monkeypatch).primary_tag == "partygames"
+
+    def test_no_family_rank_yields_empty_primary_tag(self, monkeypatch: object) -> None:
+        xml = _thing_xml_with_ranks(self.OVERALL_RANK)
+        assert self._details(xml, monkeypatch).primary_tag == ""
 
 
 SAMPLE_XML = """<?xml version="1.0" encoding="utf-8"?>

--- a/tests/domain/use_cases/conftest.py
+++ b/tests/domain/use_cases/conftest.py
@@ -139,6 +139,8 @@ class FakeGameRepository:
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> Game:
         """Legacy path: no collection_id concept."""
         now = datetime.now(UTC)
@@ -165,6 +167,8 @@ class FakeGameRepository:
             publication_types=publication_types,
             is_active=True,
             bgg_collection_id=existing.bgg_collection_id if existing else None,
+            min_age=min_age,
+            primary_tag=primary_tag,
         )
         self._games[game.id] = game
         if existing is None:
@@ -188,6 +192,8 @@ class FakeGameRepository:
         description: str = "",
         categories: tuple[str, ...] = (),
         publication_types: tuple[str, ...] = (),
+        min_age: int = 0,
+        primary_tag: str = "",
     ) -> tuple[Game, bool]:
         now = datetime.now(UTC)
         existing = self.get_by_collection_id(bgg_collection_id)
@@ -224,6 +230,8 @@ class FakeGameRepository:
             categories=categories,
             publication_types=publication_types,
             is_active=True,
+            min_age=min_age,
+            primary_tag=primary_tag,
         )
         self._games[game.id] = game
         if was_created:

--- a/tests/domain/use_cases/conftest.py
+++ b/tests/domain/use_cases/conftest.py
@@ -24,6 +24,7 @@ class FakeGameRepository:
         self._games: dict[int, Game] = {}
         self._next_id = 1
         self.blocked_collection_ids: set[int] = set()
+        self.blocked_ids: set[int] = set()
 
     def get_by_id(self, game_id: int) -> Game | None:
         return self._games.get(game_id)
@@ -85,6 +86,29 @@ class FakeGameRepository:
             if game is not None:
                 del self._games[game.id]
                 deleted.add(collection_id)
+        return frozenset(deleted), frozenset(blocked)
+
+    def deactivate_by_ids(self, game_ids: Collection[int]) -> int:
+        count = 0
+        for game_id in game_ids:
+            game = self._games.get(game_id)
+            if game is not None and game.is_active:
+                self._games[game_id] = dataclasses.replace(game, is_active=False)
+                count += 1
+        return count
+
+    def delete_by_ids(
+        self, game_ids: Collection[int]
+    ) -> tuple[frozenset[int], frozenset[int]]:
+        deleted: set[int] = set()
+        blocked: set[int] = set()
+        for game_id in game_ids:
+            if game_id in self.blocked_ids:
+                blocked.add(game_id)
+                continue
+            if game_id in self._games:
+                del self._games[game_id]
+                deleted.add(game_id)
         return frozenset(deleted), frozenset(blocked)
 
     def _slug_for(self, existing: Game | None, name: str) -> str:

--- a/tests/domain/use_cases/test_import_games.py
+++ b/tests/domain/use_cases/test_import_games.py
@@ -30,6 +30,8 @@ def _details(
     bgg_id: int = 13,
     description: str = "Trade and build.",
     categories: tuple[str, ...] = ("Economic", "Strategy"),
+    min_age: int = 10,
+    primary_tag: str = "familygames",
 ) -> BggGameDetails:
     return BggGameDetails(
         bgg_id=bgg_id,
@@ -41,6 +43,8 @@ def _details(
         bgg_rating=7.15,
         description=description,
         categories=categories,
+        min_age=min_age,
+        primary_tag=primary_tag,
     )
 
 
@@ -75,6 +79,43 @@ class TestImportGamesUseCase:
         assert game.bgg_rating == 7.15
         assert game.description == "Trade and build."
         assert game.categories == ("Economic", "Strategy")
+        assert game.min_age == 10
+        assert game.primary_tag == "familygames"
+
+    def test_missing_details_fall_back_to_existing_min_age_and_primary_tag(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        fake_game_repo.upsert_by_bgg_id(
+            13,
+            "Old Catan",
+            "https://old-thumb.jpg",
+            min_age=8,
+            primary_tag="strategygames",
+        )
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://new-thumb.jpg", 1995)]
+        )
+
+        ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo).execute()
+
+        game = fake_game_repo.get_by_bgg_id(13)
+        assert game is not None
+        assert game.min_age == 8
+        assert game.primary_tag == "strategygames"
+
+    def test_missing_details_and_no_existing_row_defaults_min_age_and_primary_tag(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        bgg_client = FakeBggClient(
+            [BggGame(13, "Catan", "https://new-thumb.jpg", 1995)]
+        )
+
+        ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo).execute()
+
+        game = fake_game_repo.get_by_bgg_id(13)
+        assert game is not None
+        assert game.min_age == 0
+        assert game.primary_tag == ""
 
     def test_missing_collection_thumbnail_uses_detail_then_stored_fallback(
         self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository

--- a/tests/domain/use_cases/test_import_games.py
+++ b/tests/domain/use_cases/test_import_games.py
@@ -533,7 +533,12 @@ class TestImportGamesUseCase:
         assert second is not None
         assert (first.name, first.thumbnail_url) == ("New A", "new-a-thumb.jpg")
         assert (second.name, second.thumbnail_url) == ("New B", "new-b-thumb.jpg")
-        assert (first.image_url, first.playing_time, first.description, first.categories) == (
+        assert (
+            first.image_url,
+            first.playing_time,
+            first.description,
+            first.categories,
+        ) == (
             "stored-a.jpg",
             30,
             "Stored A",
@@ -545,3 +550,113 @@ class TestImportGamesUseCase:
             second.description,
             second.categories,
         ) == ("stored-b.jpg", 45, "Stored B", ("Category B",))
+
+
+class TestLegacyRowRemoval:
+    """Legacy rows (bgg_collection_id IS NULL) that fall out of the BGG
+    collection must be reconciled the same way collection-id rows are —
+    they must not be silently kept forever. Each test keeps enough
+    surviving collection-id games in the fetch so the combined (collection
+    + legacy) missing ratio stays under the 50% guard."""
+
+    def _surviving_games(self) -> list[BggGame]:
+        return [
+            BggGame(101, "Catan", "https://c.jpg", 1995, collection_id=2101),
+            BggGame(102, "Azul", "https://a.jpg", 2017, collection_id=2102),
+            BggGame(103, "Pandemic", "https://p.jpg", 2008, collection_id=2103),
+        ]
+
+    def _seed_surviving_games(self, fake_game_repo: FakeGameRepository) -> None:
+        fake_game_repo.upsert_by_collection_id(
+            2101, 101, "Catan", "https://c.jpg", 1995
+        )
+        fake_game_repo.upsert_by_collection_id(2102, 102, "Azul", "https://a.jpg", 2017)
+        fake_game_repo.upsert_by_collection_id(
+            2103, 103, "Pandemic", "https://p.jpg", 2008
+        )
+
+    def test_active_legacy_row_absent_from_fetch_is_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_games(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            715, "Fuga de Colditz", "https://f.jpg"
+        )
+        assert legacy.bgg_collection_id is None
+        bgg_client = FakeBggClient(self._surviving_games())
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 1
+        assert result.deactivated == 0
+        assert result.skip_reason is None
+        assert fake_game_repo.get_by_bgg_id(715) is None
+        assert {g.bgg_id for g in fake_game_repo.list_all()} == {101, 102, 103}
+
+    def test_active_legacy_row_absent_from_fetch_but_lent_is_deactivated(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_games(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            715, "Fuga de Colditz", "https://f.jpg"
+        )
+        fake_loan_repo.set_active_loan(legacy.id, _loan(legacy.id))
+        bgg_client = FakeBggClient(self._surviving_games())
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 1
+        assert result.skip_reason is None
+        stored = fake_game_repo.get_by_bgg_id(715)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_legacy_row_still_in_fetch_is_adopted_not_removed(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_games(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            715, "Fuga de Colditz", "https://f.jpg"
+        )
+        bgg_client = FakeBggClient(
+            [
+                *self._surviving_games(),
+                BggGame(
+                    715, "Fuga de Colditz", "https://f.jpg", 1955, collection_id=2715
+                ),
+            ]
+        )
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.updated == 4
+        assert result.skip_reason is None
+        adopted = fake_game_repo.get_by_collection_id(2715)
+        assert adopted is not None
+        assert adopted.id == legacy.id
+        assert adopted.is_active is True
+
+    def test_empty_fetch_leaves_legacy_rows_untouched(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            715, "Fuga de Colditz", "https://f.jpg"
+        )
+        bgg_client = FakeBggClient([])
+
+        use_case = ImportGamesUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.skip_reason is not None
+        stored = fake_game_repo.get_by_bgg_id(715)
+        assert stored is not None
+        assert stored.id == legacy.id
+        assert stored.is_active is True

--- a/tests/domain/use_cases/test_import_rpg_items.py
+++ b/tests/domain/use_cases/test_import_rpg_items.py
@@ -314,3 +314,123 @@ class TestImportRpgItemsUseCase:
         assert {item.image_url for item in stored} == {"a.jpg", "b.jpg"}
         assert {item.categories for item in stored} == {("Fantasy",)}
         assert {item.publication_types for item in stored} == {("Core Rules",)}
+
+
+class TestLegacyRowRemoval:
+    """Legacy rows (bgg_collection_id IS NULL) that fall out of the BGG
+    collection must be reconciled the same way collection-id rows are —
+    they must not be silently kept forever. Each test keeps enough
+    surviving collection-id items in the fetch so the combined (collection
+    + legacy) missing ratio stays under the 50% guard."""
+
+    def _surviving_items(self) -> list[BggRpgItem]:
+        return [_DND_RPG_ITEM, _PF_RPG_ITEM]
+
+    def _seed_surviving_items(self, fake_game_repo: FakeGameRepository) -> None:
+        fake_game_repo.upsert_by_collection_id(
+            2001, 1001, "D&D PHB", "https://old.jpg", item_type="rpgitem"
+        )
+        fake_game_repo.upsert_by_collection_id(
+            2002, 1002, "Pathfinder", "https://pf.jpg", item_type="rpgitem"
+        )
+
+    def test_active_legacy_row_absent_from_fetch_is_deleted(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_items(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            2005,
+            "Call of Cthulhu Keeper Rulebook",
+            "https://coc.jpg",
+            item_type="rpgitem",
+        )
+        assert legacy.bgg_collection_id is None
+        bgg_client = FakeBggClientRpg(self._surviving_items())
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 1
+        assert result.deactivated == 0
+        assert result.skip_reason is None
+        assert fake_game_repo.get_by_bgg_id(2005) is None
+        assert {g.bgg_id for g in fake_game_repo.list_all()} == {1001, 1002}
+
+    def test_active_legacy_row_absent_from_fetch_but_lent_is_deactivated(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_items(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            2005,
+            "Call of Cthulhu Keeper Rulebook",
+            "https://coc.jpg",
+            item_type="rpgitem",
+        )
+        fake_loan_repo.set_active_loan(legacy.id, _loan(legacy.id))
+        bgg_client = FakeBggClientRpg(self._surviving_items())
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 1
+        assert result.skip_reason is None
+        stored = fake_game_repo.get_by_bgg_id(2005)
+        assert stored is not None
+        assert stored.is_active is False
+
+    def test_legacy_row_still_in_fetch_is_adopted_not_removed(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        self._seed_surviving_items(fake_game_repo)
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            2005,
+            "Call of Cthulhu Keeper Rulebook",
+            "https://coc.jpg",
+            item_type="rpgitem",
+        )
+        adopted_item = BggRpgItem(
+            bgg_id=2005,
+            name="Call of Cthulhu Keeper Rulebook",
+            thumbnail_url="https://coc.jpg",
+            image_url="",
+            year_published=2019,
+            bgg_rating=8.0,
+            description="",
+            collection_id=2905,
+        )
+        bgg_client = FakeBggClientRpg([*self._surviving_items(), adopted_item])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.updated == 3
+        assert result.skip_reason is None
+        adopted = fake_game_repo.get_by_collection_id(2905)
+        assert adopted is not None
+        assert adopted.id == legacy.id
+        assert adopted.is_active is True
+
+    def test_empty_fetch_leaves_legacy_rows_untouched(
+        self, fake_game_repo: FakeGameRepository, fake_loan_repo: FakeLoanRepository
+    ) -> None:
+        legacy = fake_game_repo.upsert_by_bgg_id(
+            2005,
+            "Call of Cthulhu Keeper Rulebook",
+            "https://coc.jpg",
+            item_type="rpgitem",
+        )
+        bgg_client = FakeBggClientRpg([])
+
+        use_case = ImportRpgItemsUseCase(fake_game_repo, bgg_client, fake_loan_repo)
+        result = use_case.execute()
+
+        assert result.deleted == 0
+        assert result.deactivated == 0
+        assert result.skip_reason is not None
+        stored = fake_game_repo.get_by_bgg_id(2005)
+        assert stored is not None
+        assert stored.id == legacy.id
+        assert stored.is_active is True

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -68,12 +68,62 @@ class TestMigrationRunner:
 
         applied = run_migrations(conn)
 
-        assert applied == ["010_add_catalog_metadata"]
+        assert applied == [
+            "010_add_catalog_metadata",
+            "011_add_game_min_age_and_primary_tag",
+        ]
         game = SqliteGameRepository(conn).get_by_bgg_id(99)
         assert game is not None
         assert game.bgg_collection_id == 123456
         assert game.categories == ()
         assert game.publication_types == ()
+        assert game.min_age == 0
+        assert game.primary_tag == ""
+        assert run_migrations(conn) == []
+        conn.close()
+
+    def test_applies_min_age_and_primary_tag_migration(self) -> None:
+        conn = get_memory_connection()
+        applied = run_migrations(conn)
+        assert "011_add_game_min_age_and_primary_tag" in applied
+        conn.close()
+
+    def test_min_age_and_primary_tag_default_for_existing_rows(self) -> None:
+        conn = get_memory_connection()
+        migrations = sorted(MIGRATIONS_DIR.glob("*.sql"))
+        schema_ten_migrations = [
+            migration
+            for migration in migrations
+            if migration.stem <= "010_add_catalog_metadata"
+        ]
+        for migration in schema_ten_migrations:
+            conn.executescript(migration.read_text(encoding="utf-8"))
+        conn.execute("""
+            CREATE TABLE schema_migrations (
+                version TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (
+                    strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+                )
+            )
+            """)
+        conn.executemany(
+            "INSERT INTO schema_migrations (version) VALUES (?)",
+            ((migration.stem,) for migration in schema_ten_migrations),
+        )
+        conn.execute(
+            "INSERT INTO games "
+            "(bgg_id, bgg_collection_id, name, thumbnail_url, year_published) "
+            "VALUES (99, 123456, 'Existing game', 'https://t.jpg', 2020)"
+        )
+        conn.commit()
+
+        applied = run_migrations(conn)
+
+        assert applied == ["011_add_game_min_age_and_primary_tag"]
+        game = SqliteGameRepository(conn).get_by_bgg_id(99)
+        assert game is not None
+        assert game.min_age == 0
+        assert game.primary_tag == ""
         assert run_migrations(conn) == []
         conn.close()
 
@@ -96,7 +146,7 @@ class TestMigrationRunner:
         conn = get_memory_connection()
         first_run = run_migrations(conn)
         second_run = run_migrations(conn)
-        assert len(first_run) == 10
+        assert len(first_run) == 11
         assert len(second_run) == 0
         conn.close()
 
@@ -134,6 +184,8 @@ class TestMigrationRunner:
             "publication_types_json",
             "is_active",
             "bgg_collection_id",
+            "min_age",
+            "primary_tag",
         }
         conn.close()
 


### PR DESCRIPTION
## Related Tasks
No linked issue (requested directly).

## Summary
- **Fix: games removed from BGG were never deleted locally** when they were legacy rows (`bgg_collection_id IS NULL`) — e.g. *Fuga de Colditz*, *3 Ring Circus*. Stale legacy rows now go through the same guarded removal flow (loan-aware deactivation, 50% safety guard, empty-fetch skip) in both the boardgame and RPG importers. A real import run confirmed the fix: 20 stale games removed.
- **New BGG data**: `min_age` (from `minage`) and `primary_tag` (best-ranked BGG family subdomain — familygames, strategygames, partygames, …) parsed, stored (migration 011) and exposed on the game endpoints. Backfilled: 239/239 games have `min_age`, 185/239 a subdomain tag.
- **GameCard redesign** to the approved mockup: red rating block, clamped description excerpt, age/time/players meta column, Spanish tag pill (Familiar / Estrategia / Fiesta / Temático, …) with most-common-own-category fallback, diagonal "EN PRÉSTAMO" ribbon for lent games. No favorites/hearts (not in scope yet).
- **Translation plan** for the English BGG descriptions documented in `docs/description-translation-plan.md` (import-time translation via DeepL API Free, cached by content hash; includes account registration/config steps) — deliberately not implemented.

## Test plan
- `uv run pytest tests/ -q` — 404 passed (new coverage: legacy-row removal semantics in both importers, minage/subdomain parsing, migration, API fields).
- Frontend `yarn typecheck` / `yarn test` (209) / `yarn lint` — green.
- Browser smoke test against the dev stack: catalog renders the new cards (rating, ribbon, pills, meta), `juegos/fuga-de-colditz` now 404s with "Juego no encontrado.", detail page unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgfCmPFWb26sJgftJ3xawa
