### PR TITLE
fix(menu): remove duplicate password link

### DIFF
--- a/frontend/src/components/SiteHeader/SiteHeader.test.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.test.tsx
@@ -262,7 +262,6 @@ describe("SiteHeader", () => {
       expect(menuitems).toEqual([
         "Mi perfil",
         "Mis préstamos",
-        "Cambiar contraseña",
         "Cerrar sesión",
       ]);
     });
@@ -292,17 +291,11 @@ describe("SiteHeader", () => {
       });
     });
 
-    it("links Cambiar contraseña to /change-password", () => {
+    it("does not link to password change", () => {
       setMember();
       renderHeader();
 
-      const changePasswordLinks = screen
-        .getAllByRole("menuitem")
-        .filter((el) => el.textContent?.trim() === "Cambiar contraseña")
-        .map((el) => el.querySelector("a"));
-      changePasswordLinks.forEach((link) => {
-        expect(link).toHaveAttribute("href", "/change-password");
-      });
+      expect(screen.queryByRole("link", { name: "Cambiar contraseña" })).toBeNull();
     });
 
     it("does not show Iniciar sesión or Administración for member", () => {
@@ -353,7 +346,6 @@ describe("SiteHeader", () => {
       expect(topLevelLabels).toEqual([
         "Mi perfil",
         "Mis préstamos",
-        "Cambiar contraseña",
         "Administración",
         "Cerrar sesión",
       ]);

--- a/frontend/src/components/SiteHeader/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.tsx
@@ -114,11 +114,6 @@ function UserSubmenu({
           Mis préstamos
         </Link>
       </li>
-      <li className={styles.submenuItem} role="menuitem">
-        <Link to="/change-password" onClick={onItemClick}>
-          Cambiar contraseña
-        </Link>
-      </li>
       {isAdmin && (
         <AdminNestedSubmenu
           mobileExpanded={adminExpanded}


### PR DESCRIPTION
Closes #122.\n\nRemoves the duplicate password-change link from the account menu. It remains available from Mi perfil.