### PR TITLE
fix(brand): use Refugio del Sátiro identity

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -17,7 +17,7 @@ FRONTEND_DIR = Path(__file__).resolve().parent.parent.parent / "frontend" / "dis
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="Refugio del Sátiro — Préstamos", version="0.1.0")
+    app = FastAPI(title="Refugio del Sátiro", version="0.1.0")
 
     app.include_router(games_router)
     app.include_router(rpg_items_router)

--- a/backend/data/email_client.py
+++ b/backend/data/email_client.py
@@ -20,7 +20,7 @@ class EmailClient:
 <html>
 <body style="font-family: system-ui, sans-serif; color: #1f2937; max-width: 600px; margin: 0 auto;">
     <h2>¡Hola {display_name}!</h2>
-    <p>Bienvenido/a a <strong>Préstamos Sátiros</strong>, la aplicación de préstamo de juegos del Refugio del Sátiro.</p>
+    <p>Bienvenido/a a <strong>Refugio del Sátiro</strong>, la aplicación de préstamo de juegos del Refugio del Sátiro.</p>
     <p>Para acceder, haz clic en el siguiente enlace para establecer tu contraseña:</p>
     <p style="margin: 24px 0;">
         <a href="{url}"
@@ -39,7 +39,7 @@ class EmailClient:
 </html>"""
 
         msg = MIMEMultipart("alternative")
-        msg["Subject"] = "Préstamos Sátiros — Acceso a tu cuenta"
+        msg["Subject"] = "Refugio del Sátiro — Acceso a tu cuenta"
         msg["From"] = self._settings.smtp_from  # type: ignore[assignment]
         msg["To"] = to_email
         msg.attach(MIMEText(html, "html"))

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Refugio del Sátiro — Préstamos</title>
+    <title>Refugio del Sátiro</title>
   </head>
   <body>
     <div id="root"></div>

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -30,6 +30,10 @@ def _setup_test_client() -> tuple[TestClient, sqlite3.Connection]:
     return client, conn
 
 
+def test_application_title_uses_refugio_del_satiro_brand() -> None:
+    assert create_app().title == "Refugio del Sátiro"
+
+
 class TestLogin:
     def test_login_success(self) -> None:
         client, conn = _setup_test_client()

--- a/tests/data/test_email_client.py
+++ b/tests/data/test_email_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from email import message_from_string
+from email.header import decode_header, make_header
+from unittest.mock import MagicMock
+
+from pytest import MonkeyPatch
+
+from backend.config import Settings
+from backend.data.email_client import EmailClient
+
+OBSOLETE_BRAND = "Préstamos Sát" + "iros"
+
+
+def test_send_access_link_uses_refugio_del_satiro_brand(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    smtp = MagicMock()
+    monkeypatch.setattr("backend.data.email_client.smtplib.SMTP", smtp)  # type: ignore[attr-defined]
+    client = EmailClient(
+        Settings(
+            smtp_host="smtp.example.invalid",
+            smtp_user="user",
+            smtp_password="password",
+            smtp_from="noreply@example.invalid",
+        )
+    )
+
+    sent = client.send_access_link(
+        "member@example.invalid", "Ada", "https://example.invalid/set-password"
+    )
+
+    assert sent is True
+    smtp.return_value.__enter__.return_value.sendmail.assert_called_once()
+    raw_message = smtp.return_value.__enter__.return_value.sendmail.call_args.args[2]
+    message = message_from_string(raw_message)
+    subject = str(make_header(decode_header(message["Subject"])))
+    html = message.get_payload()[0].get_payload(decode=True).decode()
+    assert "Refugio del Sátiro" in subject
+    assert OBSOLETE_BRAND not in subject
+    assert "Refugio del Sátiro" in html
+    assert OBSOLETE_BRAND not in html


### PR DESCRIPTION
Updates the public product identity to Refugio del Sátiro in account emails, OpenAPI metadata, and the browser title.

Tests:
- `pytest tests/data/test_email_client.py tests/api/test_auth_routes.py`
- `cd frontend && yarn build`

Closes #99