### PR TITLE
fix(lending): address remaining Ariadna feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ that loans have no deadline and should be returned responsibly. A borrower
 sees `Devolver`; an administrator returning another member's item sees
 `Forzar devolución` in both the action and its confirmation.
 
+`Mis préstamos` repeats the responsible-use reminder. The cover and title on
+each card link to the item's detail page. Loans open for at least 30 complete
+days show an informational marker. The marker does not set a deadline or
+restrict the loan.
+
+The admin member list has a `Rol` column that identifies each person as
+`Administrador` or `Socio`. When an administrator forces a return, the app
+tries to email the borrower and reports whether the message was sent. The
+return remains registered if the email cannot be sent.
+
 A public membership-validation page lives at `/ludoteca/validacion`: anyone
 can enter a member number and see whether that person is a current member
 (name, ES/NO ES socio·a verdict, last paid fee). The legacy

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -16,6 +16,7 @@ from backend.data.repositories.sqlite_password_token_repository import (
     SqlitePasswordTokenRepository,
 )
 from backend.domain.entities.member import Member
+from backend.domain.services.loan_return_notifier import LoanReturnNotifier
 from backend.domain.use_cases.authenticate import AuthenticateUseCase
 from backend.domain.use_cases.change_password import ChangePasswordUseCase
 from backend.domain.use_cases.get_game import GetGameUseCase
@@ -66,6 +67,15 @@ GameRepo = Annotated[SqliteGameRepository, Depends(get_game_repo)]
 MemberRepo = Annotated[SqliteMemberRepository, Depends(get_member_repo)]
 LoanRepo = Annotated[SqliteLoanRepository, Depends(get_loan_repo)]
 TokenRepo = Annotated[SqlitePasswordTokenRepository, Depends(get_token_repo)]
+
+
+def get_loan_return_notifier() -> LoanReturnNotifier:
+    from backend.data.email_client import EmailClient
+
+    return EmailClient(_settings)
+
+
+ReturnNotifier = Annotated[LoanReturnNotifier, Depends(get_loan_return_notifier)]
 
 
 def get_list_games_use_case(

--- a/backend/api/routes/loans.py
+++ b/backend/api/routes/loans.py
@@ -7,6 +7,8 @@ from backend.api.dependencies import (
     CurrentMember,
     GameRepo,
     LoanRepo,
+    MemberRepo,
+    ReturnNotifier,
 )
 from backend.domain.use_cases.borrow_game import BorrowGameError, BorrowGameUseCase
 from backend.domain.use_cases.return_game import ReturnGameError, ReturnGameUseCase
@@ -30,6 +32,10 @@ class OkResponse(BaseModel):
     ok: bool = True
 
 
+class ReturnLoanResponse(LoanResponse):
+    forced_return_email_sent: bool | None
+
+
 @router.post("/loans", response_model=LoanResponse, status_code=status.HTTP_201_CREATED)
 def borrow_game(
     body: BorrowRequest,
@@ -51,21 +57,26 @@ def borrow_game(
     )
 
 
-@router.patch("/loans/{loan_id}/return", response_model=LoanResponse)
+@router.patch("/loans/{loan_id}/return", response_model=ReturnLoanResponse)
 def return_game(
     loan_id: int,
     member: CurrentMember,
     loan_repo: LoanRepo,
-) -> LoanResponse:
-    use_case = ReturnGameUseCase(loan_repo)
+    member_repo: MemberRepo,
+    game_repo: GameRepo,
+    notifier: ReturnNotifier,
+) -> ReturnLoanResponse:
+    use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier)
     try:
-        loan = use_case.execute(loan_id, member)
+        result = use_case.execute(loan_id, member)
     except ReturnGameError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
-    return LoanResponse(
+    loan = result.loan
+    return ReturnLoanResponse(
         id=loan.id,
         game_id=loan.game_id,
         member_id=loan.member_id,
         borrowed_at=loan.borrowed_at.isoformat(),
         returned_at=loan.returned_at.isoformat() if loan.returned_at else None,
+        forced_return_email_sent=result.forced_return_email_sent,
     )

--- a/backend/api/routes/members.py
+++ b/backend/api/routes/members.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel
 
@@ -53,6 +55,8 @@ class ActiveLoanResponse(BaseModel):
     loan_id: int
     game_id: int
     game_name: str
+    game_slug: str
+    item_type: Literal["boardgame", "rpgitem"]
     game_thumbnail_url: str
     game_image_url: str
     borrowed_at: str
@@ -71,6 +75,8 @@ def get_my_loans(
             loan_id=loan.loan_id,
             game_id=loan.game_id,
             game_name=loan.game_name,
+            game_slug=loan.game_slug,
+            item_type=loan.item_type,
             game_thumbnail_url=loan.game_thumbnail_url,
             game_image_url=loan.game_image_url,
             borrowed_at=loan.borrowed_at,

--- a/backend/data/email_client.py
+++ b/backend/data/email_client.py
@@ -3,13 +3,35 @@ from __future__ import annotations
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from html import escape
 
 from backend.config import Settings
+
+SMTP_TIMEOUT_SECONDS = 10.0
 
 
 class EmailClient:
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
+
+    def _deliver(self, message: MIMEMultipart, to_email: str) -> bool:
+        smtp_host = self._settings.smtp_host
+        smtp_user = self._settings.smtp_user
+        smtp_password = self._settings.smtp_password
+        smtp_from = self._settings.smtp_from
+        if not smtp_host or not smtp_user or not smtp_password or not smtp_from:
+            return False
+
+        with smtplib.SMTP(
+            smtp_host,
+            self._settings.smtp_port,
+            timeout=SMTP_TIMEOUT_SECONDS,
+        ) as server:
+            server.starttls()
+            server.login(smtp_user, smtp_password)
+            server.sendmail(smtp_from, to_email, message.as_string())
+
+        return True
 
     def send_access_link(self, to_email: str, display_name: str, url: str) -> bool:
         """Send a password-set link email. Returns True if sent, False if SMTP not configured."""
@@ -44,9 +66,42 @@ class EmailClient:
         msg["To"] = to_email
         msg.attach(MIMEText(html, "html"))
 
-        with smtplib.SMTP(self._settings.smtp_host, self._settings.smtp_port) as server:  # type: ignore[arg-type]
-            server.starttls()
-            server.login(self._settings.smtp_user, self._settings.smtp_password)  # type: ignore[arg-type]
-            server.sendmail(self._settings.smtp_from, to_email, msg.as_string())  # type: ignore[arg-type]
+        return self._deliver(msg, to_email)
 
-        return True
+    def send_forced_return(
+        self,
+        to_email: str,
+        display_name: str,
+        item_name: str,
+    ) -> bool:
+        if not self._settings.smtp_configured:
+            return False
+
+        text = (
+            f"Hola, {display_name}:\n\n"
+            f'La administración ha marcado "{item_name}" como devuelto porque ya '
+            "estaba en el local.\n\n"
+            "Cuando devuelvas un préstamo, recuerda registrarlo en la ludoteca para "
+            "que el catálogo muestre que vuelve a estar disponible.\n\n"
+            "Gracias, Refugio del Sátiro."
+        )
+        safe_display_name = escape(display_name)
+        safe_item_name = escape(item_name)
+        html = f"""\
+<html>
+<body style="font-family: system-ui, sans-serif; color: #1f2937; max-width: 600px; margin: 0 auto;">
+    <p>Hola, {safe_display_name}:</p>
+    <p>La administración ha marcado &quot;{safe_item_name}&quot; como devuelto porque ya estaba en el local.</p>
+    <p>Cuando devuelvas un préstamo, recuerda registrarlo en la ludoteca para que el catálogo muestre que vuelve a estar disponible.</p>
+    <p>Gracias, Refugio del Sátiro.</p>
+</body>
+</html>"""
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = "Refugio del Sátiro: préstamo marcado como devuelto"
+        msg["From"] = self._settings.smtp_from  # type: ignore[assignment]
+        msg["To"] = to_email
+        msg.attach(MIMEText(text, "plain", "utf-8"))
+        msg.attach(MIMEText(html, "html", "utf-8"))
+
+        return self._deliver(msg, to_email)

--- a/backend/data/repositories/sqlite_game_repository.py
+++ b/backend/data/repositories/sqlite_game_repository.py
@@ -5,7 +5,7 @@ import sqlite3
 from collections.abc import Collection
 from datetime import UTC, datetime
 
-from backend.domain.entities.game import Game
+from backend.domain.entities.game import Game, parse_item_type
 from backend.domain.slug import ensure_unique, slugify
 
 
@@ -47,7 +47,9 @@ def _row_to_game(row: sqlite3.Row) -> Game:
         location=row["location"] if "location" in keys else "armario",
         created_at=datetime.fromisoformat(row["created_at"]),
         updated_at=datetime.fromisoformat(row["updated_at"]),
-        item_type=row["item_type"] if "item_type" in keys else "boardgame",
+        item_type=parse_item_type(
+            row["item_type"] if "item_type" in keys else "boardgame"
+        ),
         description=row["description"] if "description" in keys else "",
         categories=(
             _deserialize_metadata(row["categories_json"])

--- a/backend/domain/entities/game.py
+++ b/backend/domain/entities/game.py
@@ -2,6 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Literal
+
+ItemType = Literal["boardgame", "rpgitem"]
+
+
+def parse_item_type(value: str) -> ItemType:
+    if value == "boardgame":
+        return "boardgame"
+    if value == "rpgitem":
+        return "rpgitem"
+    raise ValueError(f"Unsupported item type: {value}")
 
 
 @dataclass(frozen=True)
@@ -20,7 +31,7 @@ class Game:
     location: str
     created_at: datetime
     updated_at: datetime
-    item_type: str = field(default="boardgame")
+    item_type: ItemType = field(default="boardgame")
     description: str = field(default="")
     categories: tuple[str, ...] = field(default=())
     publication_types: tuple[str, ...] = field(default=())

--- a/backend/domain/services/loan_return_notifier.py
+++ b/backend/domain/services/loan_return_notifier.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class LoanReturnNotifier(Protocol):
+    def send_forced_return(
+        self,
+        to_email: str,
+        display_name: str,
+        item_name: str,
+    ) -> bool: ...

--- a/backend/domain/use_cases/get_member_loans.py
+++ b/backend/domain/use_cases/get_member_loans.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from backend.domain.entities.game import ItemType
 from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
 
@@ -11,6 +12,8 @@ class ActiveLoanWithGame:
     loan_id: int
     game_id: int
     game_name: str
+    game_slug: str
+    item_type: ItemType
     game_thumbnail_url: str
     game_image_url: str
     borrowed_at: str
@@ -26,20 +29,17 @@ class GetMemberLoansUseCase:
         self._game_repo = game_repo
 
     def execute(self, member_id: int) -> list[ActiveLoanWithGame]:
-        loans = self._loan_repo.list_active_by_member_id(member_id)
-        result: list[ActiveLoanWithGame] = []
-        for loan in loans:
-            game = self._game_repo.get_by_id(loan.game_id)
-            if game is None:
-                continue
-            result.append(
-                ActiveLoanWithGame(
-                    loan_id=loan.id,
-                    game_id=game.id,
-                    game_name=game.name,
-                    game_thumbnail_url=game.thumbnail_url,
-                    game_image_url=game.image_url,
-                    borrowed_at=loan.borrowed_at.isoformat(),
-                )
+        return [
+            ActiveLoanWithGame(
+                loan_id=loan.id,
+                game_id=game.id,
+                game_name=game.name,
+                game_slug=game.slug,
+                item_type=game.item_type,
+                game_thumbnail_url=game.thumbnail_url,
+                game_image_url=game.image_url,
+                borrowed_at=loan.borrowed_at.isoformat(),
             )
-        return result
+            for loan in self._loan_repo.list_active_by_member_id(member_id)
+            if (game := self._game_repo.get_by_id(loan.game_id)) is not None
+        ]

--- a/backend/domain/use_cases/return_game.py
+++ b/backend/domain/use_cases/return_game.py
@@ -1,19 +1,42 @@
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+
 from backend.domain.entities.loan import Loan
 from backend.domain.entities.member import Member
+from backend.domain.repositories.game_repository import GameRepository
 from backend.domain.repositories.loan_repository import LoanRepository
+from backend.domain.repositories.member_repository import MemberRepository
+from backend.domain.services.loan_return_notifier import LoanReturnNotifier
+
+logger = logging.getLogger(__name__)
 
 
 class ReturnGameError(Exception):
     pass
 
 
-class ReturnGameUseCase:
-    def __init__(self, loan_repo: LoanRepository) -> None:
-        self._loan_repo = loan_repo
+@dataclass(frozen=True)
+class ReturnGameResult:
+    loan: Loan
+    forced_return_email_sent: bool | None
 
-    def execute(self, loan_id: int, member: Member) -> Loan:
+
+class ReturnGameUseCase:
+    def __init__(
+        self,
+        loan_repo: LoanRepository,
+        member_repo: MemberRepository,
+        game_repo: GameRepository,
+        notifier: LoanReturnNotifier,
+    ) -> None:
+        self._loan_repo = loan_repo
+        self._member_repo = member_repo
+        self._game_repo = game_repo
+        self._notifier = notifier
+
+    def execute(self, loan_id: int, member: Member) -> ReturnGameResult:
         loan = self._loan_repo.get_by_id(loan_id)
         if loan is None:
             raise ReturnGameError("Préstamo no encontrado.")
@@ -24,4 +47,36 @@ class ReturnGameUseCase:
         if loan.member_id != member.id and not member.is_admin:
             raise ReturnGameError("Solo puedes devolver tus propios préstamos.")
 
-        return self._loan_repo.mark_returned(loan_id)
+        returned_loan = self._loan_repo.mark_returned(loan_id)
+        if loan.member_id == member.id:
+            return ReturnGameResult(returned_loan, None)
+
+        try:
+            borrower = self._member_repo.get_by_id(loan.member_id)
+            game = self._game_repo.get_by_id(loan.game_id)
+            if (
+                borrower is None
+                or game is None
+                or not borrower.email.strip()
+                or not borrower.display_name.strip()
+                or not game.name.strip()
+            ):
+                logger.warning(
+                    "Forced return notification data unavailable for loan_id=%s",
+                    loan_id,
+                )
+                return ReturnGameResult(returned_loan, False)
+
+            email_sent = self._notifier.send_forced_return(
+                borrower.email,
+                borrower.display_name,
+                game.name,
+            )
+        except Exception:
+            logger.exception(
+                "Forced return notification preparation or delivery failed for loan_id=%s",
+                loan_id,
+            )
+            email_sent = False
+
+        return ReturnGameResult(returned_loan, email_sent)

--- a/frontend/src/components/LoanActionFeedback.css
+++ b/frontend/src/components/LoanActionFeedback.css
@@ -2,8 +2,16 @@
   max-width: 42rem;
   margin: 0;
   padding: var(--space-sm) var(--space-md);
-  border-left: 3px solid var(--color-brand);
   background-color: var(--color-surface-alt);
   color: var(--color-text-body);
   line-height: var(--line-height-relaxed);
+}
+
+.loan-action-feedback--status {
+  border-left: 3px solid var(--color-brand);
+}
+
+.loan-action-feedback--warning {
+  border-left: 3px solid var(--color-warning);
+  background-color: var(--color-lent);
 }

--- a/frontend/src/components/LoanActionFeedback.tsx
+++ b/frontend/src/components/LoanActionFeedback.tsx
@@ -1,14 +1,23 @@
+import type { LoanFeedbackVariant } from "../lib/loanFeedback";
 import "./LoanActionFeedback.css";
 
 interface LoanActionFeedbackProps {
   readonly message: string | null;
+  readonly variant?: LoanFeedbackVariant;
 }
 
-export function LoanActionFeedback({ message }: LoanActionFeedbackProps) {
+export function LoanActionFeedback({
+  message,
+  variant = "status",
+}: LoanActionFeedbackProps) {
   if (message === null) return null;
 
   return (
-    <p className="loan-action-feedback" role="status" aria-live="polite">
+    <p
+      className={`loan-action-feedback loan-action-feedback--${variant}`}
+      role={variant === "warning" ? "alert" : "status"}
+      aria-live={variant === "status" ? "polite" : undefined}
+    >
       {message}
     </p>
   );

--- a/frontend/src/hooks/useMyLoans.test.ts
+++ b/frontend/src/hooks/useMyLoans.test.ts
@@ -12,6 +12,8 @@ vi.mock("../api/client", () => ({
 const activeLoan: ActiveLoan = {
   loan_id: 7,
   game_id: 1,
+  game_slug: "catan",
+  item_type: "boardgame",
   game_name: "Catan",
   game_thumbnail_url: "https://example.com/catan.jpg",
   game_image_url: "https://example.com/catan-large.jpg",

--- a/frontend/src/lib/activeLoan.test.ts
+++ b/frontend/src/lib/activeLoan.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { getLoanDetailPath, isLoanAtLeastThirtyDaysOld } from "./activeLoan";
+
+const NOW = new Date("2026-08-17T12:00:00Z");
+
+describe("getLoanDetailPath", () => {
+  it("routes board games to the board-game detail page", () => {
+    expect(getLoanDetailPath("boardgame", "catan")).toEqual("/juegos/catan");
+  });
+
+  it("routes RPG items to the RPG detail page", () => {
+    expect(getLoanDetailPath("rpgitem", "dungeons-dragons")).toEqual(
+      "/rol/dungeons-dragons",
+    );
+  });
+});
+
+describe("isLoanAtLeastThirtyDaysOld", () => {
+  it("does not mark a loan at 29 days and 23 hours 59 minutes", () => {
+    expect(isLoanAtLeastThirtyDaysOld("2026-07-18T12:01:00Z", NOW)).toEqual(
+      false,
+    );
+  });
+
+  it("marks a loan at exactly 30 complete elapsed UTC days", () => {
+    expect(isLoanAtLeastThirtyDaysOld("2026-07-18T12:00:00Z", NOW)).toEqual(
+      true,
+    );
+  });
+
+  it("marks a loan older than 30 days", () => {
+    expect(isLoanAtLeastThirtyDaysOld("2026-06-01T08:30:00Z", NOW)).toEqual(
+      true,
+    );
+  });
+
+  it("does not mark an invalid timestamp", () => {
+    expect(isLoanAtLeastThirtyDaysOld("not-a-date", NOW)).toEqual(false);
+  });
+
+  it("does not mark a future timestamp", () => {
+    expect(isLoanAtLeastThirtyDaysOld("2026-08-18T12:00:00Z", NOW)).toEqual(
+      false,
+    );
+  });
+});

--- a/frontend/src/lib/activeLoan.ts
+++ b/frontend/src/lib/activeLoan.ts
@@ -1,0 +1,31 @@
+import type { ActiveLoanItemType } from "../types/loan";
+
+const THIRTY_DAYS_IN_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
+
+export function getLoanDetailPath(
+  itemType: ActiveLoanItemType,
+  slug: string,
+): string {
+  const catalogPath = itemType === "boardgame" ? "juegos" : "rol";
+  return `/${catalogPath}/${slug}`;
+}
+
+export function isLoanAtLeastThirtyDaysOld(
+  borrowedAt: string,
+  now = new Date(),
+): boolean {
+  const borrowedAtMilliseconds = Date.parse(borrowedAt);
+  const nowMilliseconds = now.getTime();
+
+  if (
+    !Number.isFinite(borrowedAtMilliseconds) ||
+    !Number.isFinite(nowMilliseconds) ||
+    borrowedAtMilliseconds > nowMilliseconds
+  ) {
+    return false;
+  }
+
+  return (
+    nowMilliseconds - borrowedAtMilliseconds >= THIRTY_DAYS_IN_MILLISECONDS
+  );
+}

--- a/frontend/src/lib/loanFeedback.test.ts
+++ b/frontend/src/lib/loanFeedback.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getForcedReturnFeedback } from "./loanFeedback";
+
+describe("getForcedReturnFeedback", () => {
+  it("returns polite status feedback when the forced-return email is sent", () => {
+    expect(getForcedReturnFeedback(true)).toEqual({
+      message:
+        "Devolución forzada. Se ha avisado por correo a la persona que tenía el préstamo.",
+      variant: "status",
+    });
+  });
+
+  it("returns warning feedback when the forced-return email cannot be sent", () => {
+    expect(getForcedReturnFeedback(false)).toEqual({
+      message:
+        "La devolución se ha registrado, pero no se pudo enviar el correo de aviso.",
+      variant: "warning",
+    });
+  });
+
+  it("returns no feedback for an ordinary borrower return", () => {
+    expect(getForcedReturnFeedback(null)).toBeNull();
+  });
+});

--- a/frontend/src/lib/loanFeedback.ts
+++ b/frontend/src/lib/loanFeedback.ts
@@ -1,0 +1,21 @@
+export type LoanFeedbackVariant = "status" | "warning";
+
+export interface LoanFeedback {
+  readonly message: string;
+  readonly variant: LoanFeedbackVariant;
+}
+
+const FORCED_RETURN_SUCCESS_MESSAGE =
+  "Devolución forzada. Se ha avisado por correo a la persona que tenía el préstamo.";
+const FORCED_RETURN_WARNING_MESSAGE =
+  "La devolución se ha registrado, pero no se pudo enviar el correo de aviso.";
+
+export function getForcedReturnFeedback(
+  emailSent: boolean | null,
+): LoanFeedback | null {
+  if (emailSent === null) return null;
+
+  return emailSent
+    ? { message: FORCED_RETURN_SUCCESS_MESSAGE, variant: "status" }
+    : { message: FORCED_RETURN_WARNING_MESSAGE, variant: "warning" };
+}

--- a/frontend/src/pages/AdminMembersPage.css
+++ b/frontend/src/pages/AdminMembersPage.css
@@ -143,12 +143,25 @@
 }
 
 .admin-th-sortable {
-  cursor: pointer;
   user-select: none;
 }
 
-.admin-th-sortable:hover {
+.admin-sort-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.admin-sort-button:hover {
   color: var(--color-primary);
+}
+
+.admin-sort-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: var(--space-xs);
 }
 
 .admin-table tbody tr:last-child td {
@@ -177,6 +190,16 @@
 .admin-badge--inactive {
   background-color: var(--color-lent);
   color: var(--color-warning);
+}
+
+.admin-badge--administrator {
+  background-color: var(--color-text-heading);
+  color: var(--color-brand-contrast);
+}
+
+.admin-badge--member {
+  background-color: var(--color-surface-alt);
+  color: var(--color-text-heading);
 }
 
 /* Actions cell */

--- a/frontend/src/pages/AdminMembersPage.test.tsx
+++ b/frontend/src/pages/AdminMembersPage.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminMembersPage } from "./AdminMembersPage";
-import type { ImportMembersResponse } from "../types/admin";
+import type { AdminMember, ImportMembersResponse } from "../types/admin";
 
 const useAuthMock = vi.fn();
 const apiFetchMock = vi.fn();
@@ -48,6 +48,35 @@ const guardedImport: ImportMembersResponse = {
   deactivation_skip_reason:
     "No se desactivaron socios porque el archivo contiene muy pocos registros.",
 };
+
+const roleMembers: readonly AdminMember[] = [
+  {
+    id: 1,
+    member_number: 10,
+    first_name: "Alex",
+    last_name: "Socio",
+    nickname: null,
+    display_name: "Alex Socio",
+    email: "alex@example.invalid",
+    phone: null,
+    is_admin: false,
+    is_active: true,
+    active_loan_count: 0,
+  },
+  {
+    id: 2,
+    member_number: 20,
+    first_name: "Nora",
+    last_name: "Admin",
+    nickname: null,
+    display_name: "Nora Admin",
+    email: "nora@example.invalid",
+    phone: null,
+    is_admin: true,
+    is_active: true,
+    active_loan_count: 1,
+  },
+];
 
 function renderPage() {
   return render(<AdminMembersPage />);
@@ -97,7 +126,10 @@ describe("AdminMembersPage CSV reconciliation", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(apiUploadMock).toHaveBeenCalledTimes(1);
-    expect(apiUploadMock).toHaveBeenCalledWith(IMPORT_PATH, expect.any(FormData));
+    expect(apiUploadMock).toHaveBeenCalledWith(
+      IMPORT_PATH,
+      expect.any(FormData),
+    );
 
     const uploadedForm = apiUploadMock.mock.calls[0][1] as FormData;
     expect(uploadedForm.get("file")).toBe(file);
@@ -122,13 +154,78 @@ describe("AdminMembersPage CSV reconciliation", () => {
       "Aviso de seguridad: No se desactivaron socios porque el archivo contiene muy pocos registros.",
     );
     expect(
-      screen.queryByText(/Ningún socio nuevo \(socios existentes actualizados\)/),
+      screen.queryByText(
+        /Ningún socio nuevo \(socios existentes actualizados\)/,
+      ),
     ).toBeNull();
     expect(apiUploadMock).toHaveBeenCalledTimes(1);
-    expect(apiUploadMock).toHaveBeenCalledWith(IMPORT_PATH, expect.any(FormData));
+    expect(apiUploadMock).toHaveBeenCalledWith(
+      IMPORT_PATH,
+      expect.any(FormData),
+    );
 
     const uploadedForm = apiUploadMock.mock.calls[0][1] as FormData;
     expect(uploadedForm.get("file")).toBe(file);
     await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("AdminMembersPage member roles", () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    apiFetchMock.mockReset();
+    apiUploadMock.mockReset();
+    useAuthMock.mockReturnValue({
+      member: {
+        id: 99,
+        display_name: "Admin User",
+        email: "admin@example.invalid",
+        is_admin: true,
+      },
+      loading: false,
+    });
+    apiFetchMock.mockResolvedValue(roleMembers);
+  });
+
+  it("renders each explicit role label in its member row as accessible cell text", async () => {
+    renderPage();
+
+    const adminRow = await screen.findByRole("row", { name: /Nora Admin/ });
+    const memberRow = screen.getByRole("row", { name: /Alex Socio/ });
+
+    expect(
+      within(adminRow).getByRole("cell", { name: "Administrador" }),
+    ).toHaveTextContent("Administrador");
+    expect(
+      within(memberRow).getByRole("cell", { name: "Socio" }),
+    ).toHaveTextContent("Socio");
+  });
+
+  it("sorts roles in both directions from the accessible Rol header", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const roleButton = await screen.findByRole("button", { name: "Rol" });
+    const roleHeader = screen.getByRole("columnheader", { name: "Rol" });
+
+    await user.click(roleButton);
+
+    expect(roleHeader).toHaveAttribute("aria-sort", "ascending");
+    expect(
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((row) => within(row).getAllByRole("cell")[0]?.textContent),
+    ).toEqual(["Nora Admin", "Alex Socio"]);
+
+    await user.click(roleButton);
+
+    expect(roleHeader).toHaveAttribute("aria-sort", "descending");
+    expect(
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((row) => within(row).getAllByRole("cell")[0]?.textContent),
+    ).toEqual(["Alex Socio", "Nora Admin"]);
   });
 });

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -42,14 +42,18 @@ export function AdminMembersPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const [tokenBanner, setTokenBanner] = useState<{ url: string; label: string } | null>(null);
+  const [tokenBanner, setTokenBanner] = useState<{
+    url: string;
+    label: string;
+  } | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [sortKey, setSortKey] = useState<keyof AdminMember>("display_name");
   const [sortAsc, setSortAsc] = useState(true);
   const [editTarget, setEditTarget] = useState<AdminMember | null>(null);
   const [importing, setImporting] = useState(false);
-  const [importResult, setImportResult] = useState<ImportMembersResponse | null>(null);
+  const [importResult, setImportResult] =
+    useState<ImportMembersResponse | null>(null);
   const [showImportHelp, setShowImportHelp] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -75,7 +79,17 @@ export function AdminMembersPage() {
       return sortAsc ? av - bv : bv - av;
     }
     if (typeof av === "boolean" && typeof bv === "boolean") {
-      return sortAsc ? (av === bv ? 0 : av ? -1 : 1) : (av === bv ? 0 : av ? 1 : -1);
+      return sortAsc
+        ? av === bv
+          ? 0
+          : av
+            ? -1
+            : 1
+        : av === bv
+          ? 0
+          : av
+            ? 1
+            : -1;
     }
     return 0;
   });
@@ -86,7 +100,9 @@ export function AdminMembersPage() {
       setMembers(data);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Error cargando los socios.");
+      setError(
+        err instanceof Error ? err.message : "Error cargando los socios.",
+      );
     } finally {
       setLoading(false);
     }
@@ -107,7 +123,9 @@ export function AdminMembersPage() {
       });
       await fetchMembers();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Error actualizando el estado.");
+      setError(
+        err instanceof Error ? err.message : "Error actualizando el estado.",
+      );
     } finally {
       setActionLoading(null);
     }
@@ -120,7 +138,7 @@ export function AdminMembersPage() {
     try {
       const res = await apiFetch<SendLinkResponse>(
         `/admin/members/${m.id}/send-access-link`,
-        { method: "POST" }
+        { method: "POST" },
       );
       if (res.email_sent) {
         setSuccessMessage(`Correo enviado a ${m.email}`);
@@ -131,7 +149,9 @@ export function AdminMembersPage() {
         });
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Error enviando el enlace.");
+      setError(
+        err instanceof Error ? err.message : "Error enviando el enlace.",
+      );
     } finally {
       setActionLoading(null);
     }
@@ -156,7 +176,7 @@ export function AdminMembersPage() {
       formData.append("file", file);
       const res = await apiUpload<ImportMembersResponse>(
         "/admin/members/import",
-        formData
+        formData,
       );
       setImportResult(res);
       void fetchMembers();
@@ -176,7 +196,9 @@ export function AdminMembersPage() {
       setEditTarget(null);
       await fetchMembers();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Error actualizando el socio.");
+      setError(
+        err instanceof Error ? err.message : "Error actualizando el socio.",
+      );
     }
   };
 
@@ -200,6 +222,7 @@ export function AdminMembersPage() {
     ["display_name", "Nombre"],
     ["email", "Email"],
     ["member_number", "Nº Socio"],
+    ["is_admin", "Rol"],
     ["is_active", "Estado"],
     ["active_loan_count", "Préstamos activos"],
   ];
@@ -278,7 +301,9 @@ export function AdminMembersPage() {
           <ul className="admin-import-list">
             {importResult.created.map((imported) => (
               <li key={imported.email} className="admin-import-item">
-                <span className="admin-import-name">{imported.display_name}</span>
+                <span className="admin-import-name">
+                  {imported.display_name}
+                </span>
                 <div className="admin-token-url">
                   <code>{imported.token_url}</code>
                   <Button
@@ -324,9 +349,24 @@ export function AdminMembersPage() {
                   <th
                     key={key}
                     className="admin-th-sortable"
-                    onClick={() => handleSort(key)}
+                    aria-sort={
+                      sortKey === key
+                        ? sortAsc
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
                   >
-                    {label} {sortKey === key ? (sortAsc ? "▲" : "▼") : ""}
+                    <button
+                      type="button"
+                      className="admin-sort-button"
+                      onClick={() => handleSort(key)}
+                    >
+                      {label}
+                      {sortKey === key && (
+                        <span aria-hidden="true"> {sortAsc ? "▲" : "▼"}</span>
+                      )}
+                    </button>
                   </th>
                 ))}
                 <th>Acciones</th>
@@ -341,7 +381,20 @@ export function AdminMembersPage() {
                   <td>
                     <span
                       className={`admin-badge ${
-                        m.is_active ? "admin-badge--active" : "admin-badge--inactive"
+                        m.is_admin
+                          ? "admin-badge--administrator"
+                          : "admin-badge--member"
+                      }`}
+                    >
+                      {m.is_admin ? "Administrador" : "Socio"}
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      className={`admin-badge ${
+                        m.is_active
+                          ? "admin-badge--active"
+                          : "admin-badge--inactive"
                       }`}
                     >
                       {m.is_active ? "Activo" : "Desactivado"}
@@ -405,12 +458,13 @@ export function AdminMembersPage() {
               administrador que realiza la importación siempre queda protegido.
             </li>
             <li>
-              Los archivos vacíos o sospechosamente pequeños no desactivan socios
-              ausentes: la importación muestra un aviso de seguridad en ese caso.
+              Los archivos vacíos o sospechosamente pequeños no desactivan
+              socios ausentes: la importación muestra un aviso de seguridad en
+              ese caso.
             </li>
             <li>
-              Los socios nuevos reciben un enlace para establecer su
-              contraseña, que se muestra tras la importación.
+              Los socios nuevos reciben un enlace para establecer su contraseña,
+              que se muestra tras la importación.
             </li>
             <li>
               La columna <code>admin</code> con valor <code>yes</code> marca al
@@ -418,10 +472,9 @@ export function AdminMembersPage() {
               existentes conservan su estado de administrador).
             </li>
             <li>
-              La columna <code>Pagada</code> con valor <code>No</code> marca
-              al socio como inactivo (no ha pagado la cuota). Cualquier otro
-              valor (<code>Sí</code>, <code>Honorífic</code> o vacío) lo deja
-              activo.
+              La columna <code>Pagada</code> con valor <code>No</code> marca al
+              socio como inactivo (no ha pagado la cuota). Cualquier otro valor
+              (<code>Sí</code>, <code>Honorífic</code> o vacío) lo deja activo.
             </li>
           </ul>
           <div className="admin-import-help-actions">
@@ -490,7 +543,9 @@ function CreateMemberForm({ onCreated, onCancel }: CreateMemberFormProps) {
       });
       onCreated(res);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : "Error creando el socio.");
+      setFormError(
+        err instanceof Error ? err.message : "Error creando el socio.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -616,11 +671,11 @@ function EditMemberDialog({ member, onSave, onClose }: EditMemberDialogProps) {
   const [nickname, setNickname] = useState(member.nickname ?? "");
   const [phone, setPhone] = useState(member.phone ?? "");
   const [memberNumber, setMemberNumber] = useState(
-    member.member_number !== null ? String(member.member_number) : ""
+    member.member_number !== null ? String(member.member_number) : "",
   );
   const [lastPayment, setLastPayment] = useState(member.last_payment ?? "");
   const [gender, setGender] = useState<MemberGender>(
-    (member.gender as MemberGender | undefined | null) ?? ""
+    (member.gender as MemberGender | undefined | null) ?? "",
   );
   const [isAdmin, setIsAdmin] = useState(member.is_admin);
   const [formError, setFormError] = useState<string | null>(null);

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -37,6 +37,8 @@ const RETURN_CTA = "Devolver";
 const FORCE_RETURN_CTA = "Forzar devolución";
 const BORROW_SUCCESS_MESSAGE =
   "El préstamo no tiene fecha límite, pero haz un uso responsable: devuélvelo cuando hayas jugado o si finalmente no vas a usarlo.";
+const FORCED_RETURN_SUCCESS_MESSAGE =
+  "Devolución forzada. Se ha avisado por correo a la persona que tenía el préstamo.";
 const LOGIN_LINK = "Iniciar sesión";
 const HISTORY_HEADING = /Historial de préstamos y comentarios/i;
 
@@ -144,6 +146,13 @@ function renderPage() {
       </MemoryRouter>
     </CatalogModeProvider>,
   );
+}
+
+async function confirmReturn(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: label }));
+  const buttons = screen.getAllByRole("button", { name: label });
+  await user.click(buttons[buttons.length - 1]);
 }
 
 describe("GameDetailPage borrow CTA", () => {
@@ -287,6 +296,12 @@ describe("GameDetailPage borrower visibility", () => {
 });
 
 describe("GameDetailPage return CTA", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({ forced_return_email_sent: null });
+  });
+
   it("labels the trigger and confirmation 'Devolver' for the borrower", async () => {
     setHook({
       game: {
@@ -310,9 +325,7 @@ describe("GameDetailPage return CTA", () => {
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("labels the trigger and confirmation 'Forzar devolución' for an admin returning another member's loan", async () => {
@@ -357,9 +370,7 @@ describe("GameDetailPage return CTA", () => {
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -376,9 +387,7 @@ describe("GameDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("does not infer ownership from a duplicate display name", () => {
@@ -396,9 +405,27 @@ describe("GameDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
+  });
+
+  it("shows a polite status when a forced-return email is sent", async () => {
+    apiFetchMock.mockResolvedValue({ forced_return_email_sent: true });
+    setHook({
+      game: {
+        ...game,
+        status: "lent",
+        borrower_display_name: "Bob Jones",
+        loan_id: 7,
+      },
+    });
+    setMember(admin);
+
+    renderPage();
+    await confirmReturn(FORCE_RETURN_CTA);
+
+    const feedback = await screen.findByRole("status");
+    expect(feedback).toHaveTextContent(FORCED_RETURN_SUCCESS_MESSAGE);
+    expect(feedback).toHaveAttribute("aria-live", "polite");
   });
 });
 

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -10,9 +10,11 @@ import { useGameHistory } from "../hooks/useGameHistory";
 import { useMyLoans } from "../hooks/useMyLoans";
 import { displayDescription } from "../lib/description";
 import {
-  BORROW_SUCCESS_MESSAGE,
-  getReturnAction,
-} from "../lib/loanActions";
+  getForcedReturnFeedback,
+  type LoanFeedback,
+} from "../lib/loanFeedback";
+import { BORROW_SUCCESS_MESSAGE, getReturnAction } from "../lib/loanActions";
+import type { ReturnLoanResponse } from "../types/loan";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
 import "./GameDetailPage.css";
@@ -33,7 +35,7 @@ export function GameDetailPage() {
     | null
   >(null);
   const [acting, setActing] = useState(false);
-  const [loanFeedback, setLoanFeedback] = useState<string | null>(null);
+  const [loanFeedback, setLoanFeedback] = useState<LoanFeedback | null>(null);
 
   if (loading) {
     return (
@@ -75,7 +77,7 @@ export function GameDetailPage() {
         method: "POST",
         body: JSON.stringify({ game_id: gameId }),
       });
-      setLoanFeedback(BORROW_SUCCESS_MESSAGE);
+      setLoanFeedback({ message: BORROW_SUCCESS_MESSAGE, variant: "status" });
       refetch();
       refetchMyLoans();
     } catch {
@@ -89,9 +91,13 @@ export function GameDetailPage() {
   const handleReturn = async () => {
     setActing(true);
     try {
-      await apiFetch<unknown>(`/loans/${game.loan_id}/return`, {
-        method: "PATCH",
-      });
+      const result = await apiFetch<ReturnLoanResponse>(
+        `/loans/${game.loan_id}/return`,
+        {
+          method: "PATCH",
+        },
+      );
+      setLoanFeedback(getForcedReturnFeedback(result.forced_return_email_sent));
       refetch();
       refetchMyLoans();
     } catch {
@@ -190,7 +196,10 @@ export function GameDetailPage() {
             )}
           </div>
 
-          <LoanActionFeedback message={loanFeedback} />
+          <LoanActionFeedback
+            message={loanFeedback?.message ?? null}
+            variant={loanFeedback?.variant}
+          />
 
           <div className="game-detail-bgg">
             <a

--- a/frontend/src/pages/MyLoansPage.css
+++ b/frontend/src/pages/MyLoansPage.css
@@ -4,7 +4,13 @@
   margin: 0 auto;
 }
 
-/* Page title rendered via the shared PageTitle component (Figma Title H1). */
+.my-loans-guidance {
+  max-width: 42rem;
+  margin: calc(-1 * var(--space-md)) auto var(--space-xl);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+  text-align: center;
+}
 
 .my-loans-list {
   display: flex;
@@ -31,20 +37,45 @@
   flex-shrink: 0;
 }
 
+.my-loans-cover-link {
+  display: block;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+}
+
+.my-loans-cover-link:focus-visible,
+.my-loans-name:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .my-loans-info {
   flex: 1;
   min-width: 0;
 }
 
 .my-loans-name {
-  font-weight: 600;
+  display: inline-block;
+  font-weight: var(--font-weight-bold);
   font-size: var(--font-size-md);
   margin-bottom: var(--space-xs);
+  color: var(--color-text);
 }
 
 .my-loans-date {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+}
+
+.my-loans-age-notice {
+  display: inline-block;
+  margin: var(--space-sm) 0 0;
+  padding: var(--space-xs) var(--space-sm);
+  border-left: 3px solid var(--color-primary);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
 }
 
 .my-loans-empty {
@@ -75,7 +106,7 @@
     flex-wrap: wrap;
   }
 
-  .my-loans-item .btn {
+  .my-loans-return {
     width: 100%;
   }
 }

--- a/frontend/src/pages/MyLoansPage.test.tsx
+++ b/frontend/src/pages/MyLoansPage.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActiveLoan } from "../types/loan";
+import { BORROW_SUCCESS_MESSAGE } from "../lib/loanActions";
+import { MyLoansPage } from "./MyLoansPage";
+
+const useMyLoansMock = vi.fn();
+
+vi.mock("../hooks/useMyLoans", () => ({
+  useMyLoans: () => useMyLoansMock(),
+}));
+
+const BOARD_GAME_LOAN: ActiveLoan = {
+  loan_id: 7,
+  game_id: 1,
+  game_slug: "catan",
+  item_type: "boardgame",
+  game_name: "Catan",
+  game_thumbnail_url: "https://example.com/catan.jpg",
+  game_image_url: "https://example.com/catan-large.jpg",
+  borrowed_at: "2026-08-10T12:00:00Z",
+};
+
+const RPG_LOAN: ActiveLoan = {
+  ...BOARD_GAME_LOAN,
+  loan_id: 8,
+  game_id: 2,
+  game_slug: "dungeons-dragons",
+  item_type: "rpgitem",
+  game_name: "Dungeons & Dragons",
+};
+
+function renderPage(loans: readonly ActiveLoan[]) {
+  useMyLoansMock.mockReturnValue({
+    loans,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+
+  return render(
+    <MemoryRouter>
+      <MyLoansPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-17T12:00:00Z"));
+});
+
+describe("MyLoansPage guidance", () => {
+  it("places the responsible-use guidance directly below the title in the empty state", () => {
+    renderPage([]);
+
+    const title = screen.getByRole("heading", { name: "Mis préstamos" });
+    const guidance = screen.getByText(BORROW_SUCCESS_MESSAGE);
+
+    expect(title.nextElementSibling).toEqual(guidance);
+    expect(
+      screen.getByText("No tienes ningún juego en préstamo."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("MyLoansPage item links", () => {
+  it("links a board-game cover and title to its board-game detail page", () => {
+    renderPage([BOARD_GAME_LOAN]);
+
+    expect(
+      screen.getByRole("link", { name: "Ver detalles de Catan" }),
+    ).toHaveAttribute("href", "/juegos/catan");
+    expect(screen.getByRole("link", { name: "Catan" })).toHaveAttribute(
+      "href",
+      "/juegos/catan",
+    );
+    expect(
+      screen.getByRole("button", { name: "Devolver" }).closest("a"),
+    ).toEqual(null);
+  });
+
+  it("links an RPG cover and title to its RPG detail page", () => {
+    renderPage([RPG_LOAN]);
+
+    expect(
+      screen.getByRole("link", { name: "Ver detalles de Dungeons & Dragons" }),
+    ).toHaveAttribute("href", "/rol/dungeons-dragons");
+    expect(
+      screen.getByRole("link", { name: "Dungeons & Dragons" }),
+    ).toHaveAttribute("href", "/rol/dungeons-dragons");
+  });
+});
+
+describe("MyLoansPage age notice", () => {
+  it("shows the informational label for a loan at exactly 30 days", () => {
+    renderPage([{ ...BOARD_GAME_LOAN, borrowed_at: "2026-07-18T12:00:00Z" }]);
+
+    expect(
+      screen.getByText("Lleva 30 días o más en préstamo."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the informational label before 30 complete days", () => {
+    renderPage([{ ...BOARD_GAME_LOAN, borrowed_at: "2026-07-18T12:01:00Z" }]);
+
+    expect(screen.queryByText("Lleva 30 días o más en préstamo.")).toEqual(
+      null,
+    );
+  });
+});

--- a/frontend/src/pages/MyLoansPage.tsx
+++ b/frontend/src/pages/MyLoansPage.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { useMyLoans } from "../hooks/useMyLoans";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { Button } from "../ui/Button";
 import { PageTitle } from "../ui/PageTitle";
 import { apiFetch } from "../api/client";
+import {
+  getLoanDetailPath,
+  isLoanAtLeastThirtyDaysOld,
+} from "../lib/activeLoan";
+import { BORROW_SUCCESS_MESSAGE } from "../lib/loanActions";
 import type { ActiveLoan } from "../types/loan";
 import "./MyLoansPage.css";
 
@@ -35,53 +41,61 @@ export function MyLoansPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="my-loans-page">
-        <PageTitle>Mis préstamos</PageTitle>
-        <p className="my-loans-loading">Cargando...</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="my-loans-page">
-        <PageTitle>Mis préstamos</PageTitle>
-        <p className="my-loans-error">{error}</p>
-      </div>
-    );
-  }
-
   return (
     <div className="my-loans-page">
       <PageTitle>Mis préstamos</PageTitle>
+      <p className="my-loans-guidance">{BORROW_SUCCESS_MESSAGE}</p>
 
-      {loans.length === 0 ? (
+      {loading ? (
+        <p className="my-loans-loading">Cargando...</p>
+      ) : error ? (
+        <p className="my-loans-error">{error}</p>
+      ) : loans.length === 0 ? (
         <p className="my-loans-empty">No tienes ningún juego en préstamo.</p>
       ) : (
         <div className="my-loans-list">
-          {loans.map((loan) => (
-            <div key={loan.loan_id} className="my-loans-item">
-              <img
-                className="my-loans-thumbnail"
-                src={loan.game_thumbnail_url}
-                alt={loan.game_name}
-                loading="lazy"
-              />
-              <div className="my-loans-info">
-                <div className="my-loans-name">{loan.game_name}</div>
-                <div className="my-loans-date">{`Tomado prestado el ${formatDate(loan.borrowed_at)}`}</div>
-              </div>
-              <Button
-                variant="secondary"
-                onClick={() => setReturning(loan)}
-                disabled={actionLoading}
-              >
-                Devolver
-              </Button>
-            </div>
-          ))}
+          {loans.map((loan) => {
+            const detailPath = getLoanDetailPath(
+              loan.item_type,
+              loan.game_slug,
+            );
+
+            return (
+              <article key={loan.loan_id} className="my-loans-item">
+                <Link
+                  to={detailPath}
+                  className="my-loans-cover-link"
+                  aria-label={`Ver detalles de ${loan.game_name}`}
+                >
+                  <img
+                    className="my-loans-thumbnail"
+                    src={loan.game_thumbnail_url}
+                    alt=""
+                    loading="lazy"
+                  />
+                </Link>
+                <div className="my-loans-info">
+                  <Link to={detailPath} className="my-loans-name">
+                    {loan.game_name}
+                  </Link>
+                  <div className="my-loans-date">{`Tomado prestado el ${formatDate(loan.borrowed_at)}`}</div>
+                  {isLoanAtLeastThirtyDaysOld(loan.borrowed_at) && (
+                    <p className="my-loans-age-notice">
+                      Lleva 30 días o más en préstamo.
+                    </p>
+                  )}
+                </div>
+                <Button
+                  className="my-loans-return"
+                  variant="secondary"
+                  onClick={() => setReturning(loan)}
+                  disabled={actionLoading}
+                >
+                  Devolver
+                </Button>
+              </article>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/pages/RpgDetailPage.test.tsx
+++ b/frontend/src/pages/RpgDetailPage.test.tsx
@@ -36,6 +36,8 @@ const RETURN_CTA = "Devolver";
 const FORCE_RETURN_CTA = "Forzar devolución";
 const BORROW_SUCCESS_MESSAGE =
   "El préstamo no tiene fecha límite, pero haz un uso responsable: devuélvelo cuando hayas jugado o si finalmente no vas a usarlo.";
+const FORCED_RETURN_WARNING_MESSAGE =
+  "La devolución se ha registrado, pero no se pudo enviar el correo de aviso.";
 const LOGIN_LINK = "Iniciar sesión";
 const HISTORY_HEADING = /Historial de préstamos y comentarios/i;
 
@@ -135,6 +137,13 @@ function renderPage() {
       </Routes>
     </MemoryRouter>,
   );
+}
+
+async function confirmReturn(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: label }));
+  const buttons = screen.getAllByRole("button", { name: label });
+  await user.click(buttons[buttons.length - 1]);
 }
 
 describe("RpgDetailPage loading state", () => {
@@ -294,6 +303,12 @@ describe("RpgDetailPage borrower visibility", () => {
 });
 
 describe("RpgDetailPage return CTA", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({ forced_return_email_sent: null });
+  });
+
   it("labels the trigger and confirmation 'Devolver' for the borrower", async () => {
     setHook({
       item: {
@@ -317,9 +332,7 @@ describe("RpgDetailPage return CTA", () => {
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("labels the trigger and confirmation 'Forzar devolución' for an admin returning another member's loan", async () => {
@@ -364,9 +377,7 @@ describe("RpgDetailPage return CTA", () => {
     expect(
       screen.getByRole("button", { name: RETURN_CTA }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("hides the return CTA from a non-admin who is not the borrower", () => {
@@ -383,9 +394,7 @@ describe("RpgDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("does not infer ownership from a duplicate display name", () => {
@@ -403,16 +412,10 @@ describe("RpgDetailPage return CTA", () => {
     renderPage();
 
     expect(screen.queryByRole("button", { name: RETURN_CTA })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: FORCE_RETURN_CTA }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: FORCE_RETURN_CTA })).toBeNull();
   });
 
   it("calls PATCH /loans/{loan_id}/return and refetches after confirming return", async () => {
-    refetch.mockReset();
-    apiFetchMock.mockReset();
-    apiFetchMock.mockResolvedValue({});
-
     setHook({
       item: {
         ...item,
@@ -435,6 +438,27 @@ describe("RpgDetailPage return CTA", () => {
       method: "PATCH",
     });
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an alert when a forced-return email cannot be sent", async () => {
+    apiFetchMock.mockResolvedValue({ forced_return_email_sent: false });
+    setHook({
+      item: {
+        ...item,
+        status: "lent",
+        borrower_display_name: "Bob Jones",
+        loan_id: 7,
+      },
+    });
+    setMember(admin);
+
+    renderPage();
+    await confirmReturn(FORCE_RETURN_CTA);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      FORCED_RETURN_WARNING_MESSAGE,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
   });
 });
 

--- a/frontend/src/pages/RpgDetailPage.tsx
+++ b/frontend/src/pages/RpgDetailPage.tsx
@@ -9,9 +9,11 @@ import { useRpgHistory } from "../hooks/useRpgHistory";
 import { useMyLoans } from "../hooks/useMyLoans";
 import { displayDescription } from "../lib/description";
 import {
-  BORROW_SUCCESS_MESSAGE,
-  getReturnAction,
-} from "../lib/loanActions";
+  getForcedReturnFeedback,
+  type LoanFeedback,
+} from "../lib/loanFeedback";
+import { BORROW_SUCCESS_MESSAGE, getReturnAction } from "../lib/loanActions";
+import type { ReturnLoanResponse } from "../types/loan";
 import { Badge } from "../ui/Badge";
 import { Button } from "../ui/Button";
 import "./RpgDetailPage.css";
@@ -32,7 +34,7 @@ export function RpgDetailPage() {
     | null
   >(null);
   const [acting, setActing] = useState(false);
-  const [loanFeedback, setLoanFeedback] = useState<string | null>(null);
+  const [loanFeedback, setLoanFeedback] = useState<LoanFeedback | null>(null);
 
   if (loading) {
     return (
@@ -70,7 +72,7 @@ export function RpgDetailPage() {
         method: "POST",
         body: JSON.stringify({ game_id: itemId }),
       });
-      setLoanFeedback(BORROW_SUCCESS_MESSAGE);
+      setLoanFeedback({ message: BORROW_SUCCESS_MESSAGE, variant: "status" });
       refetch();
       refetchMyLoans();
     } catch {
@@ -84,9 +86,13 @@ export function RpgDetailPage() {
   const handleReturn = async () => {
     setActing(true);
     try {
-      await apiFetch<unknown>(`/loans/${item.loan_id}/return`, {
-        method: "PATCH",
-      });
+      const result = await apiFetch<ReturnLoanResponse>(
+        `/loans/${item.loan_id}/return`,
+        {
+          method: "PATCH",
+        },
+      );
+      setLoanFeedback(getForcedReturnFeedback(result.forced_return_email_sent));
       refetch();
       refetchMyLoans();
     } catch {
@@ -190,7 +196,10 @@ export function RpgDetailPage() {
             )}
           </div>
 
-          <LoanActionFeedback message={loanFeedback} />
+          <LoanActionFeedback
+            message={loanFeedback?.message ?? null}
+            variant={loanFeedback?.variant}
+          />
 
           <div className="rpg-detail-bgg">
             <a

--- a/frontend/src/types/loan.ts
+++ b/frontend/src/types/loan.ts
@@ -1,6 +1,12 @@
+export const ACTIVE_LOAN_ITEM_TYPES = ["boardgame", "rpgitem"] as const;
+
+export type ActiveLoanItemType = (typeof ACTIVE_LOAN_ITEM_TYPES)[number];
+
 export interface ActiveLoan {
   readonly loan_id: number;
   readonly game_id: number;
+  readonly game_slug: string;
+  readonly item_type: ActiveLoanItemType;
   readonly game_name: string;
   readonly game_thumbnail_url: string;
   readonly game_image_url: string;
@@ -11,4 +17,8 @@ export interface LoanHistoryEntry {
   readonly member_display_name: string | null;
   readonly borrowed_at: string;
   readonly returned_at: string | null;
+}
+
+export interface ReturnLoanResponse {
+  readonly forced_return_email_sent: boolean | null;
 }

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-admin-members-restyle/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-admin-members-restyle/spec.md
@@ -14,9 +14,33 @@ The system SHALL restyle `AdminMembersPage` to use the primitives and tokens fro
 
 #### Scenario: No new columns or actions
 - **WHEN** the restyled page is compared with the pre-redesign page
-- **THEN** the table columns SHALL be the same (member number, name, email, phone, admin flag, active flag, active loan count)
+- **THEN** the table SHALL retain the existing member, status, and active-loan information
 - **AND** the available actions SHALL be the same (toggle active, send link, resend link, delete)
 - **AND** no API endpoint under `/admin/members*` SHALL be added or removed
+
+### Requirement: Member roles are visible
+
+The admin member table SHALL include a `Rol` column. Each row SHALL display
+`Administrador` for administrators and `Socio` for other members. The `Rol`
+header SHALL provide a keyboard-operable sort control and expose its current
+direction through `aria-sort`.
+
+#### Scenario: Administrator row
+- **WHEN** an administrator views a member whose `is_admin` value is true
+- **THEN** the row's `Rol` cell SHALL display `Administrador`
+
+#### Scenario: Member row
+- **WHEN** an administrator views a member whose `is_admin` value is false
+- **THEN** the row's `Rol` cell SHALL display `Socio`
+
+#### Scenario: Sort by role in both directions
+- **WHEN** an administrator activates the `Rol` sort control for the first time
+- **THEN** `Administrador` rows SHALL appear before `Socio` rows
+- **AND** the column header SHALL expose `aria-sort="ascending"`
+- **WHEN** the administrator activates the same control again
+- **THEN** `Socio` rows SHALL appear before `Administrador` rows
+- **AND** the column header SHALL expose `aria-sort="descending"`
+- **AND** both activations SHALL be available by keyboard
 
 ### Requirement: Wraps in PageLayout
 

--- a/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-borrow-return-flow/spec.md
+++ b/openspec/changes/archive/2026-04-25-plan-lending-redesign/specs/lending-borrow-return-flow/spec.md
@@ -34,12 +34,20 @@ was returned. Loan API responses SHALL expose both timestamps.
 ### Requirement: MyLoansPage as cards
 
 The system SHALL render `MyLoansPage` as a list of cards, one per active loan,
-showing the game cover, title, borrow date, and a Return button. The Return
-button SHALL open a confirmation dialog and call the existing return endpoint.
+showing the game cover, title, borrow date, and a Return button. The cover and
+title SHALL link to the correct board-game or RPG detail page. The Return button
+SHALL open a confirmation dialog and call the existing return endpoint.
 
 #### Scenario: Active loan card content
-- **WHEN** an authenticated member opens `/prestamos/my-loans`
-- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, and a Return button
+- **WHEN** an authenticated member opens `/ludoteca/my-loans`
+- **THEN** each active loan SHALL render as a card with the game cover, title, borrowed date, and a Return button
+- **AND** the cover and title SHALL link to that item's detail page
+
+#### Scenario: Loan reaches 30 complete days
+- **GIVEN** an active loan has been open for at least 30 complete elapsed days
+- **WHEN** the member opens `/ludoteca/my-loans`
+- **THEN** the loan card SHALL show an informational marker
+- **AND** the marker SHALL NOT set a return deadline or restrict the loan
 
 #### Scenario: Returning a game
 - **WHEN** the member clicks Return on a loan card and confirms in the dialog
@@ -51,7 +59,7 @@ button SHALL open a confirmation dialog and call the existing return endpoint.
 The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans.
 
 #### Scenario: Member with no loans
-- **WHEN** an authenticated member with zero active loans opens `/prestamos/my-loans`
+- **WHEN** an authenticated member with zero active loans opens `/ludoteca/my-loans`
 - **THEN** the page SHALL display `No tienes ningún juego en préstamo.`
 
 ### Requirement: Responsible-use feedback after borrowing
@@ -64,6 +72,11 @@ it.
 #### Scenario: Successful borrow
 - **WHEN** an authenticated member successfully borrows an available board game or RPG book
 - **THEN** the detail page SHALL expose the responsible-use guidance through a polite live status
+
+#### Scenario: Member reviews active loans
+- **WHEN** an authenticated member opens `/ludoteca/my-loans`
+- **THEN** the page SHALL explain that loans have no deadline
+- **AND** it SHALL ask the member to return items responsibly
 
 ### Requirement: Return wording reflects who owns the loan
 
@@ -83,3 +96,26 @@ not the borrower SHALL not receive either action.
 #### Scenario: Unauthorised member views another member's loan
 - **WHEN** a non-administrator views a board game or RPG book borrowed by another member
 - **THEN** neither `Devolver` nor `Forzar devolución` SHALL be available
+
+### Requirement: Forced-return notification is best effort
+
+After an administrator returns another member's loan, the system SHALL try to
+email the borrower. The return SHALL remain registered whether the email is
+sent or fails. The detail page SHALL tell the administrator which outcome
+occurred.
+
+#### Scenario: Borrower email is sent
+- **WHEN** an administrator successfully forces the return of another member's loan
+- **AND** the borrower email is sent
+- **THEN** the loan SHALL remain returned
+- **AND** the detail page SHALL confirm that the borrower was notified
+
+#### Scenario: Borrower email cannot be sent
+- **WHEN** an administrator successfully forces the return of another member's loan
+- **AND** the borrower email is unavailable or cannot be sent
+- **THEN** the loan SHALL remain returned
+- **AND** the detail page SHALL warn that the notification failed
+
+#### Scenario: Member returns their own loan
+- **WHEN** a member returns their own loan
+- **THEN** the system SHALL NOT send a forced-return email

--- a/openspec/specs/lending-admin-members-restyle/spec.md
+++ b/openspec/specs/lending-admin-members-restyle/spec.md
@@ -15,9 +15,33 @@ The system SHALL restyle `AdminMembersPage` to use the primitives and tokens fro
 
 #### Scenario: No new columns or actions
 - **WHEN** the restyled page is compared with the pre-redesign page
-- **THEN** the table columns SHALL be the same (member number, name, email, phone, admin flag, active flag, active loan count)
+- **THEN** the table SHALL retain the existing member, status, and active-loan information
 - **AND** the available actions SHALL be the same (toggle active, send link, resend link, delete)
 - **AND** no API endpoint under `/admin/members*` SHALL be added or removed
+
+### Requirement: Member roles are visible
+
+The admin member table SHALL include a `Rol` column. Each row SHALL display
+`Administrador` for administrators and `Socio` for other members. The `Rol`
+header SHALL provide a keyboard-operable sort control and expose its current
+direction through `aria-sort`.
+
+#### Scenario: Administrator row
+- **WHEN** an administrator views a member whose `is_admin` value is true
+- **THEN** the row's `Rol` cell SHALL display `Administrador`
+
+#### Scenario: Member row
+- **WHEN** an administrator views a member whose `is_admin` value is false
+- **THEN** the row's `Rol` cell SHALL display `Socio`
+
+#### Scenario: Sort by role in both directions
+- **WHEN** an administrator activates the `Rol` sort control for the first time
+- **THEN** `Administrador` rows SHALL appear before `Socio` rows
+- **AND** the column header SHALL expose `aria-sort="ascending"`
+- **WHEN** the administrator activates the same control again
+- **THEN** `Socio` rows SHALL appear before `Administrador` rows
+- **AND** the column header SHALL expose `aria-sort="descending"`
+- **AND** both activations SHALL be available by keyboard
 
 ### Requirement: Wraps in PageLayout
 

--- a/openspec/specs/lending-borrow-return-flow/spec.md
+++ b/openspec/specs/lending-borrow-return-flow/spec.md
@@ -35,12 +35,20 @@ was returned. Loan API responses SHALL expose both timestamps.
 ### Requirement: MyLoansPage as cards
 
 The system SHALL render `MyLoansPage` as a list of cards, one per active loan,
-showing the game cover, title, borrow date, and a Return button. The Return
-button SHALL open a confirmation dialog and call the existing return endpoint.
+showing the game cover, title, borrow date, and a Return button. The cover and
+title SHALL link to the correct board-game or RPG detail page. The Return button
+SHALL open a confirmation dialog and call the existing return endpoint.
 
 #### Scenario: Active loan card content
-- **WHEN** an authenticated member opens `/prestamos/my-loans`
-- **THEN** for each active loan a card SHALL render with the game cover, title, borrowed date, and a Return button
+- **WHEN** an authenticated member opens `/ludoteca/my-loans`
+- **THEN** each active loan SHALL render as a card with the game cover, title, borrowed date, and a Return button
+- **AND** the cover and title SHALL link to that item's detail page
+
+#### Scenario: Loan reaches 30 complete days
+- **GIVEN** an active loan has been open for at least 30 complete elapsed days
+- **WHEN** the member opens `/ludoteca/my-loans`
+- **THEN** the loan card SHALL show an informational marker
+- **AND** the marker SHALL NOT set a return deadline or restrict the loan
 
 #### Scenario: Returning a game
 - **WHEN** the member clicks Return on a loan card and confirms in the dialog
@@ -52,7 +60,7 @@ button SHALL open a confirmation dialog and call the existing return endpoint.
 The system SHALL show a friendly empty state on `MyLoansPage` when the member has no active loans.
 
 #### Scenario: Member with no loans
-- **WHEN** an authenticated member with zero active loans opens `/prestamos/my-loans`
+- **WHEN** an authenticated member with zero active loans opens `/ludoteca/my-loans`
 - **THEN** the page SHALL display `No tienes ningún juego en préstamo.`
 
 ### Requirement: Responsible-use feedback after borrowing
@@ -65,6 +73,11 @@ it.
 #### Scenario: Successful borrow
 - **WHEN** an authenticated member successfully borrows an available board game or RPG book
 - **THEN** the detail page SHALL expose the responsible-use guidance through a polite live status
+
+#### Scenario: Member reviews active loans
+- **WHEN** an authenticated member opens `/ludoteca/my-loans`
+- **THEN** the page SHALL explain that loans have no deadline
+- **AND** it SHALL ask the member to return items responsibly
 
 ### Requirement: Return wording reflects who owns the loan
 
@@ -84,3 +97,26 @@ not the borrower SHALL not receive either action.
 #### Scenario: Unauthorised member views another member's loan
 - **WHEN** a non-administrator views a board game or RPG book borrowed by another member
 - **THEN** neither `Devolver` nor `Forzar devolución` SHALL be available
+
+### Requirement: Forced-return notification is best effort
+
+After an administrator returns another member's loan, the system SHALL try to
+email the borrower. The return SHALL remain registered whether the email is
+sent or fails. The detail page SHALL tell the administrator which outcome
+occurred.
+
+#### Scenario: Borrower email is sent
+- **WHEN** an administrator successfully forces the return of another member's loan
+- **AND** the borrower email is sent
+- **THEN** the loan SHALL remain returned
+- **AND** the detail page SHALL confirm that the borrower was notified
+
+#### Scenario: Borrower email cannot be sent
+- **WHEN** an administrator successfully forces the return of another member's loan
+- **AND** the borrower email is unavailable or cannot be sent
+- **THEN** the loan SHALL remain returned
+- **AND** the detail page SHALL warn that the notification failed
+
+#### Scenario: Member returns their own loan
+- **WHEN** a member returns their own loan
+- **THEN** the system SHALL NOT send a forced-return email

--- a/tests/api/test_loans.py
+++ b/tests/api/test_loans.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.app import create_app
+from backend.api.auth import create_jwt
+from backend.api.dependencies import (
+    _settings,
+    get_db_conn,
+    get_game_repo,
+    get_loan_return_notifier,
+    get_member_repo,
+)
+from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
+from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepository
+from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
+from backend.domain.entities.game import Game
+from backend.domain.entities.member import Member
+from backend.migrations.runner import run_migrations
+
+
+class FakeNotifier:
+    def __init__(self, result: bool) -> None:
+        self.result = result
+        self.calls: list[tuple[str, str, str]] = []
+
+    def send_forced_return(
+        self, to_email: str, display_name: str, item_name: str
+    ) -> bool:
+        self.calls.append((to_email, display_name, item_name))
+        return self.result
+
+
+class RaisingGameRepository(SqliteGameRepository):
+    def get_by_id(self, game_id: int) -> Game | None:
+        raise RuntimeError("game lookup")
+
+
+class RaisingBorrowerMemberRepository(SqliteMemberRepository):
+    def __init__(self, conn: sqlite3.Connection, borrower_id: int) -> None:
+        super().__init__(conn)
+        self._borrower_id = borrower_id
+
+    def get_by_id(self, member_id: int) -> Member | None:
+        if member_id == self._borrower_id:
+            raise RuntimeError("member lookup")
+        return super().get_by_id(member_id)
+
+
+def _setup_client(
+    notifier: FakeNotifier | None = None,
+) -> tuple[TestClient, sqlite3.Connection]:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.row_factory = sqlite3.Row
+    run_migrations(conn)
+    app = create_app()
+
+    def override_db_conn():  # type: ignore[no-untyped-def]
+        yield conn
+
+    app.dependency_overrides[get_db_conn] = override_db_conn
+    if notifier is not None:
+        app.dependency_overrides[get_loan_return_notifier] = lambda: notifier
+    return TestClient(app), conn
+
+
+def _member(
+    repo: SqliteMemberRepository,
+    number: int,
+    *,
+    is_admin: bool = False,
+) -> Member:
+    return repo.upsert_by_email(
+        number,
+        f"Member {number}",
+        "User",
+        None,
+        None,
+        f"member{number}@example.invalid",
+        f"Member {number}",
+        is_admin,
+    )
+
+
+def _auth(member: Member) -> dict[str, str]:
+    return {"Cookie": f"session_token={create_jwt(member.id, _settings.jwt_secret)}"}
+
+
+class TestReturnLoanApi:
+    def test_borrower_return_reports_email_not_applicable(self) -> None:
+        notifier = FakeNotifier(True)
+        client, conn = _setup_client(notifier)
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        borrower = _member(SqliteMemberRepository(conn), 1)
+        loan = SqliteLoanRepository(conn).create(game.id, borrower.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(borrower))
+
+        assert response.status_code == 200
+        assert response.json()["forced_return_email_sent"] is None
+        assert notifier.calls == []
+        conn.close()
+
+    def test_admin_own_return_reports_email_not_applicable(self) -> None:
+        notifier = FakeNotifier(True)
+        client, conn = _setup_client(notifier)
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        admin = _member(SqliteMemberRepository(conn), 1, is_admin=True)
+        loan = SqliteLoanRepository(conn).create(game.id, admin.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(admin))
+
+        assert response.status_code == 200
+        assert response.json()["forced_return_email_sent"] is None
+        assert notifier.calls == []
+        conn.close()
+
+    def test_forced_return_reports_successful_email(self) -> None:
+        notifier = FakeNotifier(True)
+        client, conn = _setup_client(notifier)
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        member_repo = SqliteMemberRepository(conn)
+        borrower = _member(member_repo, 1)
+        admin = _member(member_repo, 2, is_admin=True)
+        loan = SqliteLoanRepository(conn).create(game.id, borrower.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(admin))
+
+        assert response.status_code == 200
+        assert response.json()["forced_return_email_sent"] is True
+        assert notifier.calls == [(borrower.email, borrower.display_name, game.name)]
+        conn.close()
+
+    def test_forced_return_reports_unavailable_email(self) -> None:
+        notifier = FakeNotifier(False)
+        client, conn = _setup_client(notifier)
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        member_repo = SqliteMemberRepository(conn)
+        borrower = _member(member_repo, 1)
+        admin = _member(member_repo, 2, is_admin=True)
+        loan_repo = SqliteLoanRepository(conn)
+        loan = loan_repo.create(game.id, borrower.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(admin))
+
+        assert response.status_code == 200
+        assert response.json()["forced_return_email_sent"] is False
+        assert loan_repo.get_by_id(loan.id).returned_at is not None  # type: ignore[union-attr]
+        conn.close()
+
+    @pytest.mark.parametrize("failing_lookup", ["member", "game"])
+    def test_forced_return_reports_false_when_notification_lookup_raises(
+        self, failing_lookup: str
+    ) -> None:
+        notifier = FakeNotifier(True)
+        client, conn = _setup_client(notifier)
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        member_repo = SqliteMemberRepository(conn)
+        borrower = _member(member_repo, 1)
+        admin = _member(member_repo, 2, is_admin=True)
+        loan_repo = SqliteLoanRepository(conn)
+        loan = loan_repo.create(game.id, borrower.id)
+        if failing_lookup == "member":
+            client.app.dependency_overrides[get_member_repo] = lambda: (  # type: ignore[attr-defined]
+                RaisingBorrowerMemberRepository(conn, borrower.id)
+            )
+        else:
+            client.app.dependency_overrides[get_game_repo] = lambda: (  # type: ignore[attr-defined]
+                RaisingGameRepository(conn)
+            )
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(admin))
+
+        persisted = loan_repo.get_by_id(loan.id)
+        assert response.status_code == 200
+        assert response.json()["forced_return_email_sent"] is False
+        assert persisted is not None
+        assert persisted.returned_at is not None
+        assert notifier.calls == []
+        conn.close()
+
+    def test_other_member_cannot_return_loan(self) -> None:
+        client, conn = _setup_client(FakeNotifier(True))
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        member_repo = SqliteMemberRepository(conn)
+        borrower = _member(member_repo, 1)
+        other = _member(member_repo, 2)
+        loan = SqliteLoanRepository(conn).create(game.id, borrower.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(other))
+
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": "Solo puedes devolver tus propios préstamos."
+        }
+        conn.close()
+
+    def test_already_returned_loan_is_rejected(self) -> None:
+        client, conn = _setup_client(FakeNotifier(True))
+        game = SqliteGameRepository(conn).upsert_by_bgg_id(1, "Catan", "")
+        borrower = _member(SqliteMemberRepository(conn), 1)
+        loan_repo = SqliteLoanRepository(conn)
+        loan = loan_repo.create(game.id, borrower.id)
+        loan_repo.mark_returned(loan.id)
+
+        response = client.patch(f"/api/loans/{loan.id}/return", headers=_auth(borrower))
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Este juego ya ha sido devuelto."}
+        conn.close()
+
+
+def test_my_loans_exposes_slug_and_item_type() -> None:
+    client, conn = _setup_client()
+    game_repo = SqliteGameRepository(conn)
+    boardgame = game_repo.upsert_by_bgg_id(1, "Catan", "")
+    rpg_item = game_repo.upsert_by_bgg_id(2, "Pathfinder", "", item_type="rpgitem")
+    member = _member(SqliteMemberRepository(conn), 1)
+    loan_repo = SqliteLoanRepository(conn)
+    loan_repo.create(boardgame.id, member.id)
+    loan_repo.create(rpg_item.id, member.id)
+
+    response = client.get("/api/my-loans", headers=_auth(member))
+
+    assert response.status_code == 200
+    assert [(loan["game_slug"], loan["item_type"]) for loan in response.json()] == [
+        ("catan", "boardgame"),
+        ("pathfinder", "rpgitem"),
+    ]
+    conn.close()

--- a/tests/data/test_email_client.py
+++ b/tests/data/test_email_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from pytest import MonkeyPatch
 
 from backend.config import Settings
-from backend.data.email_client import EmailClient
+from backend.data.email_client import SMTP_TIMEOUT_SECONDS, EmailClient
 
 OBSOLETE_BRAND = "Préstamos Sát" + "iros"
 
@@ -31,6 +31,9 @@ def test_send_access_link_uses_refugio_del_satiro_brand(
     )
 
     assert sent is True
+    smtp.assert_called_once_with(
+        "smtp.example.invalid", 587, timeout=SMTP_TIMEOUT_SECONDS
+    )
     smtp.return_value.__enter__.return_value.sendmail.assert_called_once()
     raw_message = smtp.return_value.__enter__.return_value.sendmail.call_args.args[2]
     message = message_from_string(raw_message)
@@ -40,3 +43,51 @@ def test_send_access_link_uses_refugio_del_satiro_brand(
     assert OBSOLETE_BRAND not in subject
     assert "Refugio del Sátiro" in html
     assert OBSOLETE_BRAND not in html
+
+
+def test_send_forced_return_sends_plain_and_escaped_html_parts(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    smtp = MagicMock()
+    monkeypatch.setattr("backend.data.email_client.smtplib.SMTP", smtp)  # type: ignore[attr-defined]
+    client = EmailClient(
+        Settings(
+            smtp_host="smtp.example.invalid",
+            smtp_user="user",
+            smtp_password="password",
+            smtp_from="noreply@example.invalid",
+        )
+    )
+
+    sent = client.send_forced_return(
+        "member@example.invalid", "Ada <Admin>", 'Catan & "Friends"'
+    )
+
+    assert sent is True
+    smtp.assert_called_once_with(
+        "smtp.example.invalid", 587, timeout=SMTP_TIMEOUT_SECONDS
+    )
+    raw_message = smtp.return_value.__enter__.return_value.sendmail.call_args.args[2]
+    message = message_from_string(raw_message)
+    subject = str(make_header(decode_header(message["Subject"])))
+    plain = message.get_payload()[0].get_payload(decode=True).decode()
+    html = message.get_payload()[1].get_payload(decode=True).decode()
+    assert subject == "Refugio del Sátiro: préstamo marcado como devuelto"
+    assert "Hola, Ada <Admin>:" in plain
+    assert '"Catan & "Friends""' in plain
+    assert "Ada &lt;Admin&gt;" in html
+    assert "Catan &amp; &quot;Friends&quot;" in html
+    assert message.get_content_type() == "multipart/alternative"
+
+
+def test_send_forced_return_returns_false_without_smtp_configuration() -> None:
+    client = EmailClient(
+        Settings(
+            smtp_host=None,
+            smtp_user=None,
+            smtp_password=None,
+            smtp_from=None,
+        )
+    )
+
+    assert client.send_forced_return("member@example.invalid", "Ada", "Catan") is False

--- a/tests/domain/use_cases/test_borrow_game.py
+++ b/tests/domain/use_cases/test_borrow_game.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from backend.data.repositories.sqlite_game_repository import SqliteGameRepository
@@ -86,10 +88,12 @@ class TestBorrowGameUseCase:
         loan = borrow_use_case.execute(game.id, member.id)
         game_repo.deactivate_by_collection_ids([101])
 
-        return_use_case = ReturnGameUseCase(loan_repo)
-        returned = return_use_case.execute(loan.id, member)
+        notifier = MagicMock()
+        return_use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier)
+        result = return_use_case.execute(loan.id, member)
 
-        assert returned.returned_at is not None
+        assert result.loan.returned_at is not None
+        assert result.forced_return_email_sent is None
 
     def test_borrow_rpg_item_succeeds(
         self,

--- a/tests/domain/use_cases/test_return_game.py
+++ b/tests/domain/use_cases/test_return_game.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,6 +10,21 @@ from backend.data.repositories.sqlite_loan_repository import SqliteLoanRepositor
 from backend.data.repositories.sqlite_member_repository import SqliteMemberRepository
 from backend.domain.entities.member import Member
 from backend.domain.use_cases.return_game import ReturnGameError, ReturnGameUseCase
+
+
+class FakeNotifier:
+    def __init__(self, result: bool = True, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, str, str]] = []
+
+    def send_forced_return(
+        self, to_email: str, display_name: str, item_name: str
+    ) -> bool:
+        self.calls.append((to_email, display_name, item_name))
+        if self.error is not None:
+            raise self.error
+        return self.result
 
 
 def _make_member(*, id: int, is_admin: bool = False) -> Member:
@@ -43,9 +59,33 @@ class TestReturnGameUseCase:
         )
         loan = loan_repo.create(game.id, member.id)
 
-        use_case = ReturnGameUseCase(loan_repo)
-        returned = use_case.execute(loan.id, _make_member(id=member.id))
-        assert returned.returned_at is not None
+        notifier = FakeNotifier()
+        use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier)
+        result = use_case.execute(loan.id, _make_member(id=member.id))
+        assert result.loan.returned_at is not None
+        assert result.forced_return_email_sent is None
+        assert notifier.calls == []
+
+    def test_admin_returning_own_loan_does_not_notify(
+        self,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        admin = member_repo.upsert_by_email(
+            1, "Admin", "User", None, None, "admin@example.invalid", "Admin", True
+        )
+        loan = loan_repo.create(game.id, admin.id)
+        notifier = FakeNotifier()
+
+        result = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier).execute(
+            loan.id, admin
+        )
+
+        assert result.loan.returned_at is not None
+        assert result.forced_return_email_sent is None
+        assert notifier.calls == []
 
     def test_other_member_cannot_return(
         self,
@@ -62,7 +102,7 @@ class TestReturnGameUseCase:
         )
         loan = loan_repo.create(game.id, m1.id)
 
-        use_case = ReturnGameUseCase(loan_repo)
+        use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, FakeNotifier())
         with pytest.raises(ReturnGameError, match="Solo puedes devolver"):
             use_case.execute(loan.id, _make_member(id=2))
 
@@ -77,13 +117,113 @@ class TestReturnGameUseCase:
             1, "A", "User", None, None, "TEST_email@domain.com", "A User", False
         )
         member_repo.upsert_by_email(
-            2, "Admin", "User", None, None, "TEST_email@domain.com", "Admin", True
+            2, "Admin", "User", None, None, "admin@example.invalid", "Admin", True
         )
         loan = loan_repo.create(game.id, m1.id)
 
-        use_case = ReturnGameUseCase(loan_repo)
-        returned = use_case.execute(loan.id, _make_member(id=2, is_admin=True))
-        assert returned.returned_at is not None
+        notifier = FakeNotifier()
+        use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier)
+        result = use_case.execute(loan.id, _make_member(id=2, is_admin=True))
+        assert result.loan.returned_at is not None
+        assert result.forced_return_email_sent is True
+        assert notifier.calls == [("TEST_email@domain.com", "A User", "Catan")]
+
+    @pytest.mark.parametrize(
+        ("notifier", "expected_calls"),
+        [
+            (FakeNotifier(result=False), 1),
+            (FakeNotifier(error=OSError("SMTP unavailable")), 1),
+        ],
+    )
+    def test_forced_return_is_persisted_when_notification_fails(
+        self,
+        notifier: FakeNotifier,
+        expected_calls: int,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        borrower = member_repo.upsert_by_email(
+            1, "A", "User", None, None, "a@example.invalid", "A User", False
+        )
+        admin = member_repo.upsert_by_email(
+            2, "Admin", "User", None, None, "admin@example.invalid", "Admin", True
+        )
+        loan = loan_repo.create(game.id, borrower.id)
+
+        result = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier).execute(
+            loan.id, admin
+        )
+
+        assert result.forced_return_email_sent is False
+        assert loan_repo.get_by_id(loan.id) == result.loan
+        assert result.loan.returned_at is not None
+        assert len(notifier.calls) == expected_calls
+
+    def test_forced_return_with_missing_notification_data_is_persisted(
+        self,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        borrower = member_repo.upsert_by_email(
+            1, "A", "User", None, None, "a@example.invalid", "A User", False
+        )
+        admin = member_repo.upsert_by_email(
+            2, "Admin", "User", None, None, "admin@example.invalid", "Admin", True
+        )
+        loan = loan_repo.create(game.id, borrower.id)
+        missing_game_repo = MagicMock()
+        missing_game_repo.get_by_id.return_value = None
+        notifier = FakeNotifier()
+
+        result = ReturnGameUseCase(
+            loan_repo, member_repo, missing_game_repo, notifier
+        ).execute(loan.id, admin)
+
+        assert result.loan.returned_at is not None
+        assert result.forced_return_email_sent is False
+        assert notifier.calls == []
+
+    @pytest.mark.parametrize("failing_lookup", ["member", "game"])
+    def test_forced_return_is_persisted_when_notification_lookup_raises(
+        self,
+        failing_lookup: str,
+        game_repo: SqliteGameRepository,
+        loan_repo: SqliteLoanRepository,
+        member_repo: SqliteMemberRepository,
+    ) -> None:
+        game = game_repo.upsert_by_bgg_id(1, "Catan", "https://c.jpg", 1995)
+        borrower = member_repo.upsert_by_email(
+            1, "A", "User", None, None, "a@example.invalid", "A User", False
+        )
+        admin = member_repo.upsert_by_email(
+            2, "Admin", "User", None, None, "admin@example.invalid", "Admin", True
+        )
+        loan = loan_repo.create(game.id, borrower.id)
+        failing_member_repo = MagicMock(wraps=member_repo)
+        failing_game_repo = MagicMock(wraps=game_repo)
+        if failing_lookup == "member":
+            failing_member_repo.get_by_id.side_effect = RuntimeError("member lookup")
+        else:
+            failing_game_repo.get_by_id.side_effect = RuntimeError("game lookup")
+        notifier = FakeNotifier()
+
+        result = ReturnGameUseCase(
+            loan_repo,
+            failing_member_repo,
+            failing_game_repo,
+            notifier,
+        ).execute(loan.id, admin)
+
+        persisted = loan_repo.get_by_id(loan.id)
+        assert persisted == result.loan
+        assert persisted is not None
+        assert persisted.returned_at is not None
+        assert result.forced_return_email_sent is False
+        assert notifier.calls == []
 
     def test_cannot_return_already_returned(
         self,
@@ -98,6 +238,8 @@ class TestReturnGameUseCase:
         loan = loan_repo.create(game.id, member.id)
         loan_repo.mark_returned(loan.id)
 
-        use_case = ReturnGameUseCase(loan_repo)
+        notifier = FakeNotifier()
+        use_case = ReturnGameUseCase(loan_repo, member_repo, game_repo, notifier)
         with pytest.raises(ReturnGameError, match="ya ha sido devuelto"):
             use_case.execute(loan.id, _make_member(id=member.id))
+        assert notifier.calls == []


### PR DESCRIPTION
Closes #129

## What changed

- Links active-loan covers and titles to the correct board-game or RPG detail page.
- Keeps the responsible-use guidance visible and adds an informational marker after 30 complete days without introducing a return deadline.
- Shows each member’s role in the administrator table and supports accessible role sorting.
- Sends a best-effort email when an administrator records another member’s return. The return stays recorded if the notification cannot be sent.
- Reports notification success or failure on both detail pages.

## Verification

- 442 Python tests passed.
- 293 frontend tests passed.
- Frontend lint, type-check, formatting, and production build passed.
- 100 Playwright tests passed; 11 project-defined tests were skipped.
- Desktop and mobile smoke checks covered My Loans, role sorting, both notification states, catalog reset/view regressions, and the `/socios/` login-notice link.
- Targeted code review found no remaining should-fix issues.