### PR TITLE
fix(lending): address Ariadna test feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ letterboxed rather than cropped.
 
 Failed sign-ins use the same generic credential message for every ineligible
 or invalid account and explain that the private lending area is limited to
-paid-up members, with a link to `/socios`. Successful sign-out is confirmed by
+paid-up members, with a link to `/socios/`. Successful sign-out is confirmed by
 an accessible four-second status notification.
 
 After a board game or RPG book is borrowed, the detail page reminds the member

--- a/README.md
+++ b/README.md
@@ -10,8 +10,22 @@ The catalog is publicly browsable read-only (no account needed; borrowing and
 reviewing a member's own profile require logging in). Legacy `/prestamos` URLs
 redirect permanently to `/ludoteca`.
 
-Board-game and RPG catalog cards share a fixed hierarchy: titles are truncated
-after two lines and descriptions after three, keeping every card aligned.
+Board-game and RPG catalogs share search and removable filter chips, a reset
+that preserves the selected sort order, sorting beside the grid/list toggle,
+and a responsive list view with readable covers, ratings, and metadata. Board
+games can also be filtered by player age from 3 to 18; items without a known
+minimum age are omitted while that filter is active. RPG covers remain
+letterboxed rather than cropped.
+
+Failed sign-ins use the same generic credential message for every ineligible
+or invalid account and explain that the private lending area is limited to
+paid-up members, with a link to `/socios`. Successful sign-out is confirmed by
+an accessible four-second status notification.
+
+After a board game or RPG book is borrowed, the detail page reminds the member
+that loans have no deadline and should be returned responsibly. A borrower
+sees `Devolver`; an administrator returning another member's item sees
+`Forzar devolución` in both the action and its confirmation.
 
 A public membership-validation page lives at `/ludoteca/validacion`: anyone
 can enter a member number and see whether that person is a current member

--- a/backend/api/routes/auth_routes.py
+++ b/backend/api/routes/auth_routes.py
@@ -89,7 +89,7 @@ def login(
     if member is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Credencials incorrectes.",
+            detail="Correo o contraseña incorrectos.",
         )
     token = create_jwt(member.id, _settings.jwt_secret)
     set_auth_cookie(response, token)

--- a/e2e/tests/ludoteca-guest.spec.ts
+++ b/e2e/tests/ludoteca-guest.spec.ts
@@ -77,17 +77,18 @@ test.describe("ludoteca @ guest", () => {
 
   test("ludo-4: pill toggle navigates to RPG catalog", async ({ page }) => {
     await page.goto(CATALOG_BOARDGAMES);
+    const catalogToggle = page.locator(".catalog-type-toggle");
 
     // Both pills must be visible on the board-game catalog.
     await expect(
-      page.getByRole("link", { name: "Juegos de mesa" }),
+      catalogToggle.getByRole("link", { name: "Juegos de mesa" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Libros de rol" }),
+      catalogToggle.getByRole("link", { name: "Libros de rol" }),
     ).toBeVisible();
 
     // Clicking "Libros de rol" navigates to /juegos-de-rol.
-    await page.getByRole("link", { name: "Libros de rol" }).click();
+    await catalogToggle.getByRole("link", { name: "Libros de rol" }).click();
     await expect(page).toHaveURL(new RegExp(CATALOG_RPG));
   });
 

--- a/e2e/tests/site-shell.spec.ts
+++ b/e2e/tests/site-shell.spec.ts
@@ -22,6 +22,7 @@ const ADMIN_STATE = resolve(FIXTURES_DIR, "admin.json");
 const HOME = "/ludoteca/";
 const LOGIN_PATH = "/ludoteca/login";
 const PROFILE_PATH = "/ludoteca/profile";
+const LUDOTECA_LABEL = "Ludoteca";
 const MEMBER_DISPLAY_NAME = "E2E Member";
 const ADMIN_DISPLAY_NAME = "E2E Admin";
 const MEMBER_EMAIL =
@@ -286,9 +287,7 @@ test.describe("site-shell @ static page (member)", () => {
     page,
   }, testInfo) => {
     await page.goto(STATIC_PAGE);
-    if (isMobileProject(testInfo.project.name)) {
-      await page.getByRole("button", { name: "Abrir menú" }).click();
-    }
+    await openUserSubmenu(page, testInfo.project.name);
     await expect(
       page.getByRole("button", { name: "Cerrar sesión" }).first(),
     ).toBeVisible();

--- a/frontend/src/components/ActiveFilterChips.css
+++ b/frontend/src/components/ActiveFilterChips.css
@@ -1,5 +1,10 @@
 .active-filter-chips {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-sm);
+}
+
+.active-filter-chips > button:last-child {
+  margin-left: auto;
 }

--- a/frontend/src/components/ActiveFilterChips.tsx
+++ b/frontend/src/components/ActiveFilterChips.tsx
@@ -1,10 +1,10 @@
 import { Chip } from "../ui/Chip";
+import { Button } from "../ui/Button";
 import {
   AVAILABILITY_OPTIONS,
   DEFAULT_CATALOG_QUERY,
   LOCATION_OPTIONS,
   PLAYER_BOUNDS,
-  SORT_OPTIONS,
   TIME_PRESET_OPTIONS,
   type CatalogQuery,
 } from "../types/catalog";
@@ -30,13 +30,21 @@ function optionLabel(
 
 function activeChips(query: CatalogQuery): readonly ActiveChip[] {
   const playerRangeActive =
-    query.playersMin > PLAYER_BOUNDS.min || query.playersMax < PLAYER_BOUNDS.max;
+    query.playersMin > PLAYER_BOUNDS.min ||
+    query.playersMax < PLAYER_BOUNDS.max;
   const playerMaxLabel =
     query.playersMax >= PLAYER_BOUNDS.max
       ? `${PLAYER_BOUNDS.max}+`
       : String(query.playersMax);
 
   const candidates: readonly (ActiveChip | null)[] = [
+    query.search.trim() !== ""
+      ? {
+          key: "search",
+          label: `Palabra clave: “${query.search.trim()}”`,
+          cleared: { ...query, search: "" },
+        }
+      : null,
     query.availability !== "all"
       ? {
           key: "availability",
@@ -76,11 +84,11 @@ function activeChips(query: CatalogQuery): readonly ActiveChip[] {
           cleared: { ...query, minRating: 0 },
         }
       : null,
-    query.sort !== DEFAULT_CATALOG_QUERY.sort
+    query.playerAge !== null
       ? {
-          key: "sort",
-          label: `Orden: ${optionLabel(SORT_OPTIONS, query.sort)}`,
-          cleared: { ...query, sort: DEFAULT_CATALOG_QUERY.sort },
+          key: "player-age",
+          label: `Edad del jugador: ${query.playerAge} años`,
+          cleared: { ...query, playerAge: null },
         }
       : null,
   ];
@@ -100,6 +108,13 @@ export function ActiveFilterChips({ query, onChange }: ActiveFilterChipsProps) {
           {chip.label}
         </Chip>
       ))}
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={() => onChange({ ...DEFAULT_CATALOG_QUERY, sort: query.sort })}
+      >
+        Limpiar búsqueda y filtros
+      </Button>
     </div>
   );
 }

--- a/frontend/src/components/CatalogCard.css
+++ b/frontend/src/components/CatalogCard.css
@@ -239,8 +239,8 @@
 }
 
 .game-card-list .game-card-cover {
-  flex: 0 0 110px;
-  width: 110px;
+  flex: 0 0 180px;
+  width: 180px;
 }
 
 .game-card-list .game-card-ribbon {
@@ -251,39 +251,57 @@
 }
 
 .game-card-list .game-card-body {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: var(--space-sm) var(--space-md);
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto;
+  align-content: center;
+  column-gap: var(--space-md);
+  row-gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
   min-height: 0;
 }
 
 .game-card-list .game-card-rating {
+  grid-column: 1;
+  grid-row: 1;
+  align-self: center;
   margin-top: 0;
-  width: 1.75rem;
-  height: 1.75rem;
-  font-size: var(--font-size-sm);
-  border-radius: 0 0 10px 0;
+  width: 56px;
+  height: 56px;
+  font-size: var(--font-size-xl);
+  border-radius: var(--radius-sm);
 }
 
 .game-card-list .game-card-name {
+  grid-column: 2 / 4;
+  grid-row: 1;
+  align-self: center;
   text-align: left;
 }
 
 .game-card-list .game-card-description {
+  grid-column: 2 / 4;
+  grid-row: 2;
   -webkit-line-clamp: 2;
   line-clamp: 2;
 }
 
 .game-card-list .game-card-meta {
+  grid-column: 2;
+  grid-row: 3;
+  align-self: center;
   flex-direction: row;
   flex-wrap: wrap;
   gap: var(--space-sm);
+  padding: 0;
 }
 
 .game-card-list .game-card-tag {
-  justify-self: start;
-  align-self: start;
+  grid-column: 3;
+  grid-row: 3;
+  justify-self: end;
+  align-self: center;
+  margin-top: 0;
 }
 
 @media (max-width: 600px) {
@@ -296,6 +314,41 @@
   .game-card-rating {
     width: 72px;
     height: 64px;
+  }
+
+  .game-card-list .game-card-cover {
+    flex-basis: 96px;
+    width: 96px;
+  }
+
+  .game-card-list .game-card-body {
+    grid-template-columns: 40px minmax(0, 1fr);
+    grid-template-rows: auto auto auto auto;
+    column-gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .game-card-list .game-card-rating {
+    width: 40px;
+    height: 40px;
+    font-size: var(--font-size-md);
+  }
+
+  .game-card-list .game-card-name,
+  .game-card-list .game-card-description {
+    grid-column: 2;
+  }
+
+  .game-card-list .game-card-meta {
+    grid-column: 2;
+    grid-row: 3;
+    gap: var(--space-xs) var(--space-sm);
+  }
+
+  .game-card-list .game-card-tag {
+    grid-column: 2;
+    grid-row: 4;
+    justify-self: start;
   }
 }
 

--- a/frontend/src/components/CatalogResultsBar.css
+++ b/frontend/src/components/CatalogResultsBar.css
@@ -1,0 +1,25 @@
+.catalog-results-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-md);
+}
+
+.catalog-results-controls > :first-child {
+  min-width: 15rem;
+}
+
+@media (max-width: 600px) {
+  .catalog-results-bar {
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  .catalog-results-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .catalog-results-controls > :first-child {
+    min-width: 0;
+  }
+}

--- a/frontend/src/components/CatalogResultsBar.tsx
+++ b/frontend/src/components/CatalogResultsBar.tsx
@@ -1,0 +1,51 @@
+import { Select } from "../ui/Select";
+import type { CatalogView } from "../types/catalog";
+import { CatalogViewToggle } from "./CatalogViewToggle";
+import "./CatalogResultsBar.css";
+
+interface SortOption<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+interface CatalogResultsBarProps<T extends string> {
+  readonly shown: number;
+  readonly total: number;
+  readonly sort: T;
+  readonly sortOptions: readonly SortOption<T>[];
+  readonly onSortChange: (sort: T) => void;
+  readonly view: CatalogView;
+  readonly onViewChange: (view: CatalogView) => void;
+}
+
+export function CatalogResultsBar<T extends string>({
+  shown,
+  total,
+  sort,
+  sortOptions,
+  onSortChange,
+  view,
+  onViewChange,
+}: CatalogResultsBarProps<T>) {
+  return (
+    <div className="catalog-results-bar">
+      <p
+        className="catalog-count"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        Mostrando {shown} de {total}
+      </p>
+      <div className="catalog-results-controls">
+        <Select
+          label="Ordenar por"
+          options={sortOptions}
+          value={sort}
+          onChange={(event) => onSortChange(event.target.value as T)}
+        />
+        <CatalogViewToggle view={view} onChange={onViewChange} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -3,13 +3,12 @@ import { Select } from "../ui/Select";
 import {
   AVAILABILITY_OPTIONS,
   LOCATION_OPTIONS,
+  PLAYER_AGE_OPTIONS,
   PLAYER_BOUNDS,
-  SORT_OPTIONS,
   TIME_PRESET_OPTIONS,
   type AvailabilityValue,
   type CatalogQuery,
   type LocationValue,
-  type SortValue,
   type TimePreset,
 } from "../types/catalog";
 import "./FilterPanel.css";
@@ -18,6 +17,7 @@ interface FilterPanelProps {
   readonly query: CatalogQuery;
   readonly onChange: (query: CatalogQuery) => void;
   readonly hasPlayerData: boolean;
+  readonly hasAgeData: boolean;
   readonly hasTimeData: boolean;
 }
 
@@ -25,6 +25,7 @@ export function FilterPanel({
   query,
   onChange,
   hasPlayerData,
+  hasAgeData,
   hasTimeData,
 }: FilterPanelProps) {
   const playerMaxLabel =
@@ -33,20 +34,16 @@ export function FilterPanel({
       : String(query.playersMax);
 
   return (
-    <div className="filter-panel" role="group" aria-label="Filtros y ordenación">
-      <Select
-        label="Ordenar por"
-        options={SORT_OPTIONS}
-        value={query.sort}
-        onChange={(e) => onChange({ ...query, sort: e.target.value as SortValue })}
-      />
-
+    <div className="filter-panel" role="group" aria-label="Filtros">
       <Select
         label="Disponibilidad"
         options={AVAILABILITY_OPTIONS}
         value={query.availability}
         onChange={(e) =>
-          onChange({ ...query, availability: e.target.value as AvailabilityValue })
+          onChange({
+            ...query,
+            availability: e.target.value as AvailabilityValue,
+          })
         }
       />
 
@@ -88,6 +85,20 @@ export function FilterPanel({
             />
           </Slider.Root>
         </div>
+      )}
+
+      {hasAgeData && (
+        <Select
+          label="Edad del jugador"
+          options={PLAYER_AGE_OPTIONS}
+          value={query.playerAge ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...query,
+              playerAge: e.target.value === "" ? null : Number(e.target.value),
+            })
+          }
+        />
       )}
 
       {hasTimeData && (

--- a/frontend/src/components/GameCard.test.tsx
+++ b/frontend/src/components/GameCard.test.tsx
@@ -64,10 +64,10 @@ describe("GameCard rating block (DQ-1)", () => {
     expect(container.querySelector(`.${RATING_CLASS}`)).toBe(rating);
   });
 
-  it("omits the rating block when the game has no rating", () => {
+  it("shows a placeholder when the game has no rating", () => {
     const { container } = renderCard({ bgg_rating: 0 });
 
-    expect(container.querySelector(`.${RATING_CLASS}`)).toBeNull();
+    expect(container.querySelector(`.${RATING_CLASS}`)).toHaveTextContent("-");
   });
 });
 
@@ -213,6 +213,19 @@ describe("GameCard view modes", () => {
 
     expect(container.querySelector("article")?.className).toBe(
       "game-card game-card-list",
+    );
+    expect(container.querySelector(".game-card-cover img")).toHaveAttribute(
+      "src",
+      "https://example.com/catan-large.jpg",
+    );
+    expect(container.querySelector(".game-card-rating")).toHaveTextContent(
+      "7.2",
+    );
+    expect(container.querySelector(".game-card-description")).toHaveTextContent(
+      "Trade and build across the island.",
+    );
+    expect(container.querySelector(".game-card-meta")).toHaveTextContent(
+      "10+90min3-4",
     );
   });
 });

--- a/frontend/src/components/LoanActionFeedback.css
+++ b/frontend/src/components/LoanActionFeedback.css
@@ -1,0 +1,9 @@
+.loan-action-feedback {
+  max-width: 42rem;
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-left: 3px solid var(--color-brand);
+  background-color: var(--color-surface-alt);
+  color: var(--color-text-body);
+  line-height: var(--line-height-relaxed);
+}

--- a/frontend/src/components/LoanActionFeedback.tsx
+++ b/frontend/src/components/LoanActionFeedback.tsx
@@ -1,0 +1,15 @@
+import "./LoanActionFeedback.css";
+
+interface LoanActionFeedbackProps {
+  readonly message: string | null;
+}
+
+export function LoanActionFeedback({ message }: LoanActionFeedbackProps) {
+  if (message === null) return null;
+
+  return (
+    <p className="loan-action-feedback" role="status" aria-live="polite">
+      {message}
+    </p>
+  );
+}

--- a/frontend/src/components/RpgActiveFilterChips.tsx
+++ b/frontend/src/components/RpgActiveFilterChips.tsx
@@ -1,10 +1,10 @@
 import { Chip } from "../ui/Chip";
+import { Button } from "../ui/Button";
 import { AVAILABILITY_OPTIONS } from "../types/catalog";
 import {
   DEFAULT_RPG_QUERY,
   RPG_GENRE_OPTIONS,
   RPG_PUBLICATION_OPTIONS,
-  RPG_SORT_OPTIONS,
   type RpgQuery,
 } from "../types/rpg";
 import "./ActiveFilterChips.css";
@@ -29,6 +29,13 @@ function optionLabel(
 
 function activeChips(query: RpgQuery): readonly ActiveChip[] {
   const candidates: readonly (ActiveChip | null)[] = [
+    query.search.trim() !== ""
+      ? {
+          key: "search",
+          label: `Palabra clave: “${query.search.trim()}”`,
+          cleared: { ...query, search: "" },
+        }
+      : null,
     query.genre !== DEFAULT_RPG_QUERY.genre
       ? {
           key: "genre",
@@ -63,16 +70,11 @@ function activeChips(query: RpgQuery): readonly ActiveChip[] {
           cleared: { ...query, minRating: DEFAULT_RPG_QUERY.minRating },
         }
       : null,
-    query.sort !== DEFAULT_RPG_QUERY.sort
-      ? {
-          key: "sort",
-          label: `Orden: ${optionLabel(RPG_SORT_OPTIONS, query.sort)}`,
-          cleared: { ...query, sort: DEFAULT_RPG_QUERY.sort },
-        }
-      : null,
   ];
 
-  return candidates.filter((candidate): candidate is ActiveChip => candidate !== null);
+  return candidates.filter(
+    (candidate): candidate is ActiveChip => candidate !== null,
+  );
 }
 
 export function RpgActiveFilterChips({
@@ -90,6 +92,13 @@ export function RpgActiveFilterChips({
           {chip.label}
         </Chip>
       ))}
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={() => onChange({ ...DEFAULT_RPG_QUERY, sort: query.sort })}
+      >
+        Limpiar búsqueda y filtros
+      </Button>
     </div>
   );
 }

--- a/frontend/src/components/RpgCard.test.tsx
+++ b/frontend/src/components/RpgCard.test.tsx
@@ -89,10 +89,10 @@ describe("RpgCard content", () => {
     expect(container.querySelector(`.${RATING_CLASS}`)).not.toBeNull();
   });
 
-  it("omits the rating block when bgg_rating is 0", () => {
+  it("shows a placeholder when bgg_rating is 0", () => {
     const { container } = renderCard({ bgg_rating: 0 });
 
-    expect(container.querySelector(`.${RATING_CLASS}`)).toBeNull();
+    expect(container.querySelector(`.${RATING_CLASS}`)).toHaveTextContent("-");
   });
 });
 
@@ -188,6 +188,18 @@ describe("RpgCard view variants", () => {
 
     expect(container.querySelector("article")?.className).toBe(
       "game-card game-card-list rpg-card",
+    );
+    expect(container.querySelector(".game-card-cover img")).toHaveClass(
+      "game-card-cover-img",
+    );
+    expect(container.querySelector(".game-card-rating")).toHaveTextContent(
+      "8.5",
+    );
+    expect(container.querySelector(".game-card-description")).toHaveTextContent(
+      "The original RPG.",
+    );
+    expect(container.querySelector(".game-card-meta")).toHaveTextContent(
+      "1974",
     );
   });
 });

--- a/frontend/src/components/RpgFilterPanel.tsx
+++ b/frontend/src/components/RpgFilterPanel.tsx
@@ -4,11 +4,9 @@ import { AVAILABILITY_OPTIONS, type AvailabilityValue } from "../types/catalog";
 import {
   RPG_GENRE_OPTIONS,
   RPG_PUBLICATION_OPTIONS,
-  RPG_SORT_OPTIONS,
   type RpgGenreValue,
   type RpgPublicationValue,
   type RpgQuery,
-  type RpgSortValue,
 } from "../types/rpg";
 import "./FilterPanel.css";
 
@@ -19,19 +17,14 @@ interface RpgFilterPanelProps {
 
 export function RpgFilterPanel({ query, onChange }: RpgFilterPanelProps) {
   return (
-    <div className="filter-panel" role="group" aria-label="Filtros y ordenación">
-      <Select
-        label="Ordenar por"
-        options={RPG_SORT_OPTIONS}
-        value={query.sort}
-        onChange={(e) => onChange({ ...query, sort: e.target.value as RpgSortValue })}
-      />
-
+    <div className="filter-panel" role="group" aria-label="Filtros">
       <Select
         label="Género"
         options={RPG_GENRE_OPTIONS}
         value={query.genre}
-        onChange={(e) => onChange({ ...query, genre: e.target.value as RpgGenreValue })}
+        onChange={(e) =>
+          onChange({ ...query, genre: e.target.value as RpgGenreValue })
+        }
       />
 
       <Select
@@ -51,7 +44,10 @@ export function RpgFilterPanel({ query, onChange }: RpgFilterPanelProps) {
         options={AVAILABILITY_OPTIONS}
         value={query.availability}
         onChange={(e) =>
-          onChange({ ...query, availability: e.target.value as AvailabilityValue })
+          onChange({
+            ...query,
+            availability: e.target.value as AvailabilityValue,
+          })
         }
       />
 

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -13,6 +13,10 @@ export function SearchBar({ value, onChange, placeholder }: SearchBarProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     setLocalValue(value);
   }, [value]);
 
@@ -25,6 +29,7 @@ export function SearchBar({ value, onChange, placeholder }: SearchBarProps) {
     }
 
     timerRef.current = setTimeout(() => {
+      timerRef.current = null;
       onChange(newValue);
     }, 300);
   };
@@ -33,6 +38,7 @@ export function SearchBar({ value, onChange, placeholder }: SearchBarProps) {
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
+        timerRef.current = null;
       }
     };
   }, []);

--- a/frontend/src/components/SiteHeader/SiteHeader.module.css
+++ b/frontend/src/components/SiteHeader/SiteHeader.module.css
@@ -366,6 +366,31 @@
   padding-top: var(--space-xs);
 }
 
+.logoutToast {
+  position: fixed;
+  top: calc(var(--header-height) + var(--space-md));
+  right: var(--space-md);
+  z-index: calc(var(--header-z) + 1);
+  max-width: min(360px, calc(100vw - 2 * var(--space-md)));
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-success);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-available);
+  box-shadow: var(--shadow-md);
+  color: var(--color-success-hover);
+  font-size: var(--font-size-sm);
+}
+
+.logoutToastError {
+  border-color: var(--color-danger);
+  background-color: color-mix(
+    in srgb,
+    var(--color-danger) 8%,
+    var(--color-surface)
+  );
+  color: var(--color-danger);
+}
+
 /* ─── Hamburger ──────────────────────────────────────────────────────── */
 
 .hamburger {

--- a/frontend/src/components/SiteHeader/SiteHeader.test.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { act, render, screen, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SiteHeader } from "./SiteHeader";
@@ -116,6 +116,7 @@ describe("SiteHeader", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     window.history.replaceState(null, "", "/");
   });
 
@@ -421,6 +422,45 @@ describe("SiteHeader", () => {
       fireEvent.click(cerrarBtn!);
 
       expect(mockLogout).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows an accessible success toast for four seconds after logout", async () => {
+      vi.useFakeTimers();
+      setMember();
+      mockLogout.mockResolvedValue(undefined);
+      renderHeader();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Cerrar sesión" }));
+      });
+
+      const status = screen.getByRole("status");
+      expect(status).toHaveAttribute("aria-live", "polite");
+      expect(status).toHaveTextContent("Sesión cerrada correctamente.");
+
+      act(() => vi.advanceTimersByTime(3_999));
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Sesión cerrada correctamente."
+      );
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(screen.queryByRole("status")).toBeNull();
+      vi.useRealTimers();
+    });
+
+    it("handles logout failure and gives the member actionable feedback", async () => {
+      setMember();
+      mockLogout.mockRejectedValue(new Error("network failure"));
+      renderHeader();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Cerrar sesión" }));
+      });
+
+      expect(screen.queryByRole("status")).toBeNull();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "No se pudo cerrar la sesión. Inténtalo de nuevo."
+      );
     });
   });
 

--- a/frontend/src/components/SiteHeader/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader/SiteHeader.tsx
@@ -86,7 +86,7 @@ interface UserSubmenuProps {
   readonly isAdmin: boolean;
   readonly adminExpanded: boolean;
   readonly onToggleAdmin: () => void;
-  readonly onLogout: () => void;
+  readonly onLogout: () => Promise<void>;
   readonly onItemClick?: () => void;
   readonly alignRight?: boolean;
 }
@@ -126,7 +126,7 @@ function UserSubmenu({
           type="button"
           className={styles.submenuButton}
           onClick={() => {
-            onLogout();
+            void onLogout();
             onItemClick?.();
           }}
         >
@@ -147,8 +147,13 @@ export function SiteHeader() {
   const [expandedDrawerHref, setExpandedDrawerHref] = useState<string | null>(null);
   const [userExpanded, setUserExpanded] = useState(false);
   const [adminExpanded, setAdminExpanded] = useState(false);
+  const [logoutNotice, setLogoutNotice] = useState<{
+    readonly kind: "success" | "error";
+    readonly message: string;
+  } | null>(null);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
-
+  const headerRef = useRef<HTMLElement>(null);
+  const logoutNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isLoginRoute = Boolean(useMatch("/login"));
 
@@ -176,19 +181,56 @@ export function SiteHeader() {
     };
   }, [drawerOpen]);
 
-  const handleLogout = () => {
-    void logout();
-  };
+  useEffect(
+    () => () => {
+      if (logoutNoticeTimerRef.current !== null) {
+        clearTimeout(logoutNoticeTimerRef.current);
+      }
+    },
+    []
+  );
 
   const closeDrawer = () => {
     setDrawerOpen(false);
     setExpandedDrawerHref(null);
     setUserExpanded(false);
     setAdminExpanded(false);
+    if (
+      document.activeElement instanceof HTMLElement &&
+      headerRef.current?.contains(document.activeElement)
+    ) {
+      document.activeElement.blur();
+    }
+  };
+
+  const handleLogout = async () => {
+    closeDrawer();
+    setLogoutNotice(null);
+    if (logoutNoticeTimerRef.current !== null) {
+      clearTimeout(logoutNoticeTimerRef.current);
+      logoutNoticeTimerRef.current = null;
+    }
+
+    try {
+      await logout();
+      setLogoutNotice({
+        kind: "success",
+        message: "Sesión cerrada correctamente.",
+      });
+      logoutNoticeTimerRef.current = setTimeout(() => {
+        setLogoutNotice(null);
+        logoutNoticeTimerRef.current = null;
+      }, 4_000);
+    } catch {
+      setLogoutNotice({
+        kind: "error",
+        message: "No se pudo cerrar la sesión. Inténtalo de nuevo.",
+      });
+    }
   };
 
   return (
-    <header className={styles.header}>
+    <header ref={headerRef} className={styles.header}>
       <div className={styles.inner}>
         {/* Logo */}
         <a href="/inicio" className={styles.logoLink} aria-label="Refugio del Sátiro – Inicio">
@@ -371,6 +413,15 @@ export function SiteHeader() {
           </ul>
         </nav>
       </div>
+      {logoutNotice !== null && (
+        <div
+          className={`${styles.logoutToast} ${logoutNotice.kind === "error" ? styles.logoutToastError : ""}`}
+          role={logoutNotice.kind === "success" ? "status" : "alert"}
+          aria-live={logoutNotice.kind === "success" ? "polite" : "assertive"}
+        >
+          {logoutNotice.message}
+        </div>
+      )}
     </header>
   );
 }

--- a/frontend/src/hooks/useMyLoans.test.ts
+++ b/frontend/src/hooks/useMyLoans.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActiveLoan } from "../types/loan";
+import { useMyLoans } from "./useMyLoans";
+
+const apiFetchMock = vi.fn();
+
+vi.mock("../api/client", () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+const activeLoan: ActiveLoan = {
+  loan_id: 7,
+  game_id: 1,
+  game_name: "Catan",
+  game_thumbnail_url: "https://example.com/catan.jpg",
+  game_image_url: "https://example.com/catan-large.jpg",
+  borrowed_at: "2026-08-16T10:00:00Z",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe("useMyLoans", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue([activeLoan]);
+  });
+
+  it("does not request authenticated loans while disabled for a guest", () => {
+    const { result } = renderHook(() => useMyLoans(false));
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(0);
+    expect(result.current.loans).toEqual([]);
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toEqual(null);
+  });
+
+  it("fetches loans when an authenticated viewer enables the hook", async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useMyLoans(enabled),
+      { initialProps: { enabled: false } },
+    );
+
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith("/my-loans");
+      expect(result.current.loans).toEqual([activeLoan]);
+      expect(result.current.loading).toEqual(false);
+      expect(result.current.error).toEqual(null);
+    });
+  });
+
+  it("ignores an older request that resolves after a newer refetch", async () => {
+    const initialRequest = deferred<readonly ActiveLoan[]>();
+    const refetchRequest = deferred<readonly ActiveLoan[]>();
+    const newerLoan = { ...activeLoan, loan_id: 8, game_id: 2 };
+    apiFetchMock
+      .mockReset()
+      .mockReturnValueOnce(initialRequest.promise)
+      .mockReturnValueOnce(refetchRequest.promise);
+
+    const { result } = renderHook(() => useMyLoans(true));
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.refetch());
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => refetchRequest.resolve([newerLoan]));
+    expect(result.current.loans).toEqual([newerLoan]);
+    expect(result.current.loading).toEqual(false);
+
+    await act(async () => initialRequest.resolve([activeLoan]));
+    expect(result.current.loans).toEqual([newerLoan]);
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toEqual(null);
+  });
+
+  it("ignores a pending authenticated response after the hook is disabled", async () => {
+    const pendingRequest = deferred<readonly ActiveLoan[]>();
+    apiFetchMock.mockReset().mockReturnValueOnce(pendingRequest.promise);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useMyLoans(enabled),
+      { initialProps: { enabled: true } },
+    );
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    expect(result.current.loans).toEqual([]);
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toEqual(null);
+
+    await act(async () => pendingRequest.resolve([activeLoan]));
+    expect(result.current.loans).toEqual([]);
+    expect(result.current.loading).toEqual(false);
+    expect(result.current.error).toEqual(null);
+  });
+});

--- a/frontend/src/hooks/useMyLoans.ts
+++ b/frontend/src/hooks/useMyLoans.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiFetch } from "../api/client";
 import type { ActiveLoan } from "../types/loan";
 
@@ -9,22 +9,42 @@ interface UseMyLoansResult {
   readonly refetch: () => void;
 }
 
-export function useMyLoans(): UseMyLoansResult {
+export function useMyLoans(enabled = true): UseMyLoansResult {
   const [loans, setLoans] = useState<readonly ActiveLoan[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
+  const requestGeneration = useRef(0);
 
   const fetchLoans = useCallback(() => {
+    const generation = ++requestGeneration.current;
+
+    if (!enabled) {
+      setLoans([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     apiFetch<readonly ActiveLoan[]>("/my-loans")
-      .then(setLoans)
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
+      .then((nextLoans) => {
+        if (generation === requestGeneration.current) setLoans(nextLoans);
+      })
+      .catch((err: Error) => {
+        if (generation === requestGeneration.current) setError(err.message);
+      })
+      .finally(() => {
+        if (generation === requestGeneration.current) setLoading(false);
+      });
+  }, [enabled]);
 
   useEffect(() => {
     fetchLoans();
+
+    return () => {
+      requestGeneration.current += 1;
+    };
   }, [fetchLoans]);
 
   return { loans, loading, error, refetch: fetchLoans };

--- a/frontend/src/lib/loanActions.ts
+++ b/frontend/src/lib/loanActions.ts
@@ -1,0 +1,34 @@
+import type { CurrentMember } from "../types/member";
+
+export const BORROW_SUCCESS_MESSAGE =
+  "El préstamo no tiene fecha límite, pero haz un uso responsable: devuélvelo cuando hayas jugado o si finalmente no vas a usarlo.";
+
+interface LoanState {
+  readonly status: "available" | "lent";
+  readonly loan_id: number | null;
+}
+
+export interface ReturnAction {
+  readonly label: "Devolver" | "Forzar devolución";
+}
+
+export function getReturnAction(
+  member: CurrentMember | null,
+  loan: LoanState,
+  activeLoanIds: ReadonlySet<number>,
+): ReturnAction | null {
+  const isBorrower = loan.loan_id !== null && activeLoanIds.has(loan.loan_id);
+  const canReturn =
+    member !== null &&
+    loan.status === "lent" &&
+    loan.loan_id !== null &&
+    (member.is_admin || isBorrower);
+
+  if (!canReturn) return null;
+
+  const isForcingAnotherMembersReturn = member.is_admin && !isBorrower;
+
+  return {
+    label: isForcingAnotherMembersReturn ? "Forzar devolución" : "Devolver",
+  };
+}

--- a/frontend/src/pages/CatalogPage.test.tsx
+++ b/frontend/src/pages/CatalogPage.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -54,7 +54,9 @@ const AVAILABILITY_SELECT = "Disponibilidad";
 const MIN_PLAYERS_THUMB = "Jugadores mínimo";
 const MAX_PLAYERS_THUMB = "Jugadores máximo";
 
-function setGames(games: readonly GameWithStatus[] = [AVAILABLE_GAME, LENT_GAME]) {
+function setGames(
+  games: readonly GameWithStatus[] = [AVAILABLE_GAME, LENT_GAME],
+) {
   useGamesMock.mockReturnValue({
     games,
     loading: false,
@@ -120,6 +122,90 @@ describe("CatalogPage filter chips", () => {
     });
     expect(removeButtons).toHaveLength(2);
   });
+
+  it("combines search and filters and removes each condition independently", async () => {
+    vi.useFakeTimers();
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText("Buscar juego por nombre..."), {
+      target: { value: "catan" },
+    });
+    act(() => vi.advanceTimersByTime(350));
+    fireEvent.click(screen.getByRole("tab", { name: FILTROS_TAB }));
+    fireEvent.change(screen.getByLabelText(AVAILABILITY_SELECT), {
+      target: { value: "available" },
+    });
+
+    expect(screen.getByText("Mostrando 1 de 2")).toBeInTheDocument();
+    expect(screen.getByText("Palabra clave: “catan”")).toBeInTheDocument();
+    const activeFilters = screen.getByLabelText("Filtros activos");
+    expect(within(activeFilters).getByText("Disponible")).toBeInTheDocument();
+
+    const searchChip = screen
+      .getByText("Palabra clave: “catan”")
+      .closest('[role="status"]') as HTMLElement;
+    fireEvent.click(
+      within(searchChip).getByRole("button", { name: "Quitar filtro" }),
+    );
+
+    expect(screen.getByText("Catan")).toBeInTheDocument();
+    expect(screen.queryByText("Azul")).toBeNull();
+    expect(screen.queryByText("Palabra clave: “catan”")).toBeNull();
+    expect(within(activeFilters).getByText("Disponible")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("clears search and filters while preserving the selected sort order", () => {
+    vi.useFakeTimers();
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText("Ordenar por"), {
+      target: { value: "name-desc" },
+    });
+    fireEvent.change(screen.getByLabelText("Buscar juego por nombre..."), {
+      target: { value: "catan" },
+    });
+    act(() => vi.advanceTimersByTime(350));
+    fireEvent.click(screen.getByRole("tab", { name: FILTROS_TAB }));
+    fireEvent.change(screen.getByLabelText(AVAILABILITY_SELECT), {
+      target: { value: "available" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Limpiar búsqueda y filtros" }),
+    );
+
+    expect(screen.getByLabelText("Ordenar por")).toHaveValue("name-desc");
+    expect(screen.getByText("Mostrando 2 de 2")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Filtros activos")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("does not restore pending search text after removing its active chip", () => {
+    vi.useFakeTimers();
+    renderPage();
+
+    const searchInput = screen.getByLabelText("Buscar juego por nombre...");
+    fireEvent.change(searchInput, { target: { value: "catan" } });
+    act(() => vi.advanceTimersByTime(350));
+
+    fireEvent.change(searchInput, { target: { value: "azul" } });
+    const searchChip = screen
+      .getByText("Palabra clave: “catan”")
+      .closest('[role="status"]') as HTMLElement;
+    fireEvent.click(
+      within(searchChip).getByRole("button", { name: "Quitar filtro" }),
+    );
+    act(() => vi.advanceTimersByTime(350));
+
+    expect(searchInput).toHaveValue("");
+    expect(screen.queryByLabelText("Filtros activos")).toBeNull();
+    expect(screen.getByText("Catan")).toBeInTheDocument();
+    expect(screen.getByText("Azul")).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
 });
 
 describe("CatalogPage search-and-filters box", () => {
@@ -143,6 +229,15 @@ describe("CatalogPage search-and-filters box", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  it("keeps sorting available from both search and filter tabs", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(screen.getByLabelText("Ordenar por")).toBeVisible();
+    await openFiltrosTab(user);
+    expect(screen.getByLabelText("Ordenar por")).toBeVisible();
   });
 
   it("shows the results count line", () => {
@@ -226,7 +321,39 @@ describe("CatalogPage player-range slider", () => {
 
     expect(screen.queryByText("Catan")).toBeNull();
     expect(screen.queryByText("Azul")).toBeNull();
-    expect(screen.getByText("No se han encontrado juegos.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No se han encontrado juegos."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("CatalogPage player-age filter", () => {
+  it("offers ages 3 through 18 and excludes unknown ages while active", async () => {
+    setGames([
+      { ...AVAILABLE_GAME, name: "Apto", min_age: 8 },
+      { ...LENT_GAME, name: "Mayor", min_age: 12 },
+      { ...LENT_GAME, id: 3, name: "Sin edad", min_age: 0 },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+    await openFiltrosTab(user);
+
+    const ageSelect = screen.getByLabelText("Edad del jugador");
+    expect(
+      within(ageSelect)
+        .getAllByRole("option")
+        .map((option) => option.textContent),
+    ).toEqual([
+      "Todas",
+      ...Array.from({ length: 16 }, (_, index) => `${index + 3} años`),
+    ]);
+
+    await user.selectOptions(ageSelect, "8");
+
+    expect(screen.getByText("Apto")).toBeInTheDocument();
+    expect(screen.queryByText("Mayor")).toBeNull();
+    expect(screen.queryByText("Sin edad")).toBeNull();
+    expect(screen.getByText("Edad del jugador: 8 años")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useGames } from "../hooks/useGames";
 import { ActiveFilterChips } from "../components/ActiveFilterChips";
 import { CatalogTypeToggle } from "../components/CatalogTypeToggle";
-import { CatalogViewToggle } from "../components/CatalogViewToggle";
+import { CatalogResultsBar } from "../components/CatalogResultsBar";
 import {
   persistCatalogView,
   storedCatalogView,
@@ -12,12 +12,16 @@ import { GameCard } from "../components/GameCard";
 import { PoweredByBgg } from "../components/PoweredByBgg";
 import { SearchBar } from "../components/SearchBar";
 import { SearchFiltersBox } from "../components/SearchFiltersBox";
-import { computeCategoryFrequency, mostCommonOwnCategory } from "../lib/gameTags";
+import {
+  computeCategoryFrequency,
+  mostCommonOwnCategory,
+} from "../lib/gameTags";
 import { Button } from "../ui/Button";
 import { PageTitle } from "../ui/PageTitle";
 import {
   applyCatalogQuery,
   DEFAULT_CATALOG_QUERY,
+  SORT_OPTIONS,
   type CatalogQuery,
   type CatalogView,
 } from "../types/catalog";
@@ -36,6 +40,7 @@ export function CatalogPage() {
     () => games.some((g) => g.min_players > 0),
     [games],
   );
+  const hasAgeData = useMemo(() => games.some((g) => g.min_age > 0), [games]);
   const hasTimeData = useMemo(
     () => games.some((g) => g.playing_time > 0),
     [games],
@@ -74,6 +79,7 @@ export function CatalogPage() {
       query={query}
       onChange={setQuery}
       hasPlayerData={hasPlayerData}
+      hasAgeData={hasAgeData}
       hasTimeData={hasTimeData}
     />
   );
@@ -105,12 +111,15 @@ export function CatalogPage() {
 
       <ActiveFilterChips query={query} onChange={setQuery} />
 
-      <div className="catalog-results-bar">
-        <p className="catalog-count">
-          Mostrando {filteredGames.length} de {games.length}
-        </p>
-        <CatalogViewToggle view={view} onChange={setView} />
-      </div>
+      <CatalogResultsBar
+        shown={filteredGames.length}
+        total={games.length}
+        sort={query.sort}
+        sortOptions={SORT_OPTIONS}
+        onSortChange={(sort) => setQuery((current) => ({ ...current, sort }))}
+        view={view}
+        onViewChange={setView}
+      />
 
       {filteredGames.length === 0 ? (
         <p className="catalog-empty">No se han encontrado juegos.</p>

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -11,8 +11,10 @@ import type { CurrentMember } from "../types/member";
 
 const refetch = vi.fn();
 const useGameHistoryMock = vi.fn();
+const useMyLoansMock = vi.fn();
 const useAuthMock = vi.fn();
 const apiFetchMock = vi.fn();
+const refetchMyLoans = vi.fn();
 
 vi.mock("../hooks/useGameHistory", () => ({
   useGameHistory: () => useGameHistoryMock(),
@@ -22,12 +24,19 @@ vi.mock("../context/AuthContext", () => ({
   useAuth: () => useAuthMock(),
 }));
 
+vi.mock("../hooks/useMyLoans", () => ({
+  useMyLoans: (...args: unknown[]) => useMyLoansMock(...args),
+}));
+
 vi.mock("../api/client", () => ({
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }));
 
 const BORROW_CTA = "Solicitar préstamo";
 const RETURN_CTA = "Devolver";
+const FORCE_RETURN_CTA = "Forzar devolución";
+const BORROW_SUCCESS_MESSAGE =
+  "El préstamo no tiene fecha límite, pero haz un uso responsable: devuélvelo cuando hayas jugado o si finalmente no vas a usarlo.";
 const LOGIN_LINK = "Iniciar sesión";
 const HISTORY_HEADING = /Historial de préstamos y comentarios/i;
 
@@ -111,6 +120,20 @@ function setMember(value: CurrentMember | null) {
   useAuthMock.mockReturnValue({ member: value, loading: false });
 }
 
+function setMyLoans(loanIds: readonly number[]) {
+  useMyLoansMock.mockReturnValue({
+    loans: loanIds.map((loan_id) => ({ loan_id })),
+    loading: false,
+    error: null,
+    refetch: refetchMyLoans,
+  });
+}
+
+beforeEach(() => {
+  refetchMyLoans.mockReset();
+  setMyLoans([]);
+});
+
 function renderPage() {
   return render(
     <CatalogModeProvider>
@@ -190,6 +213,10 @@ describe("GameDetailPage borrow CTA", () => {
       body: JSON.stringify({ game_id: 1 }),
     });
     expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetchMyLoans).toHaveBeenCalledTimes(1);
+    const feedback = await screen.findByRole("status");
+    expect(feedback).toHaveTextContent(BORROW_SUCCESS_MESSAGE);
+    expect(feedback).toHaveAttribute("aria-live", "polite");
   });
 });
 
@@ -251,6 +278,7 @@ describe("GameDetailPage borrower visibility", () => {
       },
     });
     setMember(member);
+    setMyLoans([7]);
 
     renderPage();
 
@@ -259,7 +287,7 @@ describe("GameDetailPage borrower visibility", () => {
 });
 
 describe("GameDetailPage return CTA", () => {
-  it("shows the return CTA to the borrower of a lent game", () => {
+  it("labels the trigger and confirmation 'Devolver' for the borrower", async () => {
     setHook({
       game: {
         ...game,
@@ -269,15 +297,25 @@ describe("GameDetailPage return CTA", () => {
       },
     });
     setMember(member);
+    setMyLoans([7]);
 
     renderPage();
+    const user = userEvent.setup();
 
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: RETURN_CTA }));
+
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 
-  it("shows the return CTA to an admin even when the loan is someone else's", () => {
+  it("labels the trigger and confirmation 'Forzar devolución' for an admin returning another member's loan", async () => {
     setHook({
       game: {
         ...game,
@@ -289,10 +327,39 @@ describe("GameDetailPage return CTA", () => {
     setMember(admin);
 
     renderPage();
+    const user = userEvent.setup();
+
+    expect(
+      screen.getByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: FORCE_RETURN_CTA }));
+
+    expect(
+      screen.getByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+  });
+
+  it("keeps 'Devolver' for an admin returning their own loan", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: admin.display_name,
+        loan_id: 7,
+      },
+    });
+    setMember(admin);
+    setMyLoans([7]);
+
+    renderPage();
 
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -309,6 +376,29 @@ describe("GameDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
+  });
+
+  it("does not infer ownership from a duplicate display name", () => {
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: member.display_name,
+        loan_id: 7,
+      },
+    });
+    setMember(member);
+    setMyLoans([]);
+
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 });
 

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -2,11 +2,17 @@ import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { apiFetch } from "../api/client";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { LoanActionFeedback } from "../components/LoanActionFeedback";
 import { LoanHistoryEntry } from "../components/LoanHistoryEntry";
 import { ClockIcon, PlayersIcon } from "../components/MetaIcons";
 import { useAuth } from "../context/AuthContext";
 import { useGameHistory } from "../hooks/useGameHistory";
+import { useMyLoans } from "../hooks/useMyLoans";
 import { displayDescription } from "../lib/description";
+import {
+  BORROW_SUCCESS_MESSAGE,
+  getReturnAction,
+} from "../lib/loanActions";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
 import "./GameDetailPage.css";
@@ -15,12 +21,19 @@ export function GameDetailPage() {
   const { slug } = useParams<{ slug: string }>();
   const { game, history, loading, error, refetch } = useGameHistory(slug);
   const { member } = useAuth();
+  const {
+    loans: myLoans,
+    loading: myLoansLoading,
+    error: myLoansError,
+    refetch: refetchMyLoans,
+  } = useMyLoans(member !== null);
   const [confirmAction, setConfirmAction] = useState<
     | { readonly action: "borrow"; readonly gameId: number }
     | { readonly action: "return" }
     | null
   >(null);
   const [acting, setActing] = useState(false);
+  const [loanFeedback, setLoanFeedback] = useState<string | null>(null);
 
   if (loading) {
     return (
@@ -42,11 +55,11 @@ export function GameDetailPage() {
   }
 
   const canBorrow = member !== null && game.status === "available";
-  const canReturn =
-    member !== null &&
-    game.status === "lent" &&
-    game.loan_id !== null &&
-    (member.is_admin || game.borrower_display_name === member.display_name);
+  const activeLoanIds = new Set(myLoans.map((loan) => loan.loan_id));
+  const returnAction =
+    !myLoansLoading && myLoansError === null
+      ? getReturnAction(member, game, activeLoanIds)
+      : null;
 
   // Hook point for the borrow flow. The sibling change
   // `lending-borrow-with-return-date` replaces the ConfirmDialog this opens
@@ -62,7 +75,9 @@ export function GameDetailPage() {
         method: "POST",
         body: JSON.stringify({ game_id: gameId }),
       });
+      setLoanFeedback(BORROW_SUCCESS_MESSAGE);
       refetch();
+      refetchMyLoans();
     } catch {
       /* error handled silently — refetch on close keeps UI in sync */
     } finally {
@@ -78,6 +93,7 @@ export function GameDetailPage() {
         method: "PATCH",
       });
       refetch();
+      refetchMyLoans();
     } catch {
       /* error handled silently — refetch on close keeps UI in sync */
     } finally {
@@ -158,13 +174,13 @@ export function GameDetailPage() {
                 Solicitar préstamo
               </Button>
             )}
-            {canReturn && (
+            {returnAction && (
               <Button
                 variant="secondary"
                 onClick={() => setConfirmAction({ action: "return" })}
                 disabled={acting}
               >
-                Devolver
+                {returnAction.label}
               </Button>
             )}
             {member === null && game.status === "available" && (
@@ -173,6 +189,8 @@ export function GameDetailPage() {
               </Link>
             )}
           </div>
+
+          <LoanActionFeedback message={loanFeedback} />
 
           <div className="game-detail-bgg">
             <a
@@ -223,7 +241,7 @@ export function GameDetailPage() {
           message={`¿Quieres devolver "${game.name}"?`}
           onConfirm={() => void handleReturn()}
           onCancel={() => setConfirmAction(null)}
-          confirmLabel="Devolver"
+          confirmLabel={returnAction?.label ?? "Devolver"}
         />
       )}
     </div>

--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -58,6 +58,25 @@
   margin-bottom: var(--space-md);
 }
 
+.login-error p {
+  margin: 0;
+}
+
+.login-membership-help {
+  margin-top: var(--space-sm);
+}
+
+.login-membership-help a {
+  color: inherit;
+  font-weight: var(--font-weight-medium);
+}
+
+.login-forgot-password {
+  margin-top: var(--space-md);
+  text-align: center;
+  font-size: var(--font-size-sm);
+}
+
 .login-form .btn {
   width: 100%;
   padding: var(--space-sm) var(--space-md);

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LoginPage } from "./LoginPage";
+
+const LOGIN_ERROR = "Correo o contraseña incorrectos.";
+const mockLogin = vi.fn();
+
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  );
+}
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+  });
+
+  it("shows privacy-safe membership guidance after failed login", async () => {
+    mockLogin.mockRejectedValue(new Error(LOGIN_ERROR));
+    renderLoginPage();
+
+    fireEvent.change(screen.getByLabelText("Correo electrónico"), {
+      target: { value: "unknown@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Contraseña"), {
+      target: { value: "incorrect-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(LOGIN_ERROR);
+    expect(alert).toHaveTextContent(
+      "El área privada de préstamos está disponible únicamente para socios y socias al corriente de pago."
+    );
+    expect(
+      screen.getByRole("link", { name: "hacerte socio o socia" })
+    ).toHaveAttribute("href", "/socios");
+    expect(mockLogin).toHaveBeenCalledExactlyOnceWith(
+      "unknown@example.com",
+      "incorrect-password"
+    );
+  });
+});

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -42,7 +42,7 @@ describe("LoginPage", () => {
     );
     expect(
       screen.getByRole("link", { name: "hacerte socio o socia" })
-    ).toHaveAttribute("href", "/socios");
+    ).toHaveAttribute("href", "/socios/");
     expect(mockLogin).toHaveBeenCalledExactlyOnceWith(
       "unknown@example.com",
       "incorrect-password"

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -39,7 +39,7 @@ export function LoginPage() {
             <p className="login-membership-help">
               El área privada de préstamos está disponible únicamente para
               socios y socias al corriente de pago. Consulta la información para
-              <a href="/socios"> hacerte socio o socia</a>.
+              <a href="/socios/"> hacerte socio o socia</a>.
             </p>
           </div>
         )}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -33,7 +33,16 @@ export function LoginPage() {
       <form className="login-form" onSubmit={(e) => void handleSubmit(e)}>
         <h1>Iniciar sesión</h1>
 
-        {error && <div className="login-error">{error}</div>}
+        {error && (
+          <div className="login-error" role="alert">
+            <p>{error}</p>
+            <p className="login-membership-help">
+              El área privada de préstamos está disponible únicamente para
+              socios y socias al corriente de pago. Consulta la información para
+              <a href="/socios"> hacerte socio o socia</a>.
+            </p>
+          </div>
+        )}
 
         <div className="login-field">
           <label htmlFor="email">Correo electrónico</label>
@@ -63,7 +72,7 @@ export function LoginPage() {
           {loading ? "Entrando..." : "Entrar"}
         </Button>
 
-        <p style={{ marginTop: "var(--space-md)", textAlign: "center", fontSize: "var(--font-size-sm)" }}>
+        <p className="login-forgot-password">
           <Link to="/forgot-password">¿Olvidaste tu contraseña?</Link>
         </p>
       </form>

--- a/frontend/src/pages/RpgCatalogPage.test.tsx
+++ b/frontend/src/pages/RpgCatalogPage.test.tsx
@@ -126,7 +126,9 @@ describe("RpgCatalogPage empty state", () => {
       vi.advanceTimersByTime(350);
     });
 
-    expect(screen.getByText("No se han encontrado libros.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No se han encontrado libros."),
+    ).toBeInTheDocument();
 
     vi.useRealTimers();
   });
@@ -137,7 +139,11 @@ describe("RpgCatalogPage name-asc sort (default)", () => {
     renderPage();
 
     const names = getItemNames();
-    expect(names).toEqual(["Ars Magica", "Pathfinder", "Vampire: The Masquerade"]);
+    expect(names).toEqual([
+      "Ars Magica",
+      "Pathfinder",
+      "Vampire: The Masquerade",
+    ]);
   });
 });
 
@@ -146,14 +152,17 @@ describe("RpgCatalogPage name-desc sort", () => {
     renderPage();
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole("tab", { name: "Filtros" }));
     await user.selectOptions(
       screen.getByRole("combobox", { name: /ordenar por/i }),
       "name-desc",
     );
 
     const names = getItemNames();
-    expect(names).toEqual(["Vampire: The Masquerade", "Pathfinder", "Ars Magica"]);
+    expect(names).toEqual([
+      "Vampire: The Masquerade",
+      "Pathfinder",
+      "Ars Magica",
+    ]);
   });
 });
 
@@ -170,7 +179,11 @@ describe("RpgCatalogPage rating sort", () => {
 
     const names = getItemNames();
     // ITEM_B: 8.6, ITEM_A: 7.9, ITEM_C: 7.2
-    expect(names).toEqual(["Vampire: The Masquerade", "Ars Magica", "Pathfinder"]);
+    expect(names).toEqual([
+      "Vampire: The Masquerade",
+      "Ars Magica",
+      "Pathfinder",
+    ]);
   });
 });
 
@@ -205,7 +218,9 @@ describe("RpgCatalogPage RPG filters", () => {
       .getByText("Género: Fantasía")
       .closest('[role="status"]') as HTMLElement | null;
     expect(chip).not.toBeNull();
-    await user.click(within(chip!).getByRole("button", { name: "Quitar filtro" }));
+    await user.click(
+      within(chip!).getByRole("button", { name: "Quitar filtro" }),
+    );
 
     expect(screen.getByText("Mostrando 3 de 3")).toBeInTheDocument();
     expect(screen.getByText("Vampire: The Masquerade")).toBeInTheDocument();
@@ -229,6 +244,58 @@ describe("RpgCatalogPage RPG filters", () => {
     expect(screen.getByText("Ars Magica")).toBeInTheDocument();
     expect(screen.queryByText("Pathfinder")).toBeNull();
     expect(screen.queryByText("Vampire: The Masquerade")).toBeNull();
+  });
+
+  it("clears search and filters without changing the selected sort", () => {
+    vi.useFakeTimers();
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText("Ordenar por"), {
+      target: { value: "name-desc" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: /buscar libros/i }), {
+      target: { value: "ars" },
+    });
+    act(() => vi.advanceTimersByTime(350));
+    fireEvent.click(screen.getByRole("tab", { name: "Filtros" }));
+    fireEvent.change(screen.getByRole("combobox", { name: "Género" }), {
+      target: { value: "fantasy" },
+    });
+
+    expect(screen.getByText("Palabra clave: “ars”")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Limpiar búsqueda y filtros" }),
+    );
+
+    expect(screen.getByLabelText("Ordenar por")).toHaveValue("name-desc");
+    expect(screen.getByText("Mostrando 3 de 3")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Filtros activos")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("does not restore pending search text after reset-all clears the query", () => {
+    vi.useFakeTimers();
+    renderPage();
+
+    const searchInput = screen.getByRole("textbox", { name: /buscar libros/i });
+    fireEvent.change(searchInput, { target: { value: "ars" } });
+    act(() => vi.advanceTimersByTime(350));
+
+    fireEvent.change(searchInput, { target: { value: "vampire" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Limpiar búsqueda y filtros" }),
+    );
+    act(() => vi.advanceTimersByTime(350));
+
+    expect(searchInput).toHaveValue("");
+    expect(screen.queryByLabelText("Filtros activos")).toBeNull();
+    expect(screen.getByText("Mostrando 3 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Ars Magica")).toBeInTheDocument();
+    expect(screen.getByText("Vampire: The Masquerade")).toBeInTheDocument();
+    expect(screen.getByText("Pathfinder")).toBeInTheDocument();
+
+    vi.useRealTimers();
   });
 });
 
@@ -303,6 +370,15 @@ describe("RpgCatalogPage shared catalog layout", () => {
 
     expect(container.querySelector(".catalog-grid")).toBeNull();
     expect(container.querySelector(".catalog-list")).not.toBeNull();
+  });
+
+  it("keeps sorting available when either search/filter tab is active", async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(screen.getByLabelText("Ordenar por")).toBeVisible();
+    await user.click(screen.getByRole("tab", { name: "Filtros" }));
+    expect(screen.getByLabelText("Ordenar por")).toBeVisible();
   });
 });
 

--- a/frontend/src/pages/RpgCatalogPage.tsx
+++ b/frontend/src/pages/RpgCatalogPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { CatalogTypeToggle } from "../components/CatalogTypeToggle";
-import { CatalogViewToggle } from "../components/CatalogViewToggle";
+import { CatalogResultsBar } from "../components/CatalogResultsBar";
 import { RpgActiveFilterChips } from "../components/RpgActiveFilterChips";
 import { RpgFilterPanel } from "../components/RpgFilterPanel";
 import {
@@ -12,12 +12,16 @@ import { RpgCard } from "../components/RpgCard";
 import { SearchBar } from "../components/SearchBar";
 import { SearchFiltersBox } from "../components/SearchFiltersBox";
 import { useRpgItems } from "../hooks/useRpgItems";
-import { computeCategoryFrequency, mostCommonOwnCategory } from "../lib/gameTags";
+import {
+  computeCategoryFrequency,
+  mostCommonOwnCategory,
+} from "../lib/gameTags";
 import { Button } from "../ui/Button";
 import { PageTitle } from "../ui/PageTitle";
 import {
   applyRpgQuery,
   DEFAULT_RPG_QUERY,
+  RPG_SORT_OPTIONS,
   type RpgQuery,
 } from "../types/rpg";
 import type { CatalogView } from "../types/catalog";
@@ -33,7 +37,10 @@ export function RpgCatalogPage() {
     persistCatalogView(view);
   }, [view]);
 
-  const filteredItems = useMemo(() => applyRpgQuery(items, query), [items, query]);
+  const filteredItems = useMemo(
+    () => applyRpgQuery(items, query),
+    [items, query],
+  );
 
   // RPG items carry no `primary_tag`, so the card pill is always the item's
   // own most frequent RPGGeek category, ranked across the loaded catalog.
@@ -85,12 +92,15 @@ export function RpgCatalogPage() {
 
       <RpgActiveFilterChips query={query} onChange={setQuery} />
 
-      <div className="catalog-results-bar">
-        <p className="catalog-count">
-          Mostrando {filteredItems.length} de {items.length}
-        </p>
-        <CatalogViewToggle view={view} onChange={setView} />
-      </div>
+      <CatalogResultsBar
+        shown={filteredItems.length}
+        total={items.length}
+        sort={query.sort}
+        sortOptions={RPG_SORT_OPTIONS}
+        onSortChange={(sort) => setQuery((current) => ({ ...current, sort }))}
+        view={view}
+        onViewChange={setView}
+      />
 
       {filteredItems.length === 0 ? (
         <p className="catalog-empty">No se han encontrado libros.</p>

--- a/frontend/src/pages/RpgDetailPage.test.tsx
+++ b/frontend/src/pages/RpgDetailPage.test.tsx
@@ -10,8 +10,10 @@ import type { CurrentMember } from "../types/member";
 
 const refetch = vi.fn();
 const useRpgHistoryMock = vi.fn();
+const useMyLoansMock = vi.fn();
 const useAuthMock = vi.fn();
 const apiFetchMock = vi.fn();
+const refetchMyLoans = vi.fn();
 
 vi.mock("../hooks/useRpgHistory", () => ({
   useRpgHistory: () => useRpgHistoryMock(),
@@ -21,12 +23,19 @@ vi.mock("../context/AuthContext", () => ({
   useAuth: () => useAuthMock(),
 }));
 
+vi.mock("../hooks/useMyLoans", () => ({
+  useMyLoans: (...args: unknown[]) => useMyLoansMock(...args),
+}));
+
 vi.mock("../api/client", () => ({
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }));
 
 const BORROW_CTA = "Solicitar préstamo";
 const RETURN_CTA = "Devolver";
+const FORCE_RETURN_CTA = "Forzar devolución";
+const BORROW_SUCCESS_MESSAGE =
+  "El préstamo no tiene fecha límite, pero haz un uso responsable: devuélvelo cuando hayas jugado o si finalmente no vas a usarlo.";
 const LOGIN_LINK = "Iniciar sesión";
 const HISTORY_HEADING = /Historial de préstamos y comentarios/i;
 
@@ -103,6 +112,20 @@ function setHook(
 function setMember(value: CurrentMember | null) {
   useAuthMock.mockReturnValue({ member: value, loading: false });
 }
+
+function setMyLoans(loanIds: readonly number[]) {
+  useMyLoansMock.mockReturnValue({
+    loans: loanIds.map((loan_id) => ({ loan_id })),
+    loading: false,
+    error: null,
+    refetch: refetchMyLoans,
+  });
+}
+
+beforeEach(() => {
+  refetchMyLoans.mockReset();
+  setMyLoans([]);
+});
 
 function renderPage() {
   return render(
@@ -197,6 +220,10 @@ describe("RpgDetailPage borrow CTA", () => {
       body: JSON.stringify({ game_id: 5 }),
     });
     expect(refetch).toHaveBeenCalledTimes(1);
+    expect(refetchMyLoans).toHaveBeenCalledTimes(1);
+    const feedback = await screen.findByRole("status");
+    expect(feedback).toHaveTextContent(BORROW_SUCCESS_MESSAGE);
+    expect(feedback).toHaveAttribute("aria-live", "polite");
   });
 });
 
@@ -258,6 +285,7 @@ describe("RpgDetailPage borrower visibility", () => {
       },
     });
     setMember(member);
+    setMyLoans([7]);
 
     renderPage();
 
@@ -266,7 +294,7 @@ describe("RpgDetailPage borrower visibility", () => {
 });
 
 describe("RpgDetailPage return CTA", () => {
-  it("shows the return CTA to the borrower of a lent item", () => {
+  it("labels the trigger and confirmation 'Devolver' for the borrower", async () => {
     setHook({
       item: {
         ...item,
@@ -276,15 +304,25 @@ describe("RpgDetailPage return CTA", () => {
       },
     });
     setMember(member);
+    setMyLoans([7]);
 
     renderPage();
+    const user = userEvent.setup();
 
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: RETURN_CTA }));
+
+    expect(
+      screen.getByRole("button", { name: RETURN_CTA }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 
-  it("shows the return CTA to an admin even when the loan is someone else's", () => {
+  it("labels the trigger and confirmation 'Forzar devolución' for an admin returning another member's loan", async () => {
     setHook({
       item: {
         ...item,
@@ -296,10 +334,39 @@ describe("RpgDetailPage return CTA", () => {
     setMember(admin);
 
     renderPage();
+    const user = userEvent.setup();
+
+    expect(
+      screen.getByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: FORCE_RETURN_CTA }));
+
+    expect(
+      screen.getByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+  });
+
+  it("keeps 'Devolver' for an admin returning their own loan", () => {
+    setHook({
+      item: {
+        ...item,
+        status: "lent",
+        borrower_display_name: admin.display_name,
+        loan_id: 7,
+      },
+    });
+    setMember(admin);
+    setMyLoans([7]);
+
+    renderPage();
 
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -316,6 +383,29 @@ describe("RpgDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
+  });
+
+  it("does not infer ownership from a duplicate display name", () => {
+    setHook({
+      item: {
+        ...item,
+        status: "lent",
+        borrower_display_name: member.display_name,
+        loan_id: 7,
+      },
+    });
+    setMember(member);
+    setMyLoans([]);
+
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
+    ).toBeNull();
   });
 
   it("calls PATCH /loans/{loan_id}/return and refetches after confirming return", async () => {
@@ -332,6 +422,7 @@ describe("RpgDetailPage return CTA", () => {
       },
     });
     setMember(member);
+    setMyLoans([7]);
 
     renderPage();
     const user = userEvent.setup();

--- a/frontend/src/pages/RpgDetailPage.tsx
+++ b/frontend/src/pages/RpgDetailPage.tsx
@@ -2,10 +2,16 @@ import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { apiFetch } from "../api/client";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { LoanActionFeedback } from "../components/LoanActionFeedback";
 import { LoanHistoryEntry } from "../components/LoanHistoryEntry";
 import { useAuth } from "../context/AuthContext";
 import { useRpgHistory } from "../hooks/useRpgHistory";
+import { useMyLoans } from "../hooks/useMyLoans";
 import { displayDescription } from "../lib/description";
+import {
+  BORROW_SUCCESS_MESSAGE,
+  getReturnAction,
+} from "../lib/loanActions";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
 import "./RpgDetailPage.css";
@@ -14,12 +20,19 @@ export function RpgDetailPage() {
   const { slug } = useParams<{ slug: string }>();
   const { item, history, loading, error, refetch } = useRpgHistory(slug);
   const { member } = useAuth();
+  const {
+    loans: myLoans,
+    loading: myLoansLoading,
+    error: myLoansError,
+    refetch: refetchMyLoans,
+  } = useMyLoans(member !== null);
   const [confirmAction, setConfirmAction] = useState<
     | { readonly action: "borrow"; readonly itemId: number }
     | { readonly action: "return" }
     | null
   >(null);
   const [acting, setActing] = useState(false);
+  const [loanFeedback, setLoanFeedback] = useState<string | null>(null);
 
   if (loading) {
     return (
@@ -41,11 +54,11 @@ export function RpgDetailPage() {
   }
 
   const canBorrow = member !== null && item.status === "available";
-  const canReturn =
-    member !== null &&
-    item.status === "lent" &&
-    item.loan_id !== null &&
-    (member.is_admin || item.borrower_display_name === member.display_name);
+  const activeLoanIds = new Set(myLoans.map((loan) => loan.loan_id));
+  const returnAction =
+    !myLoansLoading && myLoansError === null
+      ? getReturnAction(member, item, activeLoanIds)
+      : null;
 
   const onBorrow = (itemId: number) =>
     setConfirmAction({ action: "borrow", itemId });
@@ -57,7 +70,9 @@ export function RpgDetailPage() {
         method: "POST",
         body: JSON.stringify({ game_id: itemId }),
       });
+      setLoanFeedback(BORROW_SUCCESS_MESSAGE);
       refetch();
+      refetchMyLoans();
     } catch {
       /* error handled silently — refetch on close keeps UI in sync */
     } finally {
@@ -73,6 +88,7 @@ export function RpgDetailPage() {
         method: "PATCH",
       });
       refetch();
+      refetchMyLoans();
     } catch {
       /* error handled silently — refetch on close keeps UI in sync */
     } finally {
@@ -158,13 +174,13 @@ export function RpgDetailPage() {
                 Solicitar préstamo
               </Button>
             )}
-            {canReturn && (
+            {returnAction && (
               <Button
                 variant="secondary"
                 onClick={() => setConfirmAction({ action: "return" })}
                 disabled={acting}
               >
-                Devolver
+                {returnAction.label}
               </Button>
             )}
             {member === null && item.status === "available" && (
@@ -173,6 +189,8 @@ export function RpgDetailPage() {
               </Link>
             )}
           </div>
+
+          <LoanActionFeedback message={loanFeedback} />
 
           <div className="rpg-detail-bgg">
             <a
@@ -223,7 +241,7 @@ export function RpgDetailPage() {
           message={`¿Quieres devolver "${item.name}"?`}
           onConfirm={() => void handleReturn()}
           onCancel={() => setConfirmAction(null)}
-          confirmLabel="Devolver"
+          confirmLabel={returnAction?.label ?? "Devolver"}
         />
       )}
     </div>

--- a/frontend/src/types/catalog.test.ts
+++ b/frontend/src/types/catalog.test.ts
@@ -38,6 +38,24 @@ const SOTANO_GAME: GameWithStatus = {
   location: "sotano",
 };
 
+const YOUNGER_GAME: GameWithStatus = {
+  ...ARMARIO_GAME,
+  id: 3,
+  bgg_id: 103,
+  name: "Younger game",
+  slug: "younger-game",
+  min_age: 8,
+};
+
+const UNKNOWN_AGE_GAME: GameWithStatus = {
+  ...ARMARIO_GAME,
+  id: 4,
+  bgg_id: 104,
+  name: "Unknown age game",
+  slug: "unknown-age-game",
+  min_age: 0,
+};
+
 const GAMES = [ARMARIO_GAME, SOTANO_GAME] as const;
 
 describe("catalog location filtering", () => {
@@ -53,12 +71,41 @@ describe("catalog location filtering", () => {
     ["Todos", "all", ["Armario game", "Sótano game"]],
     ["Armario", "armario", ["Armario game"]],
     ["Sótano", "sotano", ["Sótano game"]],
-  ] as const)("returns the expected games for %s", (_label, location, names) => {
-    const games = applyCatalogQuery(GAMES, {
+  ] as const)(
+    "returns the expected games for %s",
+    (_label, location, names) => {
+      const games = applyCatalogQuery(GAMES, {
+        ...DEFAULT_CATALOG_QUERY,
+        location,
+      });
+
+      expect(games.map(({ name }) => name)).toEqual(names);
+    },
+  );
+});
+
+describe("catalog player-age filtering", () => {
+  it("includes known minimum ages up to the selected player age", () => {
+    const games = applyCatalogQuery(
+      [ARMARIO_GAME, YOUNGER_GAME, UNKNOWN_AGE_GAME],
+      { ...DEFAULT_CATALOG_QUERY, playerAge: 8 },
+    );
+
+    expect(games.map(({ name }) => name)).toEqual(["Younger game"]);
+  });
+
+  it("includes a game whose minimum age equals the selected boundary", () => {
+    const games = applyCatalogQuery([ARMARIO_GAME], {
       ...DEFAULT_CATALOG_QUERY,
-      location,
+      playerAge: 10,
     });
 
-    expect(games.map(({ name }) => name)).toEqual(names);
+    expect(games.map(({ name }) => name)).toEqual(["Armario game"]);
+  });
+
+  it("does not filter unknown ages when no player age is selected", () => {
+    const games = applyCatalogQuery([UNKNOWN_AGE_GAME], DEFAULT_CATALOG_QUERY);
+
+    expect(games.map(({ name }) => name)).toEqual(["Unknown age game"]);
   });
 });

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -6,7 +6,13 @@ export type AvailabilityValue = (typeof availabilityValues)[number];
 export const locationValues = ["all", "armario", "sotano"] as const;
 export type LocationValue = (typeof locationValues)[number];
 
-export const timePresets = ["all", "lt30", "30to60", "1to2h", "2hplus"] as const;
+export const timePresets = [
+  "all",
+  "lt30",
+  "30to60",
+  "1to2h",
+  "2hplus",
+] as const;
 export type TimePreset = (typeof timePresets)[number];
 
 export const sortValues = [
@@ -31,10 +37,12 @@ export interface CatalogQuery {
   readonly minRating: number;
   readonly playersMin: number;
   readonly playersMax: number;
+  readonly playerAge: number | null;
   readonly sort: SortValue;
 }
 
 export const PLAYER_BOUNDS = { min: 1, max: 12 } as const;
+export const PLAYER_AGE_BOUNDS = { min: 3, max: 18 } as const;
 
 interface LabelledOption<T extends string> {
   readonly value: T;
@@ -51,11 +59,12 @@ export const SORT_OPTIONS: readonly LabelledOption<SortValue>[] = [
   { value: "time-desc", label: "Tiempo de juego (largo a corto)" },
 ];
 
-export const AVAILABILITY_OPTIONS: readonly LabelledOption<AvailabilityValue>[] = [
-  { value: "all", label: "Todos" },
-  { value: "available", label: "Disponible" },
-  { value: "lent", label: "Prestado" },
-];
+export const AVAILABILITY_OPTIONS: readonly LabelledOption<AvailabilityValue>[] =
+  [
+    { value: "all", label: "Todos" },
+    { value: "available", label: "Disponible" },
+    { value: "lent", label: "Prestado" },
+  ];
 
 export const LOCATION_OPTIONS: readonly LabelledOption<LocationValue>[] = [
   { value: "all", label: "Todos" },
@@ -71,6 +80,17 @@ export const TIME_PRESET_OPTIONS: readonly LabelledOption<TimePreset>[] = [
   { value: "2hplus", label: "2h+" },
 ];
 
+export const PLAYER_AGE_OPTIONS: readonly LabelledOption<string>[] = [
+  { value: "", label: "Todas" },
+  ...Array.from(
+    { length: PLAYER_AGE_BOUNDS.max - PLAYER_AGE_BOUNDS.min + 1 },
+    (_, index) => {
+      const age = PLAYER_AGE_BOUNDS.min + index;
+      return { value: String(age), label: `${age} años` };
+    },
+  ),
+];
+
 export const DEFAULT_CATALOG_QUERY: CatalogQuery = {
   search: "",
   availability: "all",
@@ -79,6 +99,7 @@ export const DEFAULT_CATALOG_QUERY: CatalogQuery = {
   minRating: 0,
   playersMin: PLAYER_BOUNDS.min,
   playersMax: PLAYER_BOUNDS.max,
+  playerAge: null,
   sort: "name-asc",
 };
 
@@ -134,10 +155,13 @@ export function applyCatalogQuery(
 ): readonly GameWithStatus[] {
   const search = query.search.trim().toLowerCase();
   const playerRangeActive =
-    query.playersMin > PLAYER_BOUNDS.min || query.playersMax < PLAYER_BOUNDS.max;
+    query.playersMin > PLAYER_BOUNDS.min ||
+    query.playersMax < PLAYER_BOUNDS.max;
 
   return games
-    .filter((g) => query.availability === "all" || g.status === query.availability)
+    .filter(
+      (g) => query.availability === "all" || g.status === query.availability,
+    )
     .filter((g) => query.location === "all" || g.location === query.location)
     .filter((g) => search === "" || g.name.toLowerCase().includes(search))
     .filter(
@@ -147,5 +171,10 @@ export function applyCatalogQuery(
     )
     .filter((g) => matchesTimePreset(g.playing_time, query.timePreset))
     .filter((g) => query.minRating <= 0 || g.bgg_rating >= query.minRating)
+    .filter(
+      (g) =>
+        query.playerAge === null ||
+        (g.min_age > 0 && g.min_age <= query.playerAge),
+    )
     .toSorted(COMPARATORS[query.sort]);
 }

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-borrow-return-flow/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-borrow-return-flow/spec.md
@@ -2,75 +2,44 @@
 
 ## ADDED Requirements
 
-### Requirement: Borrow dialog with return-date selection
+### Requirement: Borrow confirmation
 
-The system SHALL ask the member to select an expected return date when borrowing a game, via a dialog that offers preset options ("1 semana", "2 semanas") and a calendar picker for custom dates, defaulting to "2 semanas".
+The system SHALL ask an authenticated member to confirm before borrowing an
+available board game or RPG book. Loans SHALL not have a return deadline.
 
-#### Scenario: Member borrows with default preset
-- **WHEN** an authenticated member clicks Borrow on an available game
-- **THEN** the borrow dialog SHALL open
-- **AND** the "2 semanas" preset SHALL be pre-selected
-- **AND** the resolved return date SHALL be 14 days from today
-
-#### Scenario: Member borrows with custom date
-- **WHEN** the member opens the borrow dialog and picks a date in the calendar
-- **THEN** the selected date SHALL replace any preset selection
-- **AND** confirming SHALL submit that exact date as `expected_return_date`
+#### Scenario: Member confirms a loan
+- **WHEN** an authenticated member clicks the borrow action on an available item
+- **THEN** a confirmation dialog SHALL open
+- **AND** confirming SHALL create the loan
 
 #### Scenario: Member cancels the dialog
 - **WHEN** the member opens the borrow dialog and clicks Cancel or presses Escape
 - **THEN** no loan SHALL be created
 - **AND** the dialog SHALL close and focus SHALL return to the Borrow button
 
-### Requirement: Loan domain carries an optional expected return date
+### Requirement: Loan timestamps
 
-The `Loan` domain entity SHALL include an optional `expected_return_date: date | None` field that is captured when a loan is created and exposed on `LoanResponse` and `ActiveLoanResponse`.
+The system SHALL store when each loan is created and, once returned, when it
+was returned. Loan API responses SHALL expose both timestamps.
 
-#### Scenario: Loan entity field
-- **WHEN** the `Loan` frozen dataclass is inspected
-- **THEN** it SHALL declare a field `expected_return_date: date | None`
+#### Scenario: Active loan timestamps
+- **WHEN** a loan is created
+- **THEN** `borrowed_at` SHALL contain its creation timestamp
+- **AND** `returned_at` SHALL be null
 
-#### Scenario: BorrowRequest accepts the field
-- **WHEN** the API receives `POST /loans` with `{"game_id": <id>, "expected_return_date": "YYYY-MM-DD"}`
-- **THEN** the loan SHALL be persisted with that date
-- **AND** `LoanResponse` SHALL include `expected_return_date` as an ISO date string
+#### Scenario: Returned loan timestamp
+- **WHEN** a loan is returned successfully
+- **THEN** `returned_at` SHALL contain the return timestamp
 
-#### Scenario: Field is optional and backwards-compatible
-- **WHEN** the API receives `POST /loans` without an `expected_return_date`
-- **THEN** the loan SHALL be persisted with `expected_return_date = NULL`
-- **AND** existing loans created before this change SHALL continue to be readable, with `expected_return_date` rendered as `null` in API responses
+### Requirement: MyLoansPage as cards
 
-### Requirement: Database migration for expected_return_date
-
-The system SHALL ship a forward-only SQL migration that adds a nullable `expected_return_date` column to the `loans` table without altering existing rows. The column SHALL store dates as ISO `YYYY-MM-DD` strings in a `TEXT` column to match the existing date/datetime convention in this codebase (see `001_initial.sql`).
-
-#### Scenario: Migration adds nullable TEXT column
-- **WHEN** the migration runner applies the new migration on a database with existing loans
-- **THEN** the `loans` table SHALL gain a nullable `expected_return_date TEXT` column
-- **AND** all existing rows SHALL have `expected_return_date = NULL`
-- **AND** no other columns SHALL be modified
-
-### Requirement: MyLoansPage as cards with countdown
-
-The system SHALL render `MyLoansPage` as a list of cards, one per active loan, each showing the game cover, title, borrow date, expected return date when present, and a countdown indicator (e.g. "vence en 3 días"); a Return button on each card opens a confirmation dialog and calls the existing return endpoint.
+The system SHALL render `MyLoansPage` as a list of cards, one per active loan,
+showing the game cover, title, borrow date, and a Return button. The Return
+button SHALL open a confirmation dialog and call the existing return endpoint.
 
 #### Scenario: Active loan card content
 - **WHEN** an authenticated member opens `/prestamos/my-loans`
-- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, expected return date (if set), and a Return button
-
-#### Scenario: Countdown indicator with due date
-- **WHEN** a loan has an expected return date in the future
-- **THEN** the card SHALL show a countdown such as "vence en N días" computed from today's date
-
-#### Scenario: Countdown indicator without due date
-- **WHEN** a loan has `expected_return_date = NULL`
-- **THEN** the card SHALL not display any countdown indicator
-- **AND** the card SHALL still show the borrowed date
-
-#### Scenario: Past-due loan
-- **WHEN** a loan's expected return date is before today
-- **THEN** the card SHALL show "vencido" styled with the brand red as a non-blocking visual cue
-- **AND** no automated reminder, email, or restriction SHALL be triggered (overdue is purely informational)
+- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, and a Return button
 
 #### Scenario: Returning a game
 - **WHEN** the member clicks Return on a loan card and confirms in the dialog
@@ -79,9 +48,38 @@ The system SHALL render `MyLoansPage` as a list of cards, one per active loan, e
 
 ### Requirement: Empty state
 
-The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans, including a link to the catalog.
+The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans.
 
 #### Scenario: Member with no loans
 - **WHEN** an authenticated member with zero active loans opens `/prestamos/my-loans`
-- **THEN** the page SHALL display a message such as "No tienes préstamos activos"
-- **AND** SHALL render a link to the catalog labelled "Ver el catálogo"
+- **THEN** the page SHALL display `No tienes ningún juego en préstamo.`
+
+### Requirement: Responsible-use feedback after borrowing
+
+The system SHALL display an accessible status message after a board game or RPG
+book is borrowed successfully, explaining that the loan has no deadline and
+asking the member to return it after playing or when they no longer plan to use
+it.
+
+#### Scenario: Successful borrow
+- **WHEN** an authenticated member successfully borrows an available board game or RPG book
+- **THEN** the detail page SHALL expose the responsible-use guidance through a polite live status
+
+### Requirement: Return wording reflects who owns the loan
+
+The detail page SHALL label a member returning their own loan `Devolver`. When
+an administrator returns another member's loan, both the action and its
+confirmation SHALL be labelled `Forzar devolución`. A non-administrator who is
+not the borrower SHALL not receive either action.
+
+#### Scenario: Borrower returns their own loan
+- **WHEN** the current member is the borrower, including when that member is an administrator
+- **THEN** the return action and confirmation SHALL be labelled `Devolver`
+
+#### Scenario: Administrator returns another member's loan
+- **WHEN** an administrator views a board game or RPG book borrowed by another member
+- **THEN** the return action and confirmation SHALL be labelled `Forzar devolución`
+
+#### Scenario: Unauthorised member views another member's loan
+- **WHEN** a non-administrator views a board game or RPG book borrowed by another member
+- **THEN** neither `Devolver` nor `Forzar devolución` SHALL be available

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-catalog-redesign/spec.md
@@ -45,23 +45,89 @@ toggle.
 - **WHEN** an RPG item is currently lent
 - **THEN** the same diagonal "EN PRÉSTAMO" ribbon SHALL be overlaid on the cover's bottom-right corner
 
-### Requirement: Catalog filters as side panel + chip row
+### Requirement: Readable responsive list cards
 
-The system SHALL render the catalog filters in a side panel on desktop and a chip row of active filters above the grid; selected filter values SHALL be visible at a glance and individually removable.
+The system SHALL render board-game and RPG list cards with a prominent cover
+column and rating block, a left-aligned title, a description clamped to two
+lines, and horizontal metadata. On narrow screens, the cover and rating SHALL
+use compact sizes without overflowing. RPG covers SHALL remain letterboxed in
+both desktop and compact list layouts.
+
+#### Scenario: Desktop list view
+- **WHEN** the user selects list view on a desktop viewport
+- **THEN** each card SHALL show an approximately 180 px cover column and 56 px rating block
+- **AND** the title, two-line description, and horizontal metadata SHALL remain readable
+
+#### Scenario: Compact list view
+- **WHEN** a list card renders on a narrow viewport
+- **THEN** it SHALL use an approximately 96 px cover column and 40 px rating block
+- **AND** the card SHALL not overflow its container
+- **AND** an RPG cover SHALL remain uncropped
+
+### Requirement: Catalog filters in a tabbed search-and-filters box
+
+The system SHALL render the catalog search and filters inside a centred tabbed
+box above the results: a **Buscador** tab containing the search input and a
+**Filtros** tab containing the filter controls. Active search text and filters
+SHALL remain visible as a chip row below the box, individually removable.
+Sorting SHALL be separate from filtering and SHALL appear beside the grid/list
+view toggle in the results bar.
+
+#### Scenario: Tabbed box replaces the side panel
+- **WHEN** the catalog page renders at any viewport width
+- **THEN** the search input and filter controls SHALL be inside the tabbed box above the results
+- **AND** no fixed left filter column SHALL be reserved
+
+#### Scenario: Switching tabs
+- **WHEN** the user activates the Filtros tab (click or keyboard)
+- **THEN** the filter controls SHALL replace the search input inside the box
+- **AND** previously applied search text and filters SHALL remain applied
 
 #### Scenario: Active filters visible as chips
 - **WHEN** the user selects a filter (e.g. "2–4 players", "Disponibles")
-- **THEN** the active filter SHALL appear as a removable chip in the chip row above the grid
+- **THEN** the active filter SHALL appear as a removable chip below the box
+
+#### Scenario: Search text visible as a chip
+- **WHEN** the user enters non-blank search text
+- **THEN** a removable chip labelled `Palabra clave: “<text>”` SHALL appear below the box
 
 #### Scenario: Removing a filter via its chip
 - **WHEN** the user clicks the close affordance on a chip
 - **THEN** the corresponding filter SHALL be cleared from the catalog query
 - **AND** the catalog grid SHALL re-render with the updated result set
 
-#### Scenario: Side panel on desktop
-- **WHEN** the viewport width is ≥ 1024 px
-- **THEN** the filter panel SHALL be visible as a fixed left column
-- **AND** the catalog grid SHALL render to the right of it
+#### Scenario: Clear search and filters without resetting sort
+- **WHEN** any search text or filter is active
+- **THEN** the system SHALL show a `Limpiar búsqueda y filtros` action
+- **AND WHEN** the user activates it
+- **THEN** search text and all filters SHALL return to their defaults
+- **AND** the selected sort order SHALL be preserved
+
+#### Scenario: Sorting remains available across tabs
+- **WHEN** either the Buscador or Filtros tab is active
+- **THEN** the `Ordenar por` control SHALL remain available beside the grid/list toggle
+
+### Requirement: Board-game player-age filter
+
+The board-game catalog SHALL offer an `Edad del jugador` filter with ages from
+3 through 18. Selecting age X SHALL include only games with a known minimum age
+greater than zero and less than or equal to X. The RPG catalog SHALL not expose
+this board-game-specific filter.
+
+#### Scenario: Game is suitable for the selected age
+- **WHEN** the player-age filter is set to 8
+- **AND** a game has minimum age 8 or lower
+- **THEN** the game SHALL remain in the results
+
+#### Scenario: Game requires an older player
+- **WHEN** the player-age filter is set to 8
+- **AND** a game has minimum age greater than 8
+- **THEN** the game SHALL be excluded from the results
+
+#### Scenario: Game has no known minimum age
+- **WHEN** any player-age filter is active
+- **AND** a game's minimum age is missing or zero
+- **THEN** the game SHALL be excluded from the results
 
 ### Requirement: Accessible player-range slider
 

--- a/openspec/specs/lending-borrow-return-flow/spec.md
+++ b/openspec/specs/lending-borrow-return-flow/spec.md
@@ -3,75 +3,44 @@
 ## Purpose
 TBD - created by archiving change plan-lending-redesign. Update Purpose after archive.
 ## Requirements
-### Requirement: Borrow dialog with return-date selection
+### Requirement: Borrow confirmation
 
-The system SHALL ask the member to select an expected return date when borrowing a game, via a dialog that offers preset options ("1 semana", "2 semanas") and a calendar picker for custom dates, defaulting to "2 semanas".
+The system SHALL ask an authenticated member to confirm before borrowing an
+available board game or RPG book. Loans SHALL not have a return deadline.
 
-#### Scenario: Member borrows with default preset
-- **WHEN** an authenticated member clicks Borrow on an available game
-- **THEN** the borrow dialog SHALL open
-- **AND** the "2 semanas" preset SHALL be pre-selected
-- **AND** the resolved return date SHALL be 14 days from today
-
-#### Scenario: Member borrows with custom date
-- **WHEN** the member opens the borrow dialog and picks a date in the calendar
-- **THEN** the selected date SHALL replace any preset selection
-- **AND** confirming SHALL submit that exact date as `expected_return_date`
+#### Scenario: Member confirms a loan
+- **WHEN** an authenticated member clicks the borrow action on an available item
+- **THEN** a confirmation dialog SHALL open
+- **AND** confirming SHALL create the loan
 
 #### Scenario: Member cancels the dialog
 - **WHEN** the member opens the borrow dialog and clicks Cancel or presses Escape
 - **THEN** no loan SHALL be created
 - **AND** the dialog SHALL close and focus SHALL return to the Borrow button
 
-### Requirement: Loan domain carries an optional expected return date
+### Requirement: Loan timestamps
 
-The `Loan` domain entity SHALL include an optional `expected_return_date: date | None` field that is captured when a loan is created and exposed on `LoanResponse` and `ActiveLoanResponse`.
+The system SHALL store when each loan is created and, once returned, when it
+was returned. Loan API responses SHALL expose both timestamps.
 
-#### Scenario: Loan entity field
-- **WHEN** the `Loan` frozen dataclass is inspected
-- **THEN** it SHALL declare a field `expected_return_date: date | None`
+#### Scenario: Active loan timestamps
+- **WHEN** a loan is created
+- **THEN** `borrowed_at` SHALL contain its creation timestamp
+- **AND** `returned_at` SHALL be null
 
-#### Scenario: BorrowRequest accepts the field
-- **WHEN** the API receives `POST /loans` with `{"game_id": <id>, "expected_return_date": "YYYY-MM-DD"}`
-- **THEN** the loan SHALL be persisted with that date
-- **AND** `LoanResponse` SHALL include `expected_return_date` as an ISO date string
+#### Scenario: Returned loan timestamp
+- **WHEN** a loan is returned successfully
+- **THEN** `returned_at` SHALL contain the return timestamp
 
-#### Scenario: Field is optional and backwards-compatible
-- **WHEN** the API receives `POST /loans` without an `expected_return_date`
-- **THEN** the loan SHALL be persisted with `expected_return_date = NULL`
-- **AND** existing loans created before this change SHALL continue to be readable, with `expected_return_date` rendered as `null` in API responses
+### Requirement: MyLoansPage as cards
 
-### Requirement: Database migration for expected_return_date
-
-The system SHALL ship a forward-only SQL migration that adds a nullable `expected_return_date` column to the `loans` table without altering existing rows. The column SHALL store dates as ISO `YYYY-MM-DD` strings in a `TEXT` column to match the existing date/datetime convention in this codebase (see `001_initial.sql`).
-
-#### Scenario: Migration adds nullable TEXT column
-- **WHEN** the migration runner applies the new migration on a database with existing loans
-- **THEN** the `loans` table SHALL gain a nullable `expected_return_date TEXT` column
-- **AND** all existing rows SHALL have `expected_return_date = NULL`
-- **AND** no other columns SHALL be modified
-
-### Requirement: MyLoansPage as cards with countdown
-
-The system SHALL render `MyLoansPage` as a list of cards, one per active loan, each showing the game cover, title, borrow date, expected return date when present, and a countdown indicator (e.g. "vence en 3 días"); a Return button on each card opens a confirmation dialog and calls the existing return endpoint.
+The system SHALL render `MyLoansPage` as a list of cards, one per active loan,
+showing the game cover, title, borrow date, and a Return button. The Return
+button SHALL open a confirmation dialog and call the existing return endpoint.
 
 #### Scenario: Active loan card content
 - **WHEN** an authenticated member opens `/prestamos/my-loans`
-- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, expected return date (if set), and a Return button
-
-#### Scenario: Countdown indicator with due date
-- **WHEN** a loan has an expected return date in the future
-- **THEN** the card SHALL show a countdown such as "vence en N días" computed from today's date
-
-#### Scenario: Countdown indicator without due date
-- **WHEN** a loan has `expected_return_date = NULL`
-- **THEN** the card SHALL not display any countdown indicator
-- **AND** the card SHALL still show the borrowed date
-
-#### Scenario: Past-due loan
-- **WHEN** a loan's expected return date is before today
-- **THEN** the card SHALL show "vencido" styled with the brand red as a non-blocking visual cue
-- **AND** no automated reminder, email, or restriction SHALL be triggered (overdue is purely informational)
+- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, and a Return button
 
 #### Scenario: Returning a game
 - **WHEN** the member clicks Return on a loan card and confirms in the dialog
@@ -80,10 +49,38 @@ The system SHALL render `MyLoansPage` as a list of cards, one per active loan, e
 
 ### Requirement: Empty state
 
-The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans, including a link to the catalog.
+The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans.
 
 #### Scenario: Member with no loans
 - **WHEN** an authenticated member with zero active loans opens `/prestamos/my-loans`
-- **THEN** the page SHALL display a message such as "No tienes préstamos activos"
-- **AND** SHALL render a link to the catalog labelled "Ver el catálogo"
+- **THEN** the page SHALL display `No tienes ningún juego en préstamo.`
 
+### Requirement: Responsible-use feedback after borrowing
+
+The system SHALL display an accessible status message after a board game or RPG
+book is borrowed successfully, explaining that the loan has no deadline and
+asking the member to return it after playing or when they no longer plan to use
+it.
+
+#### Scenario: Successful borrow
+- **WHEN** an authenticated member successfully borrows an available board game or RPG book
+- **THEN** the detail page SHALL expose the responsible-use guidance through a polite live status
+
+### Requirement: Return wording reflects who owns the loan
+
+The detail page SHALL label a member returning their own loan `Devolver`. When
+an administrator returns another member's loan, both the action and its
+confirmation SHALL be labelled `Forzar devolución`. A non-administrator who is
+not the borrower SHALL not receive either action.
+
+#### Scenario: Borrower returns their own loan
+- **WHEN** the current member is the borrower, including when that member is an administrator
+- **THEN** the return action and confirmation SHALL be labelled `Devolver`
+
+#### Scenario: Administrator returns another member's loan
+- **WHEN** an administrator views a board game or RPG book borrowed by another member
+- **THEN** the return action and confirmation SHALL be labelled `Forzar devolución`
+
+#### Scenario: Unauthorised member views another member's loan
+- **WHEN** a non-administrator views a board game or RPG book borrowed by another member
+- **THEN** neither `Devolver` nor `Forzar devolución` SHALL be available

--- a/openspec/specs/lending-catalog-redesign/spec.md
+++ b/openspec/specs/lending-catalog-redesign/spec.md
@@ -46,13 +46,33 @@ toggle.
 - **WHEN** an RPG item is currently lent
 - **THEN** the same diagonal "EN PRÉSTAMO" ribbon SHALL be overlaid on the cover's bottom-right corner
 
+### Requirement: Readable responsive list cards
+
+The system SHALL render board-game and RPG list cards with a prominent cover
+column and rating block, a left-aligned title, a description clamped to two
+lines, and horizontal metadata. On narrow screens, the cover and rating SHALL
+use compact sizes without overflowing. RPG covers SHALL remain letterboxed in
+both desktop and compact list layouts.
+
+#### Scenario: Desktop list view
+- **WHEN** the user selects list view on a desktop viewport
+- **THEN** each card SHALL show an approximately 180 px cover column and 56 px rating block
+- **AND** the title, two-line description, and horizontal metadata SHALL remain readable
+
+#### Scenario: Compact list view
+- **WHEN** a list card renders on a narrow viewport
+- **THEN** it SHALL use an approximately 96 px cover column and 40 px rating block
+- **AND** the card SHALL not overflow its container
+- **AND** an RPG cover SHALL remain uncropped
+
 ### Requirement: Catalog filters in a tabbed search-and-filters box
 
 The system SHALL render the catalog search and filters inside a centred tabbed
 box above the results (Figma `Search & filters box`): a **Buscador** tab
 containing the search input and a **Filtros** tab containing the filter
-controls. Active filters SHALL remain visible as a chip row below the box,
-individually removable.
+controls. Active search text and filters SHALL remain visible as a chip row
+below the box, individually removable. Sorting SHALL be separate from filtering
+and SHALL appear beside the grid/list view toggle in the results bar.
 
 #### Scenario: Tabbed box replaces the side panel
 - **WHEN** the catalog page renders at any viewport width
@@ -68,10 +88,47 @@ individually removable.
 - **WHEN** the user selects a filter (e.g. "2–4 players", "Disponibles")
 - **THEN** the active filter SHALL appear as a removable chip below the box
 
+#### Scenario: Search text visible as a chip
+- **WHEN** the user enters non-blank search text
+- **THEN** a removable chip labelled `Palabra clave: “<text>”` SHALL appear below the box
+
 #### Scenario: Removing a filter via its chip
 - **WHEN** the user clicks the close affordance on a chip
 - **THEN** the corresponding filter SHALL be cleared from the catalog query
 - **AND** the catalog grid SHALL re-render with the updated result set
+
+#### Scenario: Clear search and filters without resetting sort
+- **WHEN** any search text or filter is active
+- **THEN** the system SHALL show a `Limpiar búsqueda y filtros` action
+- **AND WHEN** the user activates it
+- **THEN** search text and all filters SHALL return to their defaults
+- **AND** the selected sort order SHALL be preserved
+
+#### Scenario: Sorting remains available across tabs
+- **WHEN** either the Buscador or Filtros tab is active
+- **THEN** the `Ordenar por` control SHALL remain available beside the grid/list toggle
+
+### Requirement: Board-game player-age filter
+
+The board-game catalog SHALL offer an `Edad del jugador` filter with ages from
+3 through 18. Selecting age X SHALL include only games with a known minimum age
+greater than zero and less than or equal to X. The RPG catalog SHALL not expose
+this board-game-specific filter.
+
+#### Scenario: Game is suitable for the selected age
+- **WHEN** the player-age filter is set to 8
+- **AND** a game has minimum age 8 or lower
+- **THEN** the game SHALL remain in the results
+
+#### Scenario: Game requires an older player
+- **WHEN** the player-age filter is set to 8
+- **AND** a game has minimum age greater than 8
+- **THEN** the game SHALL be excluded from the results
+
+#### Scenario: Game has no known minimum age
+- **WHEN** any player-age filter is active
+- **AND** a game's minimum age is missing or zero
+- **THEN** the game SHALL be excluded from the results
 
 ### Requirement: Catalog location reflects the BGG collection comment
 

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -35,6 +35,8 @@ def test_application_title_uses_refugio_del_satiro_brand() -> None:
 
 
 class TestLogin:
+    INVALID_CREDENTIALS_RESPONSE = {"detail": "Correo o contraseña incorrectos."}
+
     def test_login_success(self) -> None:
         client, conn = _setup_test_client()
         member_repo = SqliteMemberRepository(conn)
@@ -69,6 +71,7 @@ class TestLogin:
             "/api/login", json={"email": "TEST_email@domain.com", "password": "wrong"}
         )
         assert response.status_code == 401
+        assert response.json() == self.INVALID_CREDENTIALS_RESPONSE
 
     def test_login_nonexistent_email(self) -> None:
         client, _ = _setup_test_client()
@@ -76,6 +79,7 @@ class TestLogin:
             "/api/login", json={"email": "TEST_email@domain.com", "password": "test"}
         )
         assert response.status_code == 401
+        assert response.json() == self.INVALID_CREDENTIALS_RESPONSE
 
     def test_login_no_password_set(self) -> None:
         client, conn = _setup_test_client()
@@ -89,6 +93,31 @@ class TestLogin:
             json={"email": "TEST_email@domain.com", "password": "anything"},
         )
         assert response.status_code == 401
+        assert response.json() == self.INVALID_CREDENTIALS_RESPONSE
+
+    def test_login_inactive_member(self) -> None:
+        client, conn = _setup_test_client()
+        member_repo = SqliteMemberRepository(conn)
+        member = member_repo.upsert_by_email(
+            1,
+            "Test",
+            "User",
+            None,
+            None,
+            "TEST_email@domain.com",
+            "Test User",
+            False,
+            is_active=False,
+        )
+        member_repo.set_password_hash(member.id, hash_password("mypassword"))
+
+        response = client.post(
+            "/api/login",
+            json={"email": "TEST_email@domain.com", "password": "mypassword"},
+        )
+
+        assert response.status_code == 401
+        assert response.json() == self.INVALID_CREDENTIALS_RESPONSE
 
 
 class TestLogout:


### PR DESCRIPTION
## Summary

This closes the remaining actionable points from Ariadna’s latest lending-area test pass.

- Failed sign-ins now give privacy-safe guidance, and signing out shows an accessible confirmation.
- Both catalogs have clearer search/filter reset controls and sorting placement; board games also support age suitability. List cards are easier to scan on desktop and mobile.
- Borrowing shows the responsible-use reminder, while administrators get explicit forced-return wording when the loan belongs to someone else.
- The README and lending OpenSpec documents now match the behavior users actually see.

## Verification

- Backend: 425 tests passed; Ruff passed.
- Frontend: 274 tests passed; type-check, ESLint, and production build passed.
- Playwright: 100 passed, 11 intentionally skipped across mobile, tablet, and desktop.
- Manual browser smoke covered identical invalid-login guidance, logout confirmation, search/filter removal and reset, preserved sorting, age boundaries, board-game and RPG list views, borrow guidance, and borrower/admin return wording. The console and relevant network requests were clean.

Closes #127