### PR TITLE
feat(catalog): match board game catalog to Figma

### DIFF
--- a/frontend/src/components/GameCard.css
+++ b/frontend/src/components/GameCard.css
@@ -8,11 +8,16 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm); /* Figma cards: 4px */
   overflow: hidden;
-  transition: box-shadow 0.15s;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
 }
 
 .game-card:hover {
-  box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--color-brand) 36%, var(--color-border));
+  box-shadow: 0 8px 20px rgb(0 0 0 / 10%);
+  transform: translateY(-2px);
 }
 
 .game-card-link {
@@ -23,13 +28,24 @@
   text-decoration: none;
 }
 
+/* The global anchor hover underline must never bleed through the card. */
+.game-card-link:hover,
+.game-card-link:hover * {
+  text-decoration: none;
+}
+
+.game-card-link:focus-visible {
+  outline: 3px solid var(--color-brand);
+  outline-offset: -3px;
+}
+
 /* ─── Cover ───────────────────────────────────────────────────────── */
 
 .game-card-cover {
   position: relative;
   container-type: inline-size;
   background-color: var(--color-surface-alt);
-  aspect-ratio: 1;
+  aspect-ratio: 364 / 330;
   overflow: hidden;
 }
 
@@ -44,7 +60,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 1;
   background-color: var(--color-brand);
   color: var(--color-brand-contrast);
   font-size: var(--font-size-2xl);
@@ -57,18 +72,18 @@
 
 .game-card-ribbon {
   position: absolute;
-  bottom: 14px;
-  right: -34px;
-  width: 140px;
-  transform: rotate(-45deg);
+  right: -37px;
+  bottom: 17px;
+  width: 150px;
+  transform: rotate(-42deg);
   color: var(--color-brand-contrast);
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-sm);
+  font-size: 0.75rem;
   font-weight: var(--font-weight-bold);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   text-align: center;
   text-transform: uppercase;
-  padding: var(--space-xs) 0;
+  padding: 5px 0;
 }
 
 .game-card-ribbon-lent {
@@ -80,29 +95,30 @@
 .game-card-body {
   position: relative;
   display: grid;
-  grid-template-columns: 56px 1fr;
-  column-gap: var(--space-sm);
-  row-gap: var(--space-xs);
-  padding: var(--space-md);
+  grid-template-columns: 80px minmax(0, 1fr);
+  grid-template-rows: 43px minmax(85px, 1fr) auto;
+  column-gap: var(--space-md);
+  row-gap: var(--space-sm);
+  min-height: 200px;
+  padding: 0 var(--space-md) var(--space-md) 0;
   flex: 1;
 }
 
-/* DQ-1: BGG rating as a solid red square, hanging over the cover boundary. */
+/* The Figma score is a deliberately non-square block, flush with the body. */
 .game-card-rating {
   grid-column: 1;
   grid-row: 1;
   align-self: start;
-  margin-top: calc(-1 * var(--space-lg));
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 56px;
-  height: 56px;
+  width: 80px;
+  height: 71px;
   background-color: var(--color-brand);
   color: var(--color-brand-contrast);
-  border-radius: var(--radius-sm);
+  border-radius: 0 0 24px 0;
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
 }
 
@@ -111,7 +127,9 @@
   grid-row: 1;
   align-self: center;
   margin: 0;
-  font-size: var(--font-size-lg); /* Figma titles are prominent Open Sans Bold */
+  padding-top: 2px;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-xl); /* Figma titles are prominent Open Sans Bold */
   font-weight: var(--font-weight-bold);
   color: var(--color-text-heading);
   line-height: var(--line-height-tight);
@@ -120,12 +138,12 @@
 
 .game-card-meta {
   grid-column: 1;
-  grid-row: 2 / span 2;
+  grid-row: 2 / 4;
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: var(--space-sm);
   margin: 0;
-  padding: 0;
+  padding: var(--space-xl) 0 0 var(--space-sm);
   list-style: none;
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
@@ -152,8 +170,8 @@
   color: var(--color-text-muted);
   line-height: var(--line-height-normal);
   display: -webkit-box;
-  -webkit-line-clamp: 5;
-  line-clamp: 5;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -163,9 +181,13 @@
   grid-row: 3;
   justify-self: end;
   align-self: end;
-  padding: 2px var(--space-sm);
+  margin-top: var(--space-xs);
+  min-width: 110px;
+  padding: var(--space-xs) var(--space-md);
   border-radius: var(--radius-full);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  text-align: center;
   color: var(--color-text-heading);
   white-space: nowrap;
 }
@@ -227,6 +249,7 @@
   flex-direction: column;
   justify-content: center;
   padding: var(--space-sm) var(--space-md);
+  min-height: 0;
 }
 
 .game-card-list .game-card-rating {
@@ -234,6 +257,7 @@
   width: 1.75rem;
   height: 1.75rem;
   font-size: var(--font-size-sm);
+  border-radius: 0 0 10px 0;
 }
 
 .game-card-list .game-card-name {
@@ -254,4 +278,27 @@
 .game-card-list .game-card-tag {
   justify-self: start;
   align-self: start;
+}
+
+@media (max-width: 600px) {
+  .game-card-body {
+    grid-template-columns: 72px minmax(0, 1fr);
+    grid-template-rows: 64px minmax(64px, 1fr) auto;
+    min-height: 198px;
+  }
+
+  .game-card-rating {
+    width: 72px;
+    height: 64px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-card {
+    transition: none;
+  }
+
+  .game-card:hover {
+    transform: none;
+  }
 }

--- a/frontend/src/components/GameCard.test.tsx
+++ b/frontend/src/components/GameCard.test.tsx
@@ -56,7 +56,7 @@ function renderCard(
 }
 
 describe("GameCard rating block (DQ-1)", () => {
-  it("shows the BGG rating as a red square, one decimal", () => {
+  it("shows the BGG rating as the styled score block, one decimal", () => {
     const { container } = renderCard({ bgg_rating: 8.4 });
 
     const rating = screen.getByText("8.4");

--- a/frontend/src/components/SearchFiltersBox.css
+++ b/frontend/src/components/SearchFiltersBox.css
@@ -75,6 +75,37 @@
   flex-wrap: wrap;
 }
 
+.catalog-page .search-filters-box-tabs button {
+  font-family: var(--font-family-heading);
+}
+
+.catalog-page .search-filters-box-panel {
+  padding: 1.5rem 1rem 1.75rem;
+}
+
+.catalog-page .catalog-search-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: var(--space-md);
+  row-gap: 0.875rem;
+  width: 100%;
+}
+
+.catalog-page .catalog-search-form .search-bar {
+  grid-column: 1 / -1;
+}
+
+.catalog-page .catalog-search-form > button {
+  grid-column: 2;
+  width: 100%;
+}
+
+.catalog-page .catalog-search-form > button:disabled {
+  opacity: 1;
+  background-color: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
 /* ─── Results bar: count + view toggle ────────────────────────────── */
 
 .catalog-results-bar {
@@ -87,4 +118,18 @@
   color: var(--color-text-body);
   font-size: var(--font-size-lg);
   margin: 0;
+}
+
+.catalog-page .catalog-count {
+  font-size: var(--font-size-xl);
+}
+
+@media (max-width: 767px) {
+  .catalog-page .catalog-search-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .catalog-page .catalog-search-form > button {
+    grid-column: 1;
+  }
 }

--- a/frontend/src/pages/CatalogPage.css
+++ b/frontend/src/pages/CatalogPage.css
@@ -5,12 +5,33 @@
  */
 
 .catalog-page {
-  max-width: 1120px;
+  /* 1152px of usable content at the 1440px Figma desktop frame. */
+  max-width: 1184px;
   margin: 0 auto;
   padding: 0 var(--space-md) var(--space-2xl);
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
+}
+
+.catalog-page > h1 {
+  margin-top: var(--space-3xl);
+}
+
+.catalog-page > h1::after {
+  width: min(744px, 70%);
+  margin-top: var(--space-sm);
+}
+
+/* The Figma control area spans slightly wider than the card columns. */
+.catalog-page .catalog-type-toggle {
+  margin-top: var(--space-xl);
+  margin-inline: calc(-1 * var(--space-md));
+}
+
+.catalog-page > .search-filters-box,
+.catalog-page > .catalog-results-bar {
+  margin-inline: calc(-1 * var(--space-md));
 }
 
 .catalog-loading,
@@ -39,8 +60,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border: none;
   background-color: var(--color-surface);
   color: var(--color-text-muted);
@@ -66,8 +87,9 @@
 
 .catalog-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: var(--space-lg);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 30px;
+  margin-top: var(--space-md);
   align-items: start;
 }
 
@@ -75,4 +97,23 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
+}
+
+@media (max-width: 900px) {
+  .catalog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-lg);
+  }
+}
+
+@media (max-width: 600px) {
+  .catalog-page .catalog-type-toggle,
+  .catalog-page > .search-filters-box,
+  .catalog-page > .catalog-results-bar {
+    margin-inline: 0;
+  }
+
+  .catalog-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/frontend/src/pages/CatalogPage.test.tsx
+++ b/frontend/src/pages/CatalogPage.test.tsx
@@ -126,7 +126,9 @@ describe("CatalogPage search-and-filters box", () => {
   it("shows the search input on the default Buscador tab and no filter controls", () => {
     renderPage();
 
-    expect(screen.getByLabelText("Buscar juegos...")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Buscar juego por nombre..."),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText(AVAILABILITY_SELECT)).not.toBeVisible();
   });
 
@@ -153,7 +155,7 @@ describe("CatalogPage search-and-filters box", () => {
     vi.useFakeTimers();
     renderPage();
 
-    const searchInput = screen.getByLabelText("Buscar juegos...");
+    const searchInput = screen.getByLabelText("Buscar juego por nombre...");
     fireEvent.change(searchInput, { target: { value: "azul" } });
     act(() => {
       vi.advanceTimersByTime(350);
@@ -229,6 +231,14 @@ describe("CatalogPage player-range slider", () => {
 });
 
 describe("CatalogPage catalog type toggle and banner", () => {
+  it("uses the concise catalog heading from the reference design", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Catálogo" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders the catalog type toggle with both links", () => {
     renderPage();
 

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -63,16 +63,6 @@ function ViewToggle({ view, onChange }: ViewToggleProps) {
     <div className="catalog-view-toggle" role="group" aria-label="Modo de vista">
       <button
         type="button"
-        className={view === "grid" ? "active" : ""}
-        aria-pressed={view === "grid"}
-        aria-label="Vista de cuadrícula"
-        title="Vista de cuadrícula"
-        onClick={() => onChange("grid")}
-      >
-        <GridIcon />
-      </button>
-      <button
-        type="button"
         className={view === "list" ? "active" : ""}
         aria-pressed={view === "list"}
         aria-label="Vista de lista"
@@ -80,6 +70,16 @@ function ViewToggle({ view, onChange }: ViewToggleProps) {
         onClick={() => onChange("list")}
       >
         <ListIcon />
+      </button>
+      <button
+        type="button"
+        className={view === "grid" ? "active" : ""}
+        aria-pressed={view === "grid"}
+        aria-label="Vista de cuadrícula"
+        title="Vista de cuadrícula"
+        onClick={() => onChange("grid")}
+      >
+        <GridIcon />
       </button>
     </div>
   );
@@ -142,7 +142,7 @@ export function CatalogPage() {
 
   return (
     <div className="catalog-page">
-      <PageTitle>Catálogo de juegos</PageTitle>
+      <PageTitle>Catálogo</PageTitle>
 
       <CatalogTypeToggle />
 
@@ -155,8 +155,11 @@ export function CatalogPage() {
             <SearchBar
               value={query.search}
               onChange={(search) => setQuery((q) => ({ ...q, search }))}
+              placeholder="Buscar juego por nombre..."
             />
-            <Button type="submit">Buscar</Button>
+            <Button type="submit" disabled={!query.search.trim()}>
+              Buscar
+            </Button>
           </form>
         }
         filters={filterPanel}


### PR DESCRIPTION
## Summary

- Match the catalog spacing and three-column desktop grid to the supplied Figma prototype.
- Rework card geometry for the 80×71 score block, bottom-aligned category pill, and diagonal loan ribbon.
- Align the title, search area, and view controls with the reference.
- Replace the card-wide underline hover with a restrained lift and visible keyboard focus.
- Keep the two-column, single-column, and list layouts working. Board-game-specific search styles do not affect the RPG catalog.

## Verification

- Full frontend test suite: 214 tests passed
- ESLint passed
- TypeScript typecheck passed
- Production build passed
- Browser checks at 1440px, 800px, and 390px with no horizontal overflow
- Direct comparison with the Figma prototype at 1440×1000