### PR TITLE
feat(rpg): add catalog filters

### DIFF
--- a/frontend/src/components/RpgActiveFilterChips.tsx
+++ b/frontend/src/components/RpgActiveFilterChips.tsx
@@ -1,0 +1,95 @@
+import { Chip } from "../ui/Chip";
+import { AVAILABILITY_OPTIONS } from "../types/catalog";
+import {
+  DEFAULT_RPG_QUERY,
+  RPG_GENRE_OPTIONS,
+  RPG_PUBLICATION_OPTIONS,
+  RPG_SORT_OPTIONS,
+  type RpgQuery,
+} from "../types/rpg";
+import "./ActiveFilterChips.css";
+
+interface RpgActiveFilterChipsProps {
+  readonly query: RpgQuery;
+  readonly onChange: (query: RpgQuery) => void;
+}
+
+interface ActiveChip {
+  readonly key: string;
+  readonly label: string;
+  readonly cleared: RpgQuery;
+}
+
+function optionLabel(
+  options: readonly { readonly value: string; readonly label: string }[],
+  value: string,
+): string {
+  return options.find((option) => option.value === value)?.label ?? value;
+}
+
+function activeChips(query: RpgQuery): readonly ActiveChip[] {
+  const candidates: readonly (ActiveChip | null)[] = [
+    query.genre !== DEFAULT_RPG_QUERY.genre
+      ? {
+          key: "genre",
+          label: `Género: ${optionLabel(RPG_GENRE_OPTIONS, query.genre)}`,
+          cleared: { ...query, genre: DEFAULT_RPG_QUERY.genre },
+        }
+      : null,
+    query.publicationKind !== DEFAULT_RPG_QUERY.publicationKind
+      ? {
+          key: "publication-kind",
+          label: `Tipo: ${optionLabel(
+            RPG_PUBLICATION_OPTIONS,
+            query.publicationKind,
+          )}`,
+          cleared: {
+            ...query,
+            publicationKind: DEFAULT_RPG_QUERY.publicationKind,
+          },
+        }
+      : null,
+    query.availability !== DEFAULT_RPG_QUERY.availability
+      ? {
+          key: "availability",
+          label: optionLabel(AVAILABILITY_OPTIONS, query.availability),
+          cleared: { ...query, availability: DEFAULT_RPG_QUERY.availability },
+        }
+      : null,
+    query.minRating > DEFAULT_RPG_QUERY.minRating
+      ? {
+          key: "rating",
+          label: `Valoración ≥ ${query.minRating.toFixed(1)}`,
+          cleared: { ...query, minRating: DEFAULT_RPG_QUERY.minRating },
+        }
+      : null,
+    query.sort !== DEFAULT_RPG_QUERY.sort
+      ? {
+          key: "sort",
+          label: `Orden: ${optionLabel(RPG_SORT_OPTIONS, query.sort)}`,
+          cleared: { ...query, sort: DEFAULT_RPG_QUERY.sort },
+        }
+      : null,
+  ];
+
+  return candidates.filter((candidate): candidate is ActiveChip => candidate !== null);
+}
+
+export function RpgActiveFilterChips({
+  query,
+  onChange,
+}: RpgActiveFilterChipsProps) {
+  const chips = activeChips(query);
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="active-filter-chips" aria-label="Filtros activos">
+      {chips.map((chip) => (
+        <Chip key={chip.key} onRemove={() => onChange(chip.cleared)}>
+          {chip.label}
+        </Chip>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/RpgFilterPanel.tsx
+++ b/frontend/src/components/RpgFilterPanel.tsx
@@ -1,0 +1,82 @@
+import * as Slider from "@radix-ui/react-slider";
+import { Select } from "../ui/Select";
+import { AVAILABILITY_OPTIONS, type AvailabilityValue } from "../types/catalog";
+import {
+  RPG_GENRE_OPTIONS,
+  RPG_PUBLICATION_OPTIONS,
+  RPG_SORT_OPTIONS,
+  type RpgGenreValue,
+  type RpgPublicationValue,
+  type RpgQuery,
+  type RpgSortValue,
+} from "../types/rpg";
+import "./FilterPanel.css";
+
+interface RpgFilterPanelProps {
+  readonly query: RpgQuery;
+  readonly onChange: (query: RpgQuery) => void;
+}
+
+export function RpgFilterPanel({ query, onChange }: RpgFilterPanelProps) {
+  return (
+    <div className="filter-panel" role="group" aria-label="Filtros y ordenación">
+      <Select
+        label="Ordenar por"
+        options={RPG_SORT_OPTIONS}
+        value={query.sort}
+        onChange={(e) => onChange({ ...query, sort: e.target.value as RpgSortValue })}
+      />
+
+      <Select
+        label="Género"
+        options={RPG_GENRE_OPTIONS}
+        value={query.genre}
+        onChange={(e) => onChange({ ...query, genre: e.target.value as RpgGenreValue })}
+      />
+
+      <Select
+        label="Tipo de publicación"
+        options={RPG_PUBLICATION_OPTIONS}
+        value={query.publicationKind}
+        onChange={(e) =>
+          onChange({
+            ...query,
+            publicationKind: e.target.value as RpgPublicationValue,
+          })
+        }
+      />
+
+      <Select
+        label="Disponibilidad"
+        options={AVAILABILITY_OPTIONS}
+        value={query.availability}
+        onChange={(e) =>
+          onChange({ ...query, availability: e.target.value as AvailabilityValue })
+        }
+      />
+
+      <div className="filter-panel-field">
+        <span className="filter-panel-label" id="min-rating-label">
+          Valoración mínima: {query.minRating.toFixed(1)}
+        </span>
+        <Slider.Root
+          className="filter-panel-slider"
+          min={0}
+          max={10}
+          step={0.5}
+          value={[query.minRating]}
+          onValueChange={([minRating]) => onChange({ ...query, minRating })}
+          aria-labelledby="min-rating-label"
+        >
+          <Slider.Track className="filter-panel-slider-track">
+            <Slider.Range className="filter-panel-slider-range" />
+          </Slider.Track>
+          <Slider.Thumb
+            className="filter-panel-slider-thumb"
+            aria-label="Valoración mínima"
+          />
+        </Slider.Root>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/rpgTags.test.ts
+++ b/frontend/src/lib/rpgTags.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveRpgTagPill, rpgPublicationKinds } from "./rpgTags";
+import {
+  matchesPublicationKind,
+  matchesRpgGenre,
+  resolveRpgTagPill,
+  rpgPublicationKinds,
+} from "./rpgTags";
 
 const CORE_RULES_TYPE = "Core Rules (min needed to play)";
 const SOURCEBOOK_TYPE = "Sourcebook (rules/options to enhance play)";
@@ -81,5 +86,33 @@ describe("rpgPublicationKinds", () => {
       rulebook: false,
       adventure: false,
     });
+  });
+});
+
+describe("matchesRpgGenre", () => {
+  it("matches a category through its resolved genre family", () => {
+    expect(matchesRpgGenre(["Horror (Cthulhu Mythos)"], "horror")).toBe(true);
+    expect(matchesRpgGenre(["Horror (Cthulhu Mythos)"], "fantasy")).toBe(false);
+  });
+
+  it("keeps urban fantasy distinct from fantasy", () => {
+    const categories = ["Fantasy (Modern Urban Fantasy)"];
+
+    expect(matchesRpgGenre(categories, "urban-fantasy")).toBe(true);
+    expect(matchesRpgGenre(categories, "fantasy")).toBe(false);
+  });
+
+  it("matches Otros only when no category resolves to a genre family", () => {
+    expect(matchesRpgGenre([], "other")).toBe(true);
+    expect(matchesRpgGenre(["Espionage"], "other")).toBe(true);
+    expect(matchesRpgGenre(["Espionage", "Horror"], "other")).toBe(false);
+  });
+});
+
+describe("matchesPublicationKind", () => {
+  it("uses the same publication kind classification as the card icons", () => {
+    expect(matchesPublicationKind([CORE_RULES_TYPE], "rulebook")).toBe(true);
+    expect(matchesPublicationKind([CORE_RULES_TYPE], "adventure")).toBe(false);
+    expect(matchesPublicationKind([ADVENTURE_TYPE], "adventure")).toBe(true);
   });
 });

--- a/frontend/src/lib/rpgTags.ts
+++ b/frontend/src/lib/rpgTags.ts
@@ -10,29 +10,64 @@
 
 import type { TagPill } from "./gameTags";
 
+export type RpgGenreFamilyKey =
+  | "fantasy"
+  | "urban-fantasy"
+  | "horror"
+  | "sci-fi"
+  | "mythology"
+  | "history"
+  | "adventure"
+  | "modern";
+
 /** Prefix-matched, so "Horror (Cthulhu Mythos)" resolves to "Horror". */
-const RPG_CATEGORY_PILLS: readonly (readonly [string, TagPill])[] = [
+const RPG_CATEGORY_PILLS: readonly (readonly [
+  RpgGenreFamilyKey,
+  string,
+  TagPill,
+])[] = [
   [
+    "urban-fantasy",
     "Fantasy (Modern Urban Fantasy)",
     { label: "Fantasía Urbana", colorClass: "game-card-tag--turquoise" },
   ],
-  ["Fantasy", { label: "Fantasía", colorClass: "game-card-tag--mint" }],
-  ["Horror", { label: "Horror", colorClass: "game-card-tag--pink" }],
   [
+    "fantasy",
+    "Fantasy",
+    { label: "Fantasía", colorClass: "game-card-tag--mint" },
+  ],
+  ["horror", "Horror", { label: "Horror", colorClass: "game-card-tag--pink" }],
+  [
+    "sci-fi",
     "Science Fiction",
     { label: "Ciencia Ficción", colorClass: "game-card-tag--lavender" },
   ],
   [
+    "mythology",
     "Mythology / Folklore",
     { label: "Mitología", colorClass: "game-card-tag--sky" },
   ],
-  ["History", { label: "Histórico", colorClass: "game-card-tag--peach" }],
   [
+    "history",
+    "History",
+    { label: "Histórico", colorClass: "game-card-tag--peach" },
+  ],
+  [
+    "adventure",
     "Action / Adventure",
     { label: "Aventura", colorClass: "game-card-tag--yellow" },
   ],
-  ["Modern", { label: "Moderno", colorClass: "game-card-tag--pearl" }],
+  [
+    "modern",
+    "Modern",
+    { label: "Moderno", colorClass: "game-card-tag--pearl" },
+  ],
 ];
+
+export const RPG_GENRE_FAMILIES: readonly {
+  readonly key: RpgGenreFamilyKey;
+  readonly label: string;
+}[] = RPG_CATEGORY_PILLS.map(([key, , pill]) => ({ key, label: pill.label }));
 
 /** Neutral pastel used when the category has no Spanish mapping. */
 const FALLBACK_CATEGORY_COLOR_CLASS = "game-card-tag--pearl";
@@ -43,15 +78,37 @@ export function resolveRpgTagPill(
   if (!category) {
     return undefined;
   }
-  const family = RPG_CATEGORY_PILLS.find(([prefix]) =>
+  const family = RPG_CATEGORY_PILLS.find(([, prefix]) =>
     category.startsWith(prefix),
   );
   return (
-    family?.[1] ?? {
+    family?.[2] ?? {
       label: category,
       colorClass: FALLBACK_CATEGORY_COLOR_CLASS,
     }
   );
+}
+
+function resolveRpgGenreFamily(
+  category: string,
+): RpgGenreFamilyKey | undefined {
+  return RPG_CATEGORY_PILLS.find(([, prefix]) =>
+    category.startsWith(prefix),
+  )?.[0];
+}
+
+export function matchesRpgGenre(
+  categories: readonly string[],
+  genreKey: RpgGenreFamilyKey | "other",
+): boolean {
+  const resolvedFamilies = categories.flatMap((category) => {
+    const family = resolveRpgGenreFamily(category);
+    return family === undefined ? [] : [family];
+  });
+
+  return genreKey === "other"
+    ? resolvedFamilies.length === 0
+    : resolvedFamilies.includes(genreKey);
 }
 
 /*
@@ -85,4 +142,11 @@ export function rpgPublicationKinds(
       type.startsWith(ADVENTURE_TYPE_PREFIX),
     ),
   };
+}
+
+export function matchesPublicationKind(
+  publicationTypes: readonly string[],
+  kind: keyof RpgPublicationKinds,
+): boolean {
+  return rpgPublicationKinds(publicationTypes)[kind];
 }

--- a/frontend/src/pages/RpgCatalogPage.test.tsx
+++ b/frontend/src/pages/RpgCatalogPage.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,8 +23,8 @@ const ITEM_A: RpgItem = {
   bgg_rating: 7.9,
   description: "Wizards in medieval Europe.",
   description_es: "",
-  categories: [],
-  publication_types: [],
+  categories: ["Fantasy"],
+  publication_types: ["Core Rules"],
   status: "available",
   loan_id: null,
   borrower_display_name: null,
@@ -41,9 +41,9 @@ const ITEM_B: RpgItem = {
   bgg_rating: 8.6,
   description: "Gothic horror RPG.",
   description_es: "",
-  categories: [],
-  publication_types: [],
-  status: "available",
+  categories: ["Horror"],
+  publication_types: ["Scenario"],
+  status: "lent",
   loan_id: null,
   borrower_display_name: null,
 };
@@ -59,8 +59,8 @@ const ITEM_C: RpgItem = {
   bgg_rating: 7.2,
   description: "Fantasy RPG.",
   description_es: "",
-  categories: [],
-  publication_types: [],
+  categories: ["Fantasy"],
+  publication_types: ["Scenario"],
   status: "available",
   loan_id: null,
   borrower_display_name: null,
@@ -171,6 +171,64 @@ describe("RpgCatalogPage rating sort", () => {
     const names = getItemNames();
     // ITEM_B: 8.6, ITEM_A: 7.9, ITEM_C: 7.2
     expect(names).toEqual(["Vampire: The Masquerade", "Ars Magica", "Pathfinder"]);
+  });
+});
+
+describe("RpgCatalogPage RPG filters", () => {
+  it("updates the results count when filtering by genre", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("tab", { name: "Filtros" }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Género" }),
+      "fantasy",
+    );
+
+    expect(screen.getByText("Mostrando 2 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Ars Magica")).toBeInTheDocument();
+    expect(screen.getByText("Pathfinder")).toBeInTheDocument();
+    expect(screen.queryByText("Vampire: The Masquerade")).toBeNull();
+  });
+
+  it("removes an active filter chip to restore the full list", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("tab", { name: "Filtros" }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Género" }),
+      "fantasy",
+    );
+
+    const chip = screen
+      .getByText("Género: Fantasía")
+      .closest('[role="status"]') as HTMLElement | null;
+    expect(chip).not.toBeNull();
+    await user.click(within(chip!).getByRole("button", { name: "Quitar filtro" }));
+
+    expect(screen.getByText("Mostrando 3 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Vampire: The Masquerade")).toBeInTheDocument();
+  });
+
+  it("combines genre and publication filters", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("tab", { name: "Filtros" }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Género" }),
+      "fantasy",
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Tipo de publicación" }),
+      "rulebook",
+    );
+
+    expect(screen.getByText("Mostrando 1 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Ars Magica")).toBeInTheDocument();
+    expect(screen.queryByText("Pathfinder")).toBeNull();
+    expect(screen.queryByText("Vampire: The Masquerade")).toBeNull();
   });
 });
 

--- a/frontend/src/pages/RpgCatalogPage.tsx
+++ b/frontend/src/pages/RpgCatalogPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { CatalogTypeToggle } from "../components/CatalogTypeToggle";
 import { CatalogViewToggle } from "../components/CatalogViewToggle";
+import { RpgActiveFilterChips } from "../components/RpgActiveFilterChips";
+import { RpgFilterPanel } from "../components/RpgFilterPanel";
 import {
   persistCatalogView,
   storedCatalogView,
@@ -13,13 +15,10 @@ import { useRpgItems } from "../hooks/useRpgItems";
 import { computeCategoryFrequency, mostCommonOwnCategory } from "../lib/gameTags";
 import { Button } from "../ui/Button";
 import { PageTitle } from "../ui/PageTitle";
-import { Select } from "../ui/Select";
 import {
   applyRpgQuery,
   DEFAULT_RPG_QUERY,
-  RPG_SORT_OPTIONS,
   type RpgQuery,
-  type RpgSortValue,
 } from "../types/rpg";
 import type { CatalogView } from "../types/catalog";
 // Shares the board game catalog layout (page frame, results bar, grid/list).
@@ -81,17 +80,10 @@ export function RpgCatalogPage() {
             </Button>
           </form>
         }
-        filters={
-          <Select
-            label="Ordenar por"
-            value={query.sort}
-            options={RPG_SORT_OPTIONS}
-            onChange={(e) =>
-              setQuery((q) => ({ ...q, sort: e.target.value as RpgSortValue }))
-            }
-          />
-        }
+        filters={<RpgFilterPanel query={query} onChange={setQuery} />}
       />
+
+      <RpgActiveFilterChips query={query} onChange={setQuery} />
 
       <div className="catalog-results-bar">
         <p className="catalog-count">

--- a/frontend/src/types/rpg.test.ts
+++ b/frontend/src/types/rpg.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { applyRpgQuery, DEFAULT_RPG_QUERY, type RpgItem } from "./rpg";
+
+const items: readonly RpgItem[] = [
+  {
+    id: 1,
+    bgg_id: 101,
+    name: "Urban Shadows",
+    slug: "urban-shadows",
+    thumbnail_url: "",
+    image_url: "",
+    year_published: 2015,
+    bgg_rating: 8,
+    description: "",
+    description_es: "",
+    categories: ["Fantasy (Modern Urban Fantasy)"],
+    publication_types: ["Core Rules (min needed to play)"],
+    status: "available",
+    loan_id: null,
+    borrower_display_name: null,
+  },
+  {
+    id: 2,
+    bgg_id: 102,
+    name: "Call of Cthulhu Scenario",
+    slug: "call-of-cthulhu-scenario",
+    thumbnail_url: "",
+    image_url: "",
+    year_published: 1981,
+    bgg_rating: 7.5,
+    description: "",
+    description_es: "",
+    categories: ["Horror (Cthulhu Mythos)"],
+    publication_types: ["Scenario / Adventure / Module"],
+    status: "lent",
+    loan_id: 7,
+    borrower_display_name: "Ada",
+  },
+  {
+    id: 3,
+    bgg_id: 103,
+    name: "Fantasy Campaign",
+    slug: "fantasy-campaign",
+    thumbnail_url: "",
+    image_url: "",
+    year_published: 2000,
+    bgg_rating: 7,
+    description: "",
+    description_es: "",
+    categories: ["Fantasy (High Fantasy)"],
+    publication_types: [
+      "Core Rules (min needed to play)",
+      "Scenario / Adventure / Module",
+    ],
+    status: "available",
+    loan_id: null,
+    borrower_display_name: null,
+  },
+  {
+    id: 4,
+    bgg_id: 104,
+    name: "Espionage Toolkit",
+    slug: "espionage-toolkit",
+    thumbnail_url: "",
+    image_url: "",
+    year_published: 1990,
+    bgg_rating: 6.5,
+    description: "",
+    description_es: "",
+    categories: ["Espionage"],
+    publication_types: ["Accessory (dice, maps, screens, cards)"],
+    status: "available",
+    loan_id: null,
+    borrower_display_name: null,
+  },
+  {
+    id: 5,
+    bgg_id: 105,
+    name: "Uncategorised Book",
+    slug: "uncategorised-book",
+    thumbnail_url: "",
+    image_url: "",
+    year_published: 1995,
+    bgg_rating: 8.5,
+    description: "",
+    description_es: "",
+    categories: [],
+    publication_types: [],
+    status: "available",
+    loan_id: null,
+    borrower_display_name: null,
+  },
+];
+
+const ids = (filtered: readonly RpgItem[]) => filtered.map((item) => item.id);
+
+describe("applyRpgQuery", () => {
+  it("filters by a single genre without letting urban fantasy leak into fantasy", () => {
+    expect(
+      ids(applyRpgQuery(items, { ...DEFAULT_RPG_QUERY, genre: "horror" })),
+    ).toEqual([2]);
+    expect(
+      ids(applyRpgQuery(items, { ...DEFAULT_RPG_QUERY, genre: "fantasy" })),
+    ).toEqual([3]);
+  });
+
+  it("puts empty and unmapped categories in Otros, but excludes mixed categories", () => {
+    const mixed: RpgItem = {
+      ...items[3],
+      id: 6,
+      name: "Mixed categories",
+      categories: ["Espionage", "Horror"],
+    };
+
+    expect(
+      ids(
+        applyRpgQuery([...items, mixed], {
+          ...DEFAULT_RPG_QUERY,
+          genre: "other",
+        }),
+      ),
+    ).toEqual([4, 5]);
+  });
+
+  it("filters publication types, including an item that belongs to both kinds", () => {
+    expect(
+      ids(
+        applyRpgQuery(items, {
+          ...DEFAULT_RPG_QUERY,
+          publicationKind: "rulebook",
+        }),
+      ),
+    ).toEqual([3, 1]);
+    expect(
+      ids(
+        applyRpgQuery(items, {
+          ...DEFAULT_RPG_QUERY,
+          publicationKind: "adventure",
+        }),
+      ),
+    ).toEqual([2, 3]);
+  });
+
+  it("filters availability and includes the minimum rating boundary", () => {
+    expect(
+      ids(applyRpgQuery(items, { ...DEFAULT_RPG_QUERY, availability: "lent" })),
+    ).toEqual([2]);
+    expect(
+      ids(applyRpgQuery(items, { ...DEFAULT_RPG_QUERY, minRating: 7.5 })),
+    ).toEqual([2, 5, 1]);
+  });
+
+  it("returns no items when combined filters do not overlap", () => {
+    expect(
+      applyRpgQuery(items, {
+        ...DEFAULT_RPG_QUERY,
+        genre: "horror",
+        publicationKind: "rulebook",
+        availability: "available",
+        minRating: 9,
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns every item under the default query", () => {
+    expect(ids(applyRpgQuery(items, DEFAULT_RPG_QUERY))).toEqual([
+      2, 4, 3, 5, 1,
+    ]);
+  });
+});

--- a/frontend/src/types/rpg.ts
+++ b/frontend/src/types/rpg.ts
@@ -1,4 +1,9 @@
-import { stripPunctuation } from "./catalog";
+import { type AvailabilityValue, stripPunctuation } from "./catalog";
+import {
+  matchesPublicationKind,
+  matchesRpgGenre,
+  RPG_GENRE_FAMILIES,
+} from "../lib/rpgTags";
 
 export const rpgLendingStatuses = ["available", "lent"] as const;
 export type RpgLendingStatus = (typeof rpgLendingStatuses)[number];
@@ -24,13 +29,38 @@ export interface RpgItem {
 export const rpgSortValues = ["name-asc", "name-desc", "rating"] as const;
 export type RpgSortValue = (typeof rpgSortValues)[number];
 
+export const rpgGenreValues = [
+  "all",
+  "fantasy",
+  "urban-fantasy",
+  "horror",
+  "sci-fi",
+  "mythology",
+  "history",
+  "adventure",
+  "modern",
+  "other",
+] as const;
+export type RpgGenreValue = (typeof rpgGenreValues)[number];
+
+export const rpgPublicationValues = ["all", "rulebook", "adventure"] as const;
+export type RpgPublicationValue = (typeof rpgPublicationValues)[number];
+
 export interface RpgQuery {
   readonly search: string;
+  readonly genre: RpgGenreValue;
+  readonly publicationKind: RpgPublicationValue;
+  readonly availability: AvailabilityValue;
+  readonly minRating: number;
   readonly sort: RpgSortValue;
 }
 
 export const DEFAULT_RPG_QUERY: RpgQuery = {
   search: "",
+  genre: "all",
+  publicationKind: "all",
+  availability: "all",
+  minRating: 0,
   sort: "name-asc",
 };
 
@@ -43,6 +73,24 @@ export const RPG_SORT_OPTIONS: readonly RpgSortOption[] = [
   { value: "name-asc", label: "Nombre (A-Z)" },
   { value: "name-desc", label: "Nombre (Z-A)" },
   { value: "rating", label: "Valoración BGG (alta a baja)" },
+];
+
+export const RPG_GENRE_OPTIONS: readonly {
+  readonly value: RpgGenreValue;
+  readonly label: string;
+}[] = [
+  { value: "all", label: "Todos" },
+  ...RPG_GENRE_FAMILIES.map(({ key, label }) => ({ value: key, label })),
+  { value: "other", label: "Otros" },
+];
+
+export const RPG_PUBLICATION_OPTIONS: readonly {
+  readonly value: RpgPublicationValue;
+  readonly label: string;
+}[] = [
+  { value: "all", label: "Todos" },
+  { value: "rulebook", label: "Manual" },
+  { value: "adventure", label: "Aventura" },
 ];
 
 const RPG_COMPARATORS: Record<
@@ -64,7 +112,21 @@ export function applyRpgQuery(
 
   return items
     .filter(
-      (item) => search === "" || item.name.toLowerCase().includes(search),
+      (item) =>
+        query.availability === "all" || item.status === query.availability,
+    )
+    .filter(
+      (item) =>
+        query.genre === "all" || matchesRpgGenre(item.categories, query.genre),
+    )
+    .filter(
+      (item) =>
+        query.publicationKind === "all" ||
+        matchesPublicationKind(item.publication_types, query.publicationKind),
+    )
+    .filter((item) => search === "" || item.name.toLowerCase().includes(search))
+    .filter(
+      (item) => query.minRating <= 0 || item.bgg_rating >= query.minRating,
     )
     .toSorted(RPG_COMPARATORS[query.sort]);
 }


### PR DESCRIPTION
Closes #125

Adds client-side filters for the RPG catalog:

- genre, publication type, availability, and minimum BGG rating
- active filter chips with independent removal
- tests for filter behaviour and the RPG catalog UI

Checks: `yarn test`, `yarn typecheck`, `yarn lint`, and `yarn build`.