### PR TITLE
fix(catalog): clamp multiline card titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The catalog is publicly browsable read-only (no account needed; borrowing and
 reviewing a member's own profile require logging in). Legacy `/prestamos` URLs
 redirect permanently to `/ludoteca`.
 
+Board-game and RPG catalog cards share a fixed hierarchy: titles are truncated
+after two lines and descriptions after three, keeping every card aligned.
+
 A public membership-validation page lives at `/ludoteca/validacion`: anyone
 can enter a member number and see whether that person is a current member
 (name, ES/NO ES socio·a verdict, last paid fee). The legacy

--- a/frontend/src/components/CatalogCard.css
+++ b/frontend/src/components/CatalogCard.css
@@ -97,7 +97,7 @@
   position: relative;
   display: grid;
   grid-template-columns: 80px minmax(0, 1fr);
-  grid-template-rows: 43px minmax(85px, 1fr) auto;
+  grid-template-rows: 64px minmax(64px, 1fr) auto;
   column-gap: var(--space-md);
   row-gap: var(--space-sm);
   min-height: 200px;
@@ -135,6 +135,11 @@
   color: var(--color-text-heading);
   line-height: var(--line-height-tight);
   text-align: center;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
 }
 
 .game-card-meta {
@@ -171,8 +176,8 @@
   color: var(--color-text-muted);
   line-height: var(--line-height-normal);
   display: -webkit-box;
-  -webkit-line-clamp: 4;
-  line-clamp: 4;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
@@ -10,7 +10,7 @@ The system SHALL render each game in the catalog as a card where the game cover 
 - **WHEN** a `GameCard` renders for a game
 - **THEN** the cover image SHALL occupy the top portion of the card
 - **AND** a red square block with the BGG rating (one decimal) SHALL hang over the cover/body boundary on the left
-- **AND** the game title SHALL render as the card heading with the game description below it, clamped to five lines
+- **AND** the game title SHALL render as the card heading, clamped to two lines with an ellipsis when needed, with the game description below it clamped to three lines
 - **AND** a vertical meta column SHALL show minimum age ("8+"), playing time ("30min"), and player range ("3-8"), hiding any item whose value is missing
 - **AND** a single tag pill SHALL render bottom-right: the game's primary BGG subdomain mapped to a Spanish label (Familiar, Estrategia, Fiesta, Temático, …), falling back to the game's most common own category, or no pill when neither exists
 

--- a/openspec/specs/lending-catalog-redesign/spec.md
+++ b/openspec/specs/lending-catalog-redesign/spec.md
@@ -11,7 +11,7 @@ The system SHALL render each game in the catalog as a card where the game cover 
 - **WHEN** a `GameCard` renders for a game
 - **THEN** the cover image SHALL occupy the top portion of the card
 - **AND** a red square block with the BGG rating (one decimal) SHALL hang over the cover/body boundary on the left
-- **AND** the game title SHALL render as the card heading with the game description below it, clamped to five lines
+- **AND** the game title SHALL render as the card heading, clamped to two lines with an ellipsis when needed, with the game description below it clamped to three lines
 - **AND** a vertical meta column SHALL show minimum age ("8+"), playing time ("30min"), and player range ("3-8"), hiding any item whose value is missing
 - **AND** a single tag pill SHALL render bottom-right: the game's primary BGG subdomain mapped to a Spanish label (Familiar, Estrategia, Fiesta, Temático, …), falling back to the game's most common own category, or no pill when neither exists
 
@@ -117,4 +117,3 @@ The system SHALL render the catalog component at the public path `/ludoteca` in 
 #### Scenario: Authenticated member sees private catalog
 - **WHEN** an authenticated member opens `/prestamos`
 - **THEN** the same catalog component SHALL render with Borrow controls available on each available `GameCard`
-


### PR DESCRIPTION
## Summary

Catalog card titles now stop after two lines, with an ellipsis for longer names. Descriptions stop after three lines, so the metadata and tags stay aligned. This lives in the shared card styles, covering both board games and RPG books.

## Tests

- `cd frontend && npm test -- --run src/components/GameCard.test.tsx src/components/RpgCard.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`

## Related Tasks

- Closes #118